### PR TITLE
Fix typos

### DIFF
--- a/holo-bfd/src/events.rs
+++ b/holo-bfd/src/events.rs
@@ -75,7 +75,7 @@ pub(crate) fn process_udp_packet(
         sess.poll_sequence_terminate();
 
         // The peer is aware of the updated interval timers, so we can now
-        // effectivelly use them.
+        // effectively use them.
         sess.state.curr_min_tx = sess.desired_tx_interval();
         sess.state.curr_min_rx = sess.required_min_rx();
         sess.update_tx_interval();

--- a/holo-bgp/src/rib.rs
+++ b/holo-bgp/src/rib.rs
@@ -295,7 +295,7 @@ impl Route {
 
         // Compare IGP costs.
         if !selection_cfg.ignore_next_hop_igp_metric {
-            // TODO: not implemened yet.
+            // TODO: not implemented yet.
         }
 
         // If multipath is enabled, routes are considered equal under specific

--- a/holo-ldp/src/events.rs
+++ b/holo-ldp/src/events.rs
@@ -203,7 +203,7 @@ fn process_hello(
         .map(|tlv| tlv.0.into())
         .unwrap_or_else(|| source.addr);
 
-    // Create new adjacency or udpate existing one.
+    // Create new adjacency or update existing one.
     if let Some((_, adj)) =
         instance.state.ipv4.adjacencies.get_mut_by_source(&source)
     {
@@ -769,7 +769,7 @@ fn process_nbr_msg_label(
         return Err(Error::NbrSentError(nbr.lsr_id, StatusCode::Shutdown));
     }
 
-    // Process each FEC element separetely.
+    // Process each FEC element separately.
     for fec_elem in &msg.fec.0 {
         match msg.msg_type {
             LabelMessageType::LabelMapping => {

--- a/holo-ldp/src/neighbor.rs
+++ b/holo-ldp/src/neighbor.rs
@@ -325,7 +325,7 @@ impl Neighbor {
         let nbr = &mut instance.state.neighbors[nbr_idx];
         match action {
             fsm::Action::SendInitAndKeepalive => {
-                // Send initilization message.
+                // Send initialization message.
                 nbr.send_init(instance.config, &instance.state.msg_id);
 
                 // Send keepalive message.
@@ -337,7 +337,7 @@ impl Neighbor {
                 );
             }
             fsm::Action::SendInit => {
-                // Send initilization message.
+                // Send initialization message.
                 nbr.send_init(instance.config, &instance.state.msg_id);
                 Neighbor::fsm(instance, nbr_idx, fsm::Event::InitSent);
             }

--- a/holo-ldp/tests/conformance/mod.rs
+++ b/holo-ldp/tests/conformance/mod.rs
@@ -1145,7 +1145,7 @@ async fn tcp_accept1() {
 // Test description:
 //
 // Accepted TCP connection that matches an adjacency should prompt the creation
-// of a new neighor in the NON EXISTENT state.
+// of a new neighbor in the NON EXISTENT state.
 //
 // Input:
 //  * Protocol: LDP Hello message from 10.0.1.10 (new neighbor)

--- a/holo-northbound/src/lib.rs
+++ b/holo-northbound/src/lib.rs
@@ -125,7 +125,7 @@ impl CallbackOp {
                     return false;
                 }
 
-                // Only optional leafs can be deleted, or leafs whose
+                // Only optional leaves can be deleted, or leaves whose
                 // parent is a case statement.
                 if let Some(parent) = snode.ancestors().next() {
                     if parent.kind() == SchemaNodeKind::Case {

--- a/holo-northbound/src/state.rs
+++ b/holo-northbound/src/state.rs
@@ -704,7 +704,7 @@ fn iterate_leaf<'a, P>(
 where
     P: Provider,
 {
-    // Ignore config leafs and list keys.
+    // Ignore config leaves and list keys.
     if snode.is_config() || snode.is_list_key() {
         return Ok(());
     }
@@ -718,7 +718,7 @@ where
         Debug::GetElementCallback(path, &value).log();
 
         if value.is_some() {
-            // Empty leafs don't have a value.
+            // Empty leaves don't have a value.
             if snode.base_type().unwrap() == DataValueType::Empty {
                 value = None;
             }

--- a/holo-ospf/src/flood.rs
+++ b/holo-ospf/src/flood.rs
@@ -72,7 +72,7 @@ where
     let lsa_key = lsa.hdr.key();
 
     // Keep track that this LSA was flooded back out the receiving interface.
-    // This information is relevent when deciding whether or not to send a
+    // This information is relevant when deciding whether or not to send a
     // delayed ack later.
     let mut flooded_back = false;
 

--- a/holo-ospf/src/packet/auth.rs
+++ b/holo-ospf/src/packet/auth.rs
@@ -114,7 +114,7 @@ where
             mac.update(&HMAC_APAD[..digest_size - Ipv4Addr::LENGTH]);
         }
         Some(IpAddr::V6(addr)) => {
-            // RFC 7166 Secion 4.5 says:
+            // RFC 7166 Section 4.5 says:
             // "Apad is a value that is the same length as the hash output or
             // message digest. The first 16 octets contain the IPv6 source
             // address followed by the hexadecimal value 0x878FE1F3 repeated

--- a/holo-rip/src/events.rs
+++ b/holo-rip/src/events.rs
@@ -131,7 +131,7 @@ fn process_pdu_request<V>(
         return;
     }
 
-    // The response should be sent to the requestor's address and port.
+    // The response should be sent to the requester's address and port.
     let dst = SendDestination::Unicast(src);
 
     // Check if it's a request to send the entire routing table.
@@ -149,7 +149,7 @@ fn process_pdu_request<V>(
         // RTE. If there is no explicit route to the specified destination, put
         // infinity in the metric field. Once all the entries have been filled
         // in, change the command from Request to Response and send the datagram
-        // back to the requestor.
+        // back to the requester.
         for rte in pdu.rtes_mut() {
             if let Some(rte) = rte.as_route_mut() {
                 let metric = if let Some(route) =

--- a/holo-rip/src/ripng/packet.rs
+++ b/holo-rip/src/ripng/packet.rs
@@ -189,7 +189,7 @@ impl PduVersion<Ipv6Addr, Ipv6Network, DecodeError> for Pdu {
     // RFC 2080 - Section 2.1 says:
     // "The determination of the number of RTEs which may be put into a given
     // message is a function of the medium's MTU, the number of octets of header
-    // information preceeding the RIPng message, the size of the RIPng header,
+    // information preceding the RIPng message, the size of the RIPng header,
     // and the size of an RTE.  The formula is:
     //
     //             +-                                                   -+
@@ -271,7 +271,7 @@ impl Rte {
         // A next hop RTE is identified by a value of 0xFF in the metric field
         // of an RTE. The prefix field specifies the IPv6 address of the next
         // hop. The route tag and prefix length in the next hop RTE must be set
-        // to zero on sending and ignored on receiption.
+        // to zero on sending and ignored on reception.
         if metric == 0xFF {
             // An address specified as a next hop must be a link-local address.
             if !addr.is_unicast_link_local() {


### PR DESCRIPTION
Found few misspellings with `typos`.

YANG files are excluded, I think they are generated.
