### PR TITLE
Change default user path in docs

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -35,9 +35,10 @@ $ cargo build --release
 
 5. Add `holo` user and group:
 
-```
+```sh
 # groupadd -r holo
-# useradd --system --shell /sbin/nologin --home-dir /var/run/holo/ -g holo holo
+# mkdir /var/opt/holo
+# useradd --system --shell /sbin/nologin --home-dir /var/opt/holo/ -g holo holo
 ```
 
 6. Installation

--- a/holo-utils/src/bgp.rs
+++ b/holo-utils/src/bgp.rs
@@ -4,6 +4,8 @@
 // SPDX-License-Identifier: MIT
 //
 
+//! BGP definitions common to `holo-bgp` and `holo-policy`
+//!
 //! This file contains BGP definitions that are common to both `holo-bgp` and
 //! `holo-policy`. In the future, the northbound layer should be restructured
 //! so that `holo-bgp` can handle the BGP-specific policy definitions itself,


### PR DESCRIPTION
Changing the user's home directory in INSTALL.md
from /usr/run/holo to /usr/opt/holo.

/usr/run/holo was automatically deleted on
reboot which made it unoperable for end users on
reboot.