### PR TITLE
Add mac address to Interfaces

### DIFF
--- a/holo-interface/src/ibus.rs
+++ b/holo-interface/src/ibus.rs
@@ -76,6 +76,7 @@ pub(crate) fn notify_interface_update(ibus_tx: &IbusSender, iface: &Interface) {
         ifindex: iface.ifindex.unwrap_or(0),
         mtu: iface.mtu.unwrap_or(0),
         flags: iface.flags,
+        mac_address: iface.mac_address,
     });
     notify(ibus_tx, msg);
 }

--- a/holo-interface/src/interface.rs
+++ b/holo-interface/src/interface.rs
@@ -37,6 +37,7 @@ pub struct Interface {
     pub mtu: Option<u32>,
     pub flags: InterfaceFlags,
     pub addresses: BTreeMap<IpNetwork, InterfaceAddress>,
+    pub mac_address: [u8; 6],
     pub owner: Owner,
 }
 
@@ -123,6 +124,7 @@ impl Interfaces {
             flags: InterfaceFlags::default(),
             addresses: Default::default(),
             owner: Owner::CONFIG,
+            mac_address: Default::default(),
         };
 
         let iface_idx = self.arena.insert(iface);
@@ -136,6 +138,7 @@ impl Interfaces {
         ifindex: u32,
         mtu: u32,
         flags: InterfaceFlags,
+        mac_address: [u8; 6],
         netlink_handle: &rtnetlink::Handle,
         ibus_tx: Option<&IbusSender>,
     ) {
@@ -152,6 +155,7 @@ impl Interfaces {
                 if iface.name == ifname
                     && iface.mtu == Some(mtu)
                     && iface.flags == flags
+                    && iface.mac_address == mac_address
                 {
                     return;
                 }
@@ -170,6 +174,7 @@ impl Interfaces {
                 iface.owner.insert(Owner::SYSTEM);
                 iface.mtu = Some(mtu);
                 iface.flags = flags;
+                iface.mac_address = mac_address;
 
                 // Notify protocol instances about the interface update.
                 //
@@ -214,6 +219,7 @@ impl Interfaces {
                     flags,
                     addresses: Default::default(),
                     owner: Owner::SYSTEM,
+                    mac_address: Default::default(),
                 };
 
                 // Notify protocol instances about the interface update.

--- a/holo-interface/src/netlink.rs
+++ b/holo-interface/src/netlink.rs
@@ -43,6 +43,8 @@ async fn process_newlink_msg(
     let ifindex = msg.header.index;
     let mut ifname = None;
     let mut mtu = None;
+    let mut mac_address: [u8; 6] = [0u8; 6];
+
     let mut flags = InterfaceFlags::empty();
     if msg.header.link_layer_type == ARPHRD_LOOPBACK {
         flags.insert(InterfaceFlags::LOOPBACK);
@@ -57,6 +59,9 @@ async fn process_newlink_msg(
         match nla {
             Nla::IfName(nla_ifname) => ifname = Some(nla_ifname),
             Nla::Mtu(nla_mtu) => mtu = Some(nla_mtu),
+            Nla::Address(addr) => {
+                mac_address = addr.try_into().unwrap_or([0u8; 6]);
+            }
             _ => (),
         }
     }
@@ -68,7 +73,15 @@ async fn process_newlink_msg(
     let ibus_tx = notify.then_some(&master.ibus_tx);
     master
         .interfaces
-        .update(ifname, ifindex, mtu, flags, &master.netlink_handle, ibus_tx)
+        .update(
+            ifname,
+            ifindex,
+            mtu,
+            flags,
+            mac_address,
+            &master.netlink_handle,
+            ibus_tx,
+        )
         .await;
 }
 

--- a/holo-utils/src/southbound.rs
+++ b/holo-utils/src/southbound.rs
@@ -73,6 +73,9 @@ pub struct InterfaceUpdateMsg {
     pub ifindex: u32,
     pub mtu: u32,
     pub flags: InterfaceFlags,
+
+    #[serde(skip)]
+    pub mac_address: [u8; 6],
 }
 
 #[derive(Clone, Debug)]


### PR DESCRIPTION
We introduce the Mac Address to the Interface struct inside the `holo-interface` module. 

The netlink message Nla giving us this information has been modified to catter for this, we also modify the respective Ibus functions to make sure the mac address is put in while updating the interface details. 
