### PR TITLE
Restructure IbusMsg 

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,7 @@ chrono = { version = "0.4", features = ["serde"] }
 convert_case = "0.6"
 criterion = "0.4"
 crossbeam-channel = "0.5"
+derive_more = { version="1.0.0", features = ["from"] }
 derive-new = "0.5"
 enum-as-inner = "0.6"
 fletcher = "1.0"

--- a/holo-bfd/src/master.rs
+++ b/holo-bfd/src/master.rs
@@ -144,7 +144,7 @@ impl ProtocolInstance for Master {
 
     async fn init(&mut self) {
         // Request information about all interfaces.
-        let _ = self.tx.ibus.send(IbusMsg::Interface(InterfaceMsg::Dump));
+        let _ = self.tx.ibus.send(InterfaceMsg::Dump.into());
     }
 
     async fn process_ibus_msg(&mut self, msg: IbusMsg) {

--- a/holo-bfd/src/session.rs
+++ b/holo-bfd/src/session.rs
@@ -15,7 +15,7 @@ use generational_arena::{Arena, Index};
 use holo_northbound::yang::control_plane_protocol::bfd;
 use holo_protocol::InstanceChannelsTx;
 use holo_utils::bfd::{ClientCfg, ClientId, SessionKey, State};
-use holo_utils::ibus::IbusMsg;
+use holo_utils::ibus::{BfdSessionMsg, IbusMsg};
 use holo_utils::ip::{IpAddrExt, IpAddrKind};
 use holo_utils::socket::{UdpSocket, TTL_MAX};
 use holo_utils::task::{IntervalTask, TimeoutTask};
@@ -141,10 +141,10 @@ impl Session {
 
         // Notify protocol clients about the state transition if necessary.
         if self.should_notify_clients(old_state) && !self.clients.is_empty() {
-            let msg = IbusMsg::BfdStateUpd {
+            let msg = IbusMsg::BfdSession(BfdSessionMsg::Update {
                 sess_key: self.key.clone(),
                 state,
-            };
+            });
             let _ = tx.ibus.send(msg);
         }
 

--- a/holo-bfd/src/session.rs
+++ b/holo-bfd/src/session.rs
@@ -15,7 +15,7 @@ use generational_arena::{Arena, Index};
 use holo_northbound::yang::control_plane_protocol::bfd;
 use holo_protocol::InstanceChannelsTx;
 use holo_utils::bfd::{ClientCfg, ClientId, SessionKey, State};
-use holo_utils::ibus::{BfdSessionMsg, IbusMsg};
+use holo_utils::ibus::BfdSessionMsg;
 use holo_utils::ip::{IpAddrExt, IpAddrKind};
 use holo_utils::socket::{UdpSocket, TTL_MAX};
 use holo_utils::task::{IntervalTask, TimeoutTask};
@@ -141,11 +141,11 @@ impl Session {
 
         // Notify protocol clients about the state transition if necessary.
         if self.should_notify_clients(old_state) && !self.clients.is_empty() {
-            let msg = IbusMsg::BfdSession(BfdSessionMsg::Update {
+            let msg = BfdSessionMsg::Update {
                 sess_key: self.key.clone(),
                 state,
-            });
-            let _ = tx.ibus.send(msg);
+            };
+            let _ = tx.ibus.send(msg.into());
         }
 
         // Send YANG notification.

--- a/holo-bgp/src/northbound/configuration.rs
+++ b/holo-bgp/src/northbound/configuration.rs
@@ -18,7 +18,7 @@ use holo_northbound::configuration::{
 };
 use holo_northbound::yang::control_plane_protocol::bgp;
 use holo_utils::bgp::AfiSafi;
-use holo_utils::ibus::IbusMsg;
+use holo_utils::ibus::{IbusMsg, RouteRedistributeMsg};
 use holo_utils::ip::{AddressFamily, IpAddrKind};
 use holo_utils::policy::{ApplyPolicyCfg, DefaultPolicyType};
 use holo_utils::protocol::Protocol;
@@ -1363,10 +1363,12 @@ impl Provider for Instance {
                 }
             }
             Event::RedistributeRequest(protocol, af) => {
-                let _ = self.tx.ibus.send(IbusMsg::RouteRedistributeDump {
-                    protocol,
-                    af: Some(af),
-                });
+                let _ = self.tx.ibus.send(IbusMsg::RouteRedistribute(
+                    RouteRedistributeMsg::Dump {
+                        protocol,
+                        af: Some(af),
+                    },
+                ));
             }
             Event::RedistributeDelete(protocol, afi_safi) => {
                 let Some((mut instance, _)) = self.as_up() else {

--- a/holo-bgp/src/northbound/configuration.rs
+++ b/holo-bgp/src/northbound/configuration.rs
@@ -18,7 +18,7 @@ use holo_northbound::configuration::{
 };
 use holo_northbound::yang::control_plane_protocol::bgp;
 use holo_utils::bgp::AfiSafi;
-use holo_utils::ibus::{IbusMsg, RouteRedistributeMsg};
+use holo_utils::ibus::RouteRedistributeMsg;
 use holo_utils::ip::{AddressFamily, IpAddrKind};
 use holo_utils::policy::{ApplyPolicyCfg, DefaultPolicyType};
 use holo_utils::protocol::Protocol;
@@ -1363,12 +1363,13 @@ impl Provider for Instance {
                 }
             }
             Event::RedistributeRequest(protocol, af) => {
-                let _ = self.tx.ibus.send(IbusMsg::RouteRedistribute(
+                let _ = self.tx.ibus.send(
                     RouteRedistributeMsg::Dump {
                         protocol,
                         af: Some(af),
-                    },
-                ));
+                    }
+                    .into(),
+                );
             }
             Event::RedistributeDelete(protocol, afi_safi) => {
                 let Some((mut instance, _)) = self.as_up() else {

--- a/holo-bgp/src/southbound/tx.rs
+++ b/holo-bgp/src/southbound/tx.rs
@@ -7,7 +7,9 @@
 use std::collections::BTreeSet;
 use std::net::IpAddr;
 
-use holo_utils::ibus::{IbusMsg, IbusSender};
+use holo_utils::ibus::{
+    IbusMsg, IbusSender, NexthopMsg, RouteIpMsg, RouterIdMsg,
+};
 use holo_utils::protocol::Protocol;
 use holo_utils::southbound::{
     Nexthop, RouteKeyMsg, RouteMsg, RouteOpaqueAttrs,
@@ -19,7 +21,7 @@ use crate::rib::LocalRoute;
 // ===== global functions =====
 
 pub(crate) fn router_id_query(ibus_tx: &IbusSender) {
-    let _ = ibus_tx.send(IbusMsg::RouterIdQuery);
+    let _ = ibus_tx.send(IbusMsg::RouterId(RouterIdMsg::Query));
 }
 
 pub(crate) fn route_install(
@@ -50,7 +52,7 @@ pub(crate) fn route_install(
         opaque_attrs: RouteOpaqueAttrs::None,
         nexthops: nexthops.clone(),
     };
-    let msg = IbusMsg::RouteIpAdd(msg);
+    let msg = IbusMsg::RouteIp(RouteIpMsg::Add(msg));
     let _ = ibus_tx.send(msg);
 }
 
@@ -63,16 +65,16 @@ pub(crate) fn route_uninstall(
         protocol: Protocol::BGP,
         prefix: prefix.into(),
     };
-    let msg = IbusMsg::RouteIpDel(msg);
+    let msg = IbusMsg::RouteIp(RouteIpMsg::Delete(msg));
     let _ = ibus_tx.send(msg);
 }
 
 pub(crate) fn nexthop_track(ibus_tx: &IbusSender, addr: IpAddr) {
-    let msg = IbusMsg::NexthopTrack(addr);
+    let msg = IbusMsg::Nexthop(NexthopMsg::Track(addr));
     let _ = ibus_tx.send(msg);
 }
 
 pub(crate) fn nexthop_untrack(ibus_tx: &IbusSender, addr: IpAddr) {
-    let msg = IbusMsg::NexthopUntrack(addr);
+    let msg = IbusMsg::Nexthop(NexthopMsg::Untrack(addr));
     let _ = ibus_tx.send(msg);
 }

--- a/holo-bgp/src/southbound/tx.rs
+++ b/holo-bgp/src/southbound/tx.rs
@@ -7,9 +7,7 @@
 use std::collections::BTreeSet;
 use std::net::IpAddr;
 
-use holo_utils::ibus::{
-    IbusMsg, IbusSender, NexthopMsg, RouteIpMsg, RouterIdMsg,
-};
+use holo_utils::ibus::{IbusSender, NexthopMsg, RouteIpMsg, RouterIdMsg};
 use holo_utils::protocol::Protocol;
 use holo_utils::southbound::{
     Nexthop, RouteKeyMsg, RouteMsg, RouteOpaqueAttrs,
@@ -21,7 +19,7 @@ use crate::rib::LocalRoute;
 // ===== global functions =====
 
 pub(crate) fn router_id_query(ibus_tx: &IbusSender) {
-    let _ = ibus_tx.send(IbusMsg::RouterId(RouterIdMsg::Query));
+    let _ = ibus_tx.send(RouterIdMsg::Query.into());
 }
 
 pub(crate) fn route_install(
@@ -43,7 +41,7 @@ pub(crate) fn route_install(
         .collect::<BTreeSet<_>>();
 
     // Install route.
-    let msg = RouteMsg {
+    let msg = RouteIpMsg::Add(RouteMsg {
         protocol: Protocol::BGP,
         prefix: prefix.into(),
         distance: distance.into(),
@@ -51,9 +49,8 @@ pub(crate) fn route_install(
         tag: None,
         opaque_attrs: RouteOpaqueAttrs::None,
         nexthops: nexthops.clone(),
-    };
-    let msg = IbusMsg::RouteIp(RouteIpMsg::Add(msg));
-    let _ = ibus_tx.send(msg);
+    });
+    let _ = ibus_tx.send(msg.into());
 }
 
 pub(crate) fn route_uninstall(
@@ -61,20 +58,19 @@ pub(crate) fn route_uninstall(
     prefix: impl Into<IpNetwork>,
 ) {
     // Uninstall route.
-    let msg = RouteKeyMsg {
+    let msg = RouteIpMsg::Delete(RouteKeyMsg {
         protocol: Protocol::BGP,
         prefix: prefix.into(),
-    };
-    let msg = IbusMsg::RouteIp(RouteIpMsg::Delete(msg));
-    let _ = ibus_tx.send(msg);
+    });
+    let _ = ibus_tx.send(msg.into());
 }
 
 pub(crate) fn nexthop_track(ibus_tx: &IbusSender, addr: IpAddr) {
-    let msg = IbusMsg::Nexthop(NexthopMsg::Track(addr));
-    let _ = ibus_tx.send(msg);
+    let msg = NexthopMsg::Track(addr);
+    let _ = ibus_tx.send(msg.into());
 }
 
 pub(crate) fn nexthop_untrack(ibus_tx: &IbusSender, addr: IpAddr) {
-    let msg = IbusMsg::Nexthop(NexthopMsg::Untrack(addr));
-    let _ = ibus_tx.send(msg);
+    let msg = NexthopMsg::Untrack(addr);
+    let _ = ibus_tx.send(msg.into());
 }

--- a/holo-interface/src/ibus.rs
+++ b/holo-interface/src/ibus.rs
@@ -6,7 +6,9 @@
 
 use std::net::Ipv4Addr;
 
-use holo_utils::ibus::{IbusMsg, IbusSender};
+use holo_utils::ibus::{
+    IbusMsg, IbusSender, InterfaceAddressMsg, InterfaceMsg, RouterIdMsg,
+};
 use holo_utils::ip::IpNetworkKind;
 use holo_utils::southbound::{AddressFlags, AddressMsg, InterfaceUpdateMsg};
 use ipnetwork::IpNetwork;
@@ -18,40 +20,46 @@ use crate::Master;
 
 pub(crate) fn process_msg(master: &mut Master, msg: IbusMsg) {
     match msg {
-        IbusMsg::InterfaceDump => {
-            for iface in master.interfaces.iter() {
-                notify_interface_update(&master.ibus_tx, iface);
+        // Interface Message
+        IbusMsg::Interface(iface_msg) => match iface_msg {
+            InterfaceMsg::Dump => {
+                for iface in master.interfaces.iter() {
+                    notify_interface_update(&master.ibus_tx, iface);
 
-                for iface_addr in iface.addresses.values() {
-                    notify_addr_add(
-                        &master.ibus_tx,
-                        iface.name.clone(),
-                        iface_addr.addr,
-                        iface_addr.flags,
-                    );
+                    for iface_addr in iface.addresses.values() {
+                        notify_addr_add(
+                            &master.ibus_tx,
+                            iface.name.clone(),
+                            iface_addr.addr,
+                            iface_addr.flags,
+                        );
+                    }
                 }
             }
-        }
-        IbusMsg::InterfaceQuery { ifname, af } => {
-            if let Some(iface) = master.interfaces.get_by_name(&ifname) {
-                notify_interface_update(&master.ibus_tx, iface);
+            InterfaceMsg::Query { ifname, af } => {
+                if let Some(iface) = master.interfaces.get_by_name(&ifname) {
+                    notify_interface_update(&master.ibus_tx, iface);
 
-                for iface_addr in
-                    iface.addresses.values().filter(|iface_addr| match af {
-                        Some(af) => iface_addr.addr.address_family() == af,
-                        None => true,
-                    })
-                {
-                    notify_addr_add(
-                        &master.ibus_tx,
-                        iface.name.clone(),
-                        iface_addr.addr,
-                        iface_addr.flags,
-                    );
+                    for iface_addr in
+                        iface.addresses.values().filter(|iface_addr| match af {
+                            Some(af) => iface_addr.addr.address_family() == af,
+                            None => true,
+                        })
+                    {
+                        notify_addr_add(
+                            &master.ibus_tx,
+                            iface.name.clone(),
+                            iface_addr.addr,
+                            iface_addr.flags,
+                        );
+                    }
                 }
             }
-        }
-        IbusMsg::RouterIdQuery => {
+            _ => {}
+        },
+
+        // RouterId
+        IbusMsg::RouterId(RouterIdMsg::Query) => {
             notify_router_id_update(
                 &master.ibus_tx,
                 master.interfaces.router_id(),
@@ -66,23 +74,25 @@ pub(crate) fn notify_router_id_update(
     ibus_tx: &IbusSender,
     router_id: Option<Ipv4Addr>,
 ) {
-    let msg = IbusMsg::RouterIdUpdate(router_id);
+    let msg = IbusMsg::RouterId(RouterIdMsg::Update(router_id));
     notify(ibus_tx, msg);
 }
 
 pub(crate) fn notify_interface_update(ibus_tx: &IbusSender, iface: &Interface) {
-    let msg = IbusMsg::InterfaceUpd(InterfaceUpdateMsg {
+    let update_msg = InterfaceUpdateMsg {
         ifname: iface.name.clone(),
         ifindex: iface.ifindex.unwrap_or(0),
         mtu: iface.mtu.unwrap_or(0),
         flags: iface.flags,
         mac_address: iface.mac_address,
-    });
+    };
+    let msg = IbusMsg::Interface(InterfaceMsg::Update(update_msg));
+
     notify(ibus_tx, msg);
 }
 
 pub(crate) fn notify_interface_del(ibus_tx: &IbusSender, ifname: String) {
-    let msg = IbusMsg::InterfaceDel(ifname);
+    let msg = IbusMsg::Interface(InterfaceMsg::Delete(ifname));
     notify(ibus_tx, msg);
 }
 
@@ -92,11 +102,12 @@ pub(crate) fn notify_addr_add(
     addr: IpNetwork,
     flags: AddressFlags,
 ) {
-    let msg = IbusMsg::InterfaceAddressAdd(AddressMsg {
+    let addr_msg = AddressMsg {
         ifname,
         addr,
         flags,
-    });
+    };
+    let msg = IbusMsg::InterfaceAddress(InterfaceAddressMsg::Add(addr_msg));
     notify(ibus_tx, msg);
 }
 
@@ -106,11 +117,12 @@ pub(crate) fn notify_addr_del(
     addr: IpNetwork,
     flags: AddressFlags,
 ) {
-    let msg = IbusMsg::InterfaceAddressDel(AddressMsg {
-        ifname,
-        addr,
-        flags,
-    });
+    let msg =
+        IbusMsg::InterfaceAddress(InterfaceAddressMsg::Delete(AddressMsg {
+            ifname,
+            addr,
+            flags,
+        }));
     notify(ibus_tx, msg);
 }
 

--- a/holo-interface/src/ibus.rs
+++ b/holo-interface/src/ibus.rs
@@ -74,8 +74,8 @@ pub(crate) fn notify_router_id_update(
     ibus_tx: &IbusSender,
     router_id: Option<Ipv4Addr>,
 ) {
-    let msg = IbusMsg::RouterId(RouterIdMsg::Update(router_id));
-    notify(ibus_tx, msg);
+    let msg = RouterIdMsg::Update(router_id);
+    notify(ibus_tx, msg.into());
 }
 
 pub(crate) fn notify_interface_update(ibus_tx: &IbusSender, iface: &Interface) {
@@ -86,14 +86,14 @@ pub(crate) fn notify_interface_update(ibus_tx: &IbusSender, iface: &Interface) {
         flags: iface.flags,
         mac_address: iface.mac_address,
     };
-    let msg = IbusMsg::Interface(InterfaceMsg::Update(update_msg));
+    let msg = InterfaceMsg::Update(update_msg);
 
-    notify(ibus_tx, msg);
+    notify(ibus_tx, msg.into());
 }
 
 pub(crate) fn notify_interface_del(ibus_tx: &IbusSender, ifname: String) {
-    let msg = IbusMsg::Interface(InterfaceMsg::Delete(ifname));
-    notify(ibus_tx, msg);
+    let msg = InterfaceMsg::Delete(ifname);
+    notify(ibus_tx, msg.into());
 }
 
 pub(crate) fn notify_addr_add(
@@ -107,8 +107,8 @@ pub(crate) fn notify_addr_add(
         addr,
         flags,
     };
-    let msg = IbusMsg::InterfaceAddress(InterfaceAddressMsg::Add(addr_msg));
-    notify(ibus_tx, msg);
+    let msg = InterfaceAddressMsg::Add(addr_msg);
+    notify(ibus_tx, msg.into());
 }
 
 pub(crate) fn notify_addr_del(
@@ -117,13 +117,12 @@ pub(crate) fn notify_addr_del(
     addr: IpNetwork,
     flags: AddressFlags,
 ) {
-    let msg =
-        IbusMsg::InterfaceAddress(InterfaceAddressMsg::Delete(AddressMsg {
-            ifname,
-            addr,
-            flags,
-        }));
-    notify(ibus_tx, msg);
+    let msg = InterfaceAddressMsg::Delete(AddressMsg {
+        ifname,
+        addr,
+        flags,
+    });
+    notify(ibus_tx, msg.into());
 }
 
 // ===== helper functions =====

--- a/holo-isis/src/interface.rs
+++ b/holo-isis/src/interface.rs
@@ -13,7 +13,7 @@ use std::sync::Arc;
 
 use chrono::{DateTime, Utc};
 use holo_protocol::InstanceChannelsTx;
-use holo_utils::ibus::{IbusMsg, IbusSender};
+use holo_utils::ibus::{IbusMsg, IbusSender, InterfaceMsg};
 use holo_utils::ip::AddressFamily;
 use holo_utils::socket::{AsyncFd, Socket, SocketExt};
 use holo_utils::southbound::InterfaceFlags;
@@ -643,10 +643,10 @@ impl Interface {
     // Sends a southbound request for interface system information, such as
     // operational status and IP addresses.
     pub(crate) fn query_southbound(&self, ibus_tx: &IbusSender) {
-        let _ = ibus_tx.send(IbusMsg::InterfaceQuery {
+        let _ = ibus_tx.send(IbusMsg::Interface(InterfaceMsg::Query {
             ifname: self.name.clone(),
             af: None,
-        });
+        }));
     }
 }
 

--- a/holo-isis/src/interface.rs
+++ b/holo-isis/src/interface.rs
@@ -13,7 +13,7 @@ use std::sync::Arc;
 
 use chrono::{DateTime, Utc};
 use holo_protocol::InstanceChannelsTx;
-use holo_utils::ibus::{IbusMsg, IbusSender, InterfaceMsg};
+use holo_utils::ibus::{IbusSender, InterfaceMsg};
 use holo_utils::ip::AddressFamily;
 use holo_utils::socket::{AsyncFd, Socket, SocketExt};
 use holo_utils::southbound::InterfaceFlags;
@@ -643,10 +643,11 @@ impl Interface {
     // Sends a southbound request for interface system information, such as
     // operational status and IP addresses.
     pub(crate) fn query_southbound(&self, ibus_tx: &IbusSender) {
-        let _ = ibus_tx.send(IbusMsg::Interface(InterfaceMsg::Query {
+        let msg = InterfaceMsg::Query {
             ifname: self.name.clone(),
             af: None,
-        }));
+        };
+        let _ = ibus_tx.send(msg.into());
     }
 }
 

--- a/holo-isis/src/southbound/tx.rs
+++ b/holo-isis/src/southbound/tx.rs
@@ -7,10 +7,10 @@
 // See: https://nlnet.nl/NGI0
 //
 
-use holo_utils::ibus::{IbusMsg, IbusSender};
+use holo_utils::ibus::{IbusMsg, IbusSender, RouterIdMsg};
 
 // ===== global functions =====
 
 pub(crate) fn router_id_query(ibus_tx: &IbusSender) {
-    let _ = ibus_tx.send(IbusMsg::RouterIdQuery);
+    let _ = ibus_tx.send(IbusMsg::RouterId(RouterIdMsg::Query));
 }

--- a/holo-isis/src/southbound/tx.rs
+++ b/holo-isis/src/southbound/tx.rs
@@ -7,10 +7,10 @@
 // See: https://nlnet.nl/NGI0
 //
 
-use holo_utils::ibus::{IbusMsg, IbusSender, RouterIdMsg};
+use holo_utils::ibus::{IbusSender, RouterIdMsg};
 
 // ===== global functions =====
 
 pub(crate) fn router_id_query(ibus_tx: &IbusSender) {
-    let _ = ibus_tx.send(IbusMsg::RouterId(RouterIdMsg::Query));
+    let _ = ibus_tx.send(RouterIdMsg::Query.into());
 }

--- a/holo-keychain/src/northbound/configuration.rs
+++ b/holo-keychain/src/northbound/configuration.rs
@@ -15,7 +15,7 @@ use holo_northbound::configuration::{
 };
 use holo_northbound::yang::key_chains;
 use holo_utils::crypto::CryptoAlgo;
-use holo_utils::ibus::IbusMsg;
+use holo_utils::ibus::{IbusMsg, KeychainMsg};
 use holo_utils::keychain::{Key, Keychain, KeychainKey};
 use holo_utils::yang::DataNodeRefExt;
 use holo_yang::TryFromYang;
@@ -443,12 +443,12 @@ impl Provider for Master {
                 let keychain = Arc::new(keychain.clone());
 
                 // Notify protocols that the keychain has been updated.
-                let msg = IbusMsg::KeychainUpd(keychain);
+                let msg = IbusMsg::Keychain(KeychainMsg::Update(keychain));
                 let _ = self.ibus_tx.send(msg);
             }
             Event::KeychainDelete(name) => {
                 // Notify protocols that the keychain has been deleted.
-                let msg = IbusMsg::KeychainDel(name);
+                let msg = IbusMsg::Keychain(KeychainMsg::Delete(name));
                 let _ = self.ibus_tx.send(msg);
             }
         }

--- a/holo-keychain/src/northbound/configuration.rs
+++ b/holo-keychain/src/northbound/configuration.rs
@@ -15,7 +15,7 @@ use holo_northbound::configuration::{
 };
 use holo_northbound::yang::key_chains;
 use holo_utils::crypto::CryptoAlgo;
-use holo_utils::ibus::{IbusMsg, KeychainMsg};
+use holo_utils::ibus::KeychainMsg;
 use holo_utils::keychain::{Key, Keychain, KeychainKey};
 use holo_utils::yang::DataNodeRefExt;
 use holo_yang::TryFromYang;
@@ -443,13 +443,13 @@ impl Provider for Master {
                 let keychain = Arc::new(keychain.clone());
 
                 // Notify protocols that the keychain has been updated.
-                let msg = IbusMsg::Keychain(KeychainMsg::Update(keychain));
-                let _ = self.ibus_tx.send(msg);
+                let msg = KeychainMsg::Update(keychain);
+                let _ = self.ibus_tx.send(msg.into());
             }
             Event::KeychainDelete(name) => {
                 // Notify protocols that the keychain has been deleted.
-                let msg = IbusMsg::Keychain(KeychainMsg::Delete(name));
-                let _ = self.ibus_tx.send(msg);
+                let msg = KeychainMsg::Delete(name);
+                let _ = self.ibus_tx.send(msg.into());
             }
         }
     }

--- a/holo-ldp/src/northbound/configuration.rs
+++ b/holo-ldp/src/northbound/configuration.rs
@@ -15,7 +15,7 @@ use holo_northbound::configuration::{
     ValidationCallbacksBuilder,
 };
 use holo_northbound::yang::control_plane_protocol::mpls_ldp;
-use holo_utils::ibus::{IbusMsg, InterfaceMsg};
+use holo_utils::ibus::InterfaceMsg;
 use holo_utils::ip::AddressFamily;
 use holo_utils::yang::DataNodeRefExt;
 
@@ -471,12 +471,11 @@ impl Provider for Instance {
             }
             Event::InterfaceQuerySouthbound(ifname) => {
                 if let Some((instance, _, _)) = self.as_up() {
-                    let _ = instance.tx.ibus.send(IbusMsg::Interface(
-                        InterfaceMsg::Query {
-                            ifname,
-                            af: Some(AddressFamily::Ipv4),
-                        },
-                    ));
+                    let msg = InterfaceMsg::Query {
+                        ifname,
+                        af: Some(AddressFamily::Ipv4),
+                    };
+                    let _ = instance.tx.ibus.send(msg.into());
                 }
             }
             Event::TargetedNbrUpdate(tnbr_idx) => {

--- a/holo-ldp/src/northbound/configuration.rs
+++ b/holo-ldp/src/northbound/configuration.rs
@@ -15,7 +15,7 @@ use holo_northbound::configuration::{
     ValidationCallbacksBuilder,
 };
 use holo_northbound::yang::control_plane_protocol::mpls_ldp;
-use holo_utils::ibus::IbusMsg;
+use holo_utils::ibus::{IbusMsg, InterfaceMsg};
 use holo_utils::ip::AddressFamily;
 use holo_utils::yang::DataNodeRefExt;
 
@@ -471,10 +471,12 @@ impl Provider for Instance {
             }
             Event::InterfaceQuerySouthbound(ifname) => {
                 if let Some((instance, _, _)) = self.as_up() {
-                    let _ = instance.tx.ibus.send(IbusMsg::InterfaceQuery {
-                        ifname,
-                        af: Some(AddressFamily::Ipv4),
-                    });
+                    let _ = instance.tx.ibus.send(IbusMsg::Interface(
+                        InterfaceMsg::Query {
+                            ifname,
+                            af: Some(AddressFamily::Ipv4),
+                        },
+                    ));
                 }
             }
             Event::TargetedNbrUpdate(tnbr_idx) => {

--- a/holo-ldp/src/southbound/tx.rs
+++ b/holo-ldp/src/southbound/tx.rs
@@ -4,7 +4,7 @@
 // SPDX-License-Identifier: MIT
 //
 
-use holo_utils::ibus::{IbusMsg, IbusSender, RouteMplsMsg, RouterIdMsg};
+use holo_utils::ibus::{IbusSender, RouteMplsMsg, RouterIdMsg};
 use holo_utils::protocol::Protocol;
 use holo_utils::southbound::{self, LabelInstallMsg, LabelUninstallMsg};
 
@@ -13,7 +13,7 @@ use crate::fec::{FecInner, Nexthop};
 // ===== global functions =====
 
 pub(crate) fn router_id_query(ibus_tx: &IbusSender) {
-    let _ = ibus_tx.send(IbusMsg::RouterId(RouterIdMsg::Query));
+    let _ = ibus_tx.send(RouterIdMsg::Query.into());
 }
 
 pub(crate) fn label_install(
@@ -35,7 +35,7 @@ pub(crate) fn label_install(
     let protocol = fec.protocol.unwrap();
 
     // Fill-in message.
-    let msg = LabelInstallMsg {
+    let msg = RouteMplsMsg::Add(LabelInstallMsg {
         protocol: Protocol::LDP,
         label: local_label,
         nexthops: [southbound::Nexthop::Address {
@@ -46,11 +46,10 @@ pub(crate) fn label_install(
         .into(),
         route: Some((protocol, *fec.prefix)),
         replace: false,
-    };
+    });
 
     // Send message.
-    let msg = IbusMsg::RouteMpls(RouteMplsMsg::Add(msg));
-    let _ = ibus_tx.send(msg);
+    let _ = ibus_tx.send(msg.into());
 }
 
 pub(crate) fn label_uninstall(
@@ -72,7 +71,7 @@ pub(crate) fn label_uninstall(
     let protocol = fec.protocol.unwrap();
 
     // Fill-in message.
-    let msg = LabelUninstallMsg {
+    let msg = RouteMplsMsg::Delete(LabelUninstallMsg {
         protocol: Protocol::LDP,
         label: local_label,
         nexthops: [southbound::Nexthop::Address {
@@ -82,9 +81,8 @@ pub(crate) fn label_uninstall(
         }]
         .into(),
         route: Some((protocol, *fec.prefix)),
-    };
+    });
 
     // Send message.
-    let msg = IbusMsg::RouteMpls(RouteMplsMsg::Delete(msg));
-    let _ = ibus_tx.send(msg);
+    let _ = ibus_tx.send(msg.into());
 }

--- a/holo-ldp/src/southbound/tx.rs
+++ b/holo-ldp/src/southbound/tx.rs
@@ -4,7 +4,7 @@
 // SPDX-License-Identifier: MIT
 //
 
-use holo_utils::ibus::{IbusMsg, IbusSender};
+use holo_utils::ibus::{IbusMsg, IbusSender, RouteMplsMsg, RouterIdMsg};
 use holo_utils::protocol::Protocol;
 use holo_utils::southbound::{self, LabelInstallMsg, LabelUninstallMsg};
 
@@ -13,7 +13,7 @@ use crate::fec::{FecInner, Nexthop};
 // ===== global functions =====
 
 pub(crate) fn router_id_query(ibus_tx: &IbusSender) {
-    let _ = ibus_tx.send(IbusMsg::RouterIdQuery);
+    let _ = ibus_tx.send(IbusMsg::RouterId(RouterIdMsg::Query));
 }
 
 pub(crate) fn label_install(
@@ -49,7 +49,7 @@ pub(crate) fn label_install(
     };
 
     // Send message.
-    let msg = IbusMsg::RouteMplsAdd(msg);
+    let msg = IbusMsg::RouteMpls(RouteMplsMsg::Add(msg));
     let _ = ibus_tx.send(msg);
 }
 
@@ -85,6 +85,6 @@ pub(crate) fn label_uninstall(
     };
 
     // Send message.
-    let msg = IbusMsg::RouteMplsDel(msg);
+    let msg = IbusMsg::RouteMpls(RouteMplsMsg::Delete(msg));
     let _ = ibus_tx.send(msg);
 }

--- a/holo-ospf/src/neighbor.rs
+++ b/holo-ospf/src/neighbor.rs
@@ -553,11 +553,13 @@ where
     ) {
         Debug::<V>::NeighborBfdReg(self.router_id).log();
 
-        let msg = IbusMsg::BfdSessionReg {
-            sess_key: self.bfd_session_key(iface),
-            client_id: self.bfd_client_id(instance),
-            client_config: Some(iface.config.bfd_params),
-        };
+        let msg = IbusMsg::BfdSession(
+            holo_utils::ibus::BfdSessionMsg::Registration {
+                sess_key: self.bfd_session_key(iface),
+                client_id: self.bfd_client_id(instance),
+                client_config: Some(iface.config.bfd_params),
+            },
+        );
         let _ = instance.tx.ibus.send(msg);
     }
 
@@ -568,10 +570,12 @@ where
     ) {
         Debug::<V>::NeighborBfdUnreg(self.router_id).log();
 
-        let msg = IbusMsg::BfdSessionUnreg {
-            sess_key: self.bfd_session_key(iface),
-            client_id: self.bfd_client_id(instance),
-        };
+        let msg = IbusMsg::BfdSession(
+            holo_utils::ibus::BfdSessionMsg::Unregistration {
+                sess_key: self.bfd_session_key(iface),
+                client_id: self.bfd_client_id(instance),
+            },
+        );
         let _ = instance.tx.ibus.send(msg);
     }
 

--- a/holo-ospf/src/neighbor.rs
+++ b/holo-ospf/src/neighbor.rs
@@ -10,7 +10,7 @@ use std::sync::Arc;
 
 use chrono::{DateTime, Utc};
 use holo_utils::bfd;
-use holo_utils::ibus::IbusMsg;
+use holo_utils::ibus::BfdSessionMsg;
 use holo_utils::task::{IntervalTask, TimeoutTask};
 use nsm::{Event, State};
 use rand::RngCore;
@@ -553,14 +553,12 @@ where
     ) {
         Debug::<V>::NeighborBfdReg(self.router_id).log();
 
-        let msg = IbusMsg::BfdSession(
-            holo_utils::ibus::BfdSessionMsg::Registration {
-                sess_key: self.bfd_session_key(iface),
-                client_id: self.bfd_client_id(instance),
-                client_config: Some(iface.config.bfd_params),
-            },
-        );
-        let _ = instance.tx.ibus.send(msg);
+        let msg = BfdSessionMsg::Registration {
+            sess_key: self.bfd_session_key(iface),
+            client_id: self.bfd_client_id(instance),
+            client_config: Some(iface.config.bfd_params),
+        };
+        let _ = instance.tx.ibus.send(msg.into());
     }
 
     pub(crate) fn bfd_unregister(
@@ -570,13 +568,11 @@ where
     ) {
         Debug::<V>::NeighborBfdUnreg(self.router_id).log();
 
-        let msg = IbusMsg::BfdSession(
-            holo_utils::ibus::BfdSessionMsg::Unregistration {
-                sess_key: self.bfd_session_key(iface),
-                client_id: self.bfd_client_id(instance),
-            },
-        );
-        let _ = instance.tx.ibus.send(msg);
+        let msg = BfdSessionMsg::Unregistration {
+            sess_key: self.bfd_session_key(iface),
+            client_id: self.bfd_client_id(instance),
+        };
+        let _ = instance.tx.ibus.send(msg.into());
     }
 
     fn bfd_session_key(&self, iface: &Interface<V>) -> bfd::SessionKey {

--- a/holo-ospf/src/northbound/configuration.rs
+++ b/holo-ospf/src/northbound/configuration.rs
@@ -17,7 +17,7 @@ use holo_northbound::configuration::{
 use holo_northbound::yang::control_plane_protocol::ospf;
 use holo_utils::bfd;
 use holo_utils::crypto::CryptoAlgo;
-use holo_utils::ibus::IbusMsg;
+use holo_utils::ibus::{IbusMsg, InterfaceMsg};
 use holo_utils::ip::{AddressFamily, IpAddrKind, IpNetworkKind};
 use holo_utils::yang::DataNodeRefExt;
 use holo_yang::{ToYang, TryFromYang};
@@ -1448,10 +1448,12 @@ where
             }
             Event::InterfaceQuerySouthbound(ifname, af) => {
                 if self.is_active() {
-                    let _ = self.tx.ibus.send(IbusMsg::InterfaceQuery {
-                        ifname,
-                        af: Some(af),
-                    });
+                    let _ = self.tx.ibus.send(IbusMsg::Interface(
+                        InterfaceMsg::Query {
+                            ifname,
+                            af: Some(af),
+                        },
+                    ));
                 }
             }
             Event::StubRouterChange => {

--- a/holo-ospf/src/northbound/configuration.rs
+++ b/holo-ospf/src/northbound/configuration.rs
@@ -1448,12 +1448,11 @@ where
             }
             Event::InterfaceQuerySouthbound(ifname, af) => {
                 if self.is_active() {
-                    let _ = self.tx.ibus.send(IbusMsg::Interface(
-                        InterfaceMsg::Query {
-                            ifname,
-                            af: Some(af),
-                        },
-                    ));
+                    let msg = InterfaceMsg::Query {
+                        ifname,
+                        af: Some(af),
+                    };
+                    let _ = self.tx.ibus.send(msg.into());
                 }
             }
             Event::StubRouterChange => {

--- a/holo-policy/src/northbound/configuration.rs
+++ b/holo-policy/src/northbound/configuration.rs
@@ -13,7 +13,7 @@ use holo_northbound::configuration::{
     self, Callbacks, CallbacksBuilder, Provider,
 };
 use holo_northbound::yang::routing_policy;
-use holo_utils::ibus::{IbusMsg, PolicyMsg};
+use holo_utils::ibus::PolicyMsg;
 use holo_utils::ip::AddressFamily;
 use holo_utils::policy::{
     IpPrefixRange, MatchSetRestrictedType, MatchSetType, MetricType,
@@ -1109,9 +1109,8 @@ impl Provider for Master {
 
                 // Notify protocols that the policy match sets have been
                 // updated.
-                let msg =
-                    IbusMsg::Policy(PolicyMsg::MatchSetsUpdate(match_sets));
-                let _ = self.ibus_tx.send(msg);
+                let msg = PolicyMsg::MatchSetsUpdate(match_sets);
+                let _ = self.ibus_tx.send(msg.into());
             }
             Event::PolicyChange(name) => {
                 let policy = self.policies.get_mut(&name).unwrap();
@@ -1121,13 +1120,13 @@ impl Provider for Master {
                 let policy = Arc::new(policy.clone());
 
                 // Notify protocols that the policy has been updated.
-                let msg = IbusMsg::Policy(PolicyMsg::Update(policy));
-                let _ = self.ibus_tx.send(msg);
+                let msg = PolicyMsg::Update(policy);
+                let _ = self.ibus_tx.send(msg.into());
             }
             Event::PolicyDelete(name) => {
                 // Notify protocols that the policy definition has been deleted.
-                let msg = IbusMsg::Policy(PolicyMsg::Delete(name));
-                let _ = self.ibus_tx.send(msg);
+                let msg = PolicyMsg::Delete(name);
+                let _ = self.ibus_tx.send(msg.into());
             }
         }
     }

--- a/holo-policy/src/northbound/configuration.rs
+++ b/holo-policy/src/northbound/configuration.rs
@@ -13,7 +13,7 @@ use holo_northbound::configuration::{
     self, Callbacks, CallbacksBuilder, Provider,
 };
 use holo_northbound::yang::routing_policy;
-use holo_utils::ibus::IbusMsg;
+use holo_utils::ibus::{IbusMsg, PolicyMsg};
 use holo_utils::ip::AddressFamily;
 use holo_utils::policy::{
     IpPrefixRange, MatchSetRestrictedType, MatchSetType, MetricType,
@@ -1109,7 +1109,8 @@ impl Provider for Master {
 
                 // Notify protocols that the policy match sets have been
                 // updated.
-                let msg = IbusMsg::PolicyMatchSetsUpd(match_sets);
+                let msg =
+                    IbusMsg::Policy(PolicyMsg::MatchSetsUpdate(match_sets));
                 let _ = self.ibus_tx.send(msg);
             }
             Event::PolicyChange(name) => {
@@ -1120,12 +1121,12 @@ impl Provider for Master {
                 let policy = Arc::new(policy.clone());
 
                 // Notify protocols that the policy has been updated.
-                let msg = IbusMsg::PolicyUpd(policy);
+                let msg = IbusMsg::Policy(PolicyMsg::Update(policy));
                 let _ = self.ibus_tx.send(msg);
             }
             Event::PolicyDelete(name) => {
                 // Notify protocols that the policy definition has been deleted.
-                let msg = IbusMsg::PolicyDel(name);
+                let msg = IbusMsg::Policy(PolicyMsg::Delete(name));
                 let _ = self.ibus_tx.send(msg);
             }
         }

--- a/holo-rip/src/instance.rs
+++ b/holo-rip/src/instance.rs
@@ -16,7 +16,7 @@ use enum_as_inner::EnumAsInner;
 use holo_protocol::{
     InstanceChannelsTx, InstanceShared, MessageReceiver, ProtocolInstance,
 };
-use holo_utils::ibus::IbusMsg;
+use holo_utils::ibus::{IbusMsg, InterfaceAddressMsg, InterfaceMsg};
 use holo_utils::protocol::Protocol;
 use holo_utils::task::{IntervalTask, TimeoutTask};
 use holo_utils::{Receiver, Sender, UnboundedReceiver, UnboundedSender};
@@ -539,17 +539,22 @@ where
 {
     match msg {
         // Interface update notification.
-        IbusMsg::InterfaceUpd(msg) => {
+        IbusMsg::Interface(InterfaceMsg::Update(msg)) => {
             southbound::rx::process_iface_update(instance, msg);
         }
-        // Interface address addition notification.
-        IbusMsg::InterfaceAddressAdd(msg) => {
-            southbound::rx::process_addr_add(instance, msg);
-        }
-        // Interface address delete notification.
-        IbusMsg::InterfaceAddressDel(msg) => {
-            southbound::rx::process_addr_del(instance, msg);
-        }
+
+        // Interface address
+        IbusMsg::InterfaceAddress(iface_addr_msg) => match iface_addr_msg {
+            // Interface address addition notification.
+            InterfaceAddressMsg::Add(msg) => {
+                southbound::rx::process_addr_add(instance, msg);
+            }
+
+            // Interface address delete notification.
+            InterfaceAddressMsg::Delete(msg) => {
+                southbound::rx::process_addr_del(instance, msg);
+            }
+        },
         // Ignore other events.
         _ => {}
     }

--- a/holo-rip/src/northbound/configuration.rs
+++ b/holo-rip/src/northbound/configuration.rs
@@ -16,7 +16,7 @@ use holo_northbound::configuration::{
 };
 use holo_northbound::yang::control_plane_protocol::rip;
 use holo_utils::crypto::CryptoAlgo;
-use holo_utils::ibus::{IbusMsg, InterfaceMsg};
+use holo_utils::ibus::InterfaceMsg;
 use holo_utils::ip::IpAddrKind;
 use holo_utils::yang::DataNodeRefExt;
 use holo_yang::{ToYang, TryFromYang};
@@ -456,12 +456,11 @@ where
             }
             Event::InterfaceQuerySouthbound(ifname) => {
                 if let Instance::Up(instance) = self {
-                    let _ = instance.tx.ibus.send(IbusMsg::Interface(
-                        InterfaceMsg::Query {
-                            ifname,
-                            af: Some(V::ADDRESS_FAMILY),
-                        },
-                    ));
+                    let msg = InterfaceMsg::Query {
+                        ifname,
+                        af: Some(V::ADDRESS_FAMILY),
+                    };
+                    let _ = instance.tx.ibus.send(msg.into());
                 }
             }
             Event::JoinMulticast(iface_idx) => {

--- a/holo-rip/src/northbound/configuration.rs
+++ b/holo-rip/src/northbound/configuration.rs
@@ -16,7 +16,7 @@ use holo_northbound::configuration::{
 };
 use holo_northbound::yang::control_plane_protocol::rip;
 use holo_utils::crypto::CryptoAlgo;
-use holo_utils::ibus::IbusMsg;
+use holo_utils::ibus::{IbusMsg, InterfaceMsg};
 use holo_utils::ip::IpAddrKind;
 use holo_utils::yang::DataNodeRefExt;
 use holo_yang::{ToYang, TryFromYang};
@@ -456,10 +456,12 @@ where
             }
             Event::InterfaceQuerySouthbound(ifname) => {
                 if let Instance::Up(instance) = self {
-                    let _ = instance.tx.ibus.send(IbusMsg::InterfaceQuery {
-                        ifname,
-                        af: Some(V::ADDRESS_FAMILY),
-                    });
+                    let _ = instance.tx.ibus.send(IbusMsg::Interface(
+                        InterfaceMsg::Query {
+                            ifname,
+                            af: Some(V::ADDRESS_FAMILY),
+                        },
+                    ));
                 }
             }
             Event::JoinMulticast(iface_idx) => {

--- a/holo-rip/src/southbound/tx.rs
+++ b/holo-rip/src/southbound/tx.rs
@@ -4,7 +4,7 @@
 // SPDX-License-Identifier: MIT
 //
 
-use holo_utils::ibus::{IbusMsg, IbusSender};
+use holo_utils::ibus::{IbusMsg, IbusSender, RouteIpMsg};
 use holo_utils::southbound::{
     Nexthop, RouteKeyMsg, RouteMsg, RouteOpaqueAttrs,
 };
@@ -43,7 +43,7 @@ pub(crate) fn route_install<V>(
     };
 
     // Send message.
-    let msg = IbusMsg::RouteIpAdd(msg);
+    let msg = IbusMsg::RouteIp(RouteIpMsg::Add(msg));
     let _ = ibus_tx.send(msg);
 }
 
@@ -63,6 +63,6 @@ where
     };
 
     // Send message.
-    let msg = IbusMsg::RouteIpDel(msg);
+    let msg = IbusMsg::RouteIp(RouteIpMsg::Delete(msg));
     let _ = ibus_tx.send(msg);
 }

--- a/holo-rip/src/southbound/tx.rs
+++ b/holo-rip/src/southbound/tx.rs
@@ -4,7 +4,7 @@
 // SPDX-License-Identifier: MIT
 //
 
-use holo_utils::ibus::{IbusMsg, IbusSender, RouteIpMsg};
+use holo_utils::ibus::{IbusSender, RouteIpMsg};
 use holo_utils::southbound::{
     Nexthop, RouteKeyMsg, RouteMsg, RouteOpaqueAttrs,
 };
@@ -27,7 +27,7 @@ pub(crate) fn route_install<V>(
     }
 
     // Fill-in message.
-    let msg = RouteMsg {
+    let msg = RouteIpMsg::Add(RouteMsg {
         protocol: V::PROTOCOL,
         prefix: route.prefix.into(),
         distance: distance.into(),
@@ -40,11 +40,10 @@ pub(crate) fn route_install<V>(
             labels: Vec::new(),
         }]
         .into(),
-    };
+    });
 
     // Send message.
-    let msg = IbusMsg::RouteIp(RouteIpMsg::Add(msg));
-    let _ = ibus_tx.send(msg);
+    let _ = ibus_tx.send(msg.into());
 }
 
 // Uninstall RIP route from the RIB.
@@ -57,12 +56,11 @@ where
     }
 
     // Fill-in message.
-    let msg = RouteKeyMsg {
+    let msg = RouteIpMsg::Delete(RouteKeyMsg {
         protocol: V::PROTOCOL,
         prefix: route.prefix.into(),
-    };
+    });
 
     // Send message.
-    let msg = IbusMsg::RouteIp(RouteIpMsg::Delete(msg));
-    let _ = ibus_tx.send(msg);
+    let _ = ibus_tx.send(msg.into());
 }

--- a/holo-routing/src/ibus.rs
+++ b/holo-routing/src/ibus.rs
@@ -164,7 +164,7 @@ pub(crate) fn process_msg(master: &mut Master, msg: IbusMsg) {
 
 // Requests information about all interfaces addresses.
 pub(crate) fn request_addresses(ibus_tx: &IbusSender) {
-    send(ibus_tx, IbusMsg::Interface(InterfaceMsg::Dump));
+    send(ibus_tx, InterfaceMsg::Dump.into());
 }
 
 // Sends route redistribute update notification.
@@ -173,7 +173,7 @@ pub(crate) fn notify_redistribute_add(
     prefix: IpNetwork,
     route: &Route,
 ) {
-    let msg = RouteMsg {
+    let msg = RouteRedistributeMsg::Add(RouteMsg {
         protocol: route.protocol,
         prefix,
         distance: route.distance,
@@ -181,9 +181,8 @@ pub(crate) fn notify_redistribute_add(
         tag: route.tag,
         opaque_attrs: route.opaque_attrs.clone(),
         nexthops: route.nexthops.clone(),
-    };
-    let msg = IbusMsg::RouteRedistribute(RouteRedistributeMsg::Add(msg));
-    send(ibus_tx, msg);
+    });
+    send(ibus_tx, msg.into());
 }
 
 // Sends route redistribute delete notification.
@@ -193,8 +192,8 @@ pub(crate) fn notify_redistribute_del(
     protocol: Protocol,
 ) {
     let msg = RouteKeyMsg { protocol, prefix };
-    let msg = IbusMsg::RouteRedistribute(RouteRedistributeMsg::Delete(msg));
-    send(ibus_tx, msg);
+    let msg = RouteRedistributeMsg::Delete(msg);
+    send(ibus_tx, msg.into());
 }
 
 // Sends route redistribute delete notification.
@@ -203,8 +202,8 @@ pub(crate) fn notify_nht_update(
     addr: IpAddr,
     metric: Option<u32>,
 ) {
-    let msg = IbusMsg::Nexthop(NexthopMsg::Update { addr, metric });
-    send(ibus_tx, msg);
+    let msg = NexthopMsg::Update { addr, metric };
+    send(ibus_tx, msg.into());
 }
 
 // ===== helper functions =====

--- a/holo-system/src/ibus.rs
+++ b/holo-system/src/ibus.rs
@@ -20,8 +20,8 @@ pub(crate) fn notify_hostname_update(
     ibus_tx: &IbusSender,
     hostname: Option<String>,
 ) {
-    let msg = IbusMsg::Hostname(HostnameMsg::Update(hostname));
-    notify(ibus_tx, msg);
+    let msg = HostnameMsg::Update(hostname);
+    notify(ibus_tx, msg.into());
 }
 
 // ===== helper functions =====

--- a/holo-system/src/ibus.rs
+++ b/holo-system/src/ibus.rs
@@ -4,22 +4,15 @@
 // SPDX-License-Identifier: MIT
 //
 
-use holo_utils::ibus::{IbusMsg, IbusSender};
+use holo_utils::ibus::{HostnameMsg, IbusMsg, IbusSender};
 
 use crate::Master;
 
 // ===== global functions =====
 
 pub(crate) fn process_msg(master: &mut Master, msg: IbusMsg) {
-    match msg {
-        IbusMsg::HostnameQuery => {
-            notify_hostname_update(
-                &master.ibus_tx,
-                master.config.hostname.clone(),
-            );
-        }
-        // Ignore other events.
-        _ => {}
+    if let IbusMsg::Hostname(HostnameMsg::Query) = msg {
+        notify_hostname_update(&master.ibus_tx, master.config.hostname.clone());
     }
 }
 
@@ -27,7 +20,7 @@ pub(crate) fn notify_hostname_update(
     ibus_tx: &IbusSender,
     hostname: Option<String>,
 ) {
-    let msg = IbusMsg::HostnameUpdate(hostname);
+    let msg = IbusMsg::Hostname(HostnameMsg::Update(hostname));
     notify(ibus_tx, msg);
 }
 

--- a/holo-utils/Cargo.toml
+++ b/holo-utils/Cargo.toml
@@ -13,6 +13,7 @@ bitflags.workspace = true
 bytes.workspace = true
 capctl.workspace = true
 chrono.workspace = true
+derive_more.workspace = true
 derive-new.workspace = true
 enum-as-inner.workspace = true
 ipnetwork.workspace = true

--- a/holo-utils/src/ibus.rs
+++ b/holo-utils/src/ibus.rs
@@ -29,93 +29,34 @@ pub type IbusSender = Sender<IbusMsg>;
 // Ibus message for communication among the different Holo components.
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub enum IbusMsg {
-    // BFD peer registration.
-    BfdSessionReg {
-        sess_key: bfd::SessionKey,
-        client_id: bfd::ClientId,
-        client_config: Option<bfd::ClientCfg>,
-    },
-    // BFD peer unregistration.
-    BfdSessionUnreg {
-        sess_key: bfd::SessionKey,
-        client_id: bfd::ClientId,
-    },
-    // BFD peer state update.
-    BfdStateUpd {
-        sess_key: bfd::SessionKey,
-        state: bfd::State,
-    },
-    // Query the current hostname.
-    HostnameQuery,
-    // Hostname update notification.
-    HostnameUpdate(Option<String>),
-    // Request to dump information about all interfaces.
-    InterfaceDump,
-    // Query information about a specific interface.
-    InterfaceQuery {
-        ifname: String,
-        af: Option<AddressFamily>,
-    },
-    // Interface update notification.
-    InterfaceUpd(InterfaceUpdateMsg),
-    // Interface delete notification.
-    InterfaceDel(String),
-    // Interface address addition notification.
-    InterfaceAddressAdd(AddressMsg),
-    // Interface address delete notification.
-    InterfaceAddressDel(AddressMsg),
-    // Keychain update notification.
-    KeychainUpd(Arc<Keychain>),
-    // Keychain delete notification.
-    KeychainDel(String),
-    // Nexthop tracking registration.
-    NexthopTrack(IpAddr),
-    // Nexthop tracking unregistration.
-    NexthopUntrack(IpAddr),
-    // Nexthop tracking update.
-    NexthopUpd {
-        addr: IpAddr,
-        metric: Option<u32>,
-    },
-    // Policy match sets update notification.
-    PolicyMatchSetsUpd(Arc<MatchSets>),
-    // Policy definition update notification.
-    PolicyUpd(Arc<Policy>),
-    // Policy definition delete notification.
-    PolicyDel(String),
-    // Query the current Router ID.
-    RouterIdQuery,
-    // Router ID update notification.
-    RouterIdUpdate(Option<Ipv4Addr>),
-    // Request to install IP route in the RIB.
-    RouteIpAdd(RouteMsg),
-    // Request to uninstall IP route from the RIB.
-    RouteIpDel(RouteKeyMsg),
-    // Request to install MPLS route in the LIB.
-    RouteMplsAdd(LabelInstallMsg),
-    // Request to uninstall MPLS route from the LIB.
-    RouteMplsDel(LabelUninstallMsg),
-    // Request to redistribute routes.
-    RouteRedistributeDump {
-        protocol: Protocol,
-        af: Option<AddressFamily>,
-    },
-    // Route redistribute update notification.
-    RouteRedistributeAdd(RouteMsg),
-    // Route redistribute delete notification.
-    RouteRedistributeDel(RouteKeyMsg),
-    // Segment Routing configuration update.
-    SrCfgUpd(Arc<SrCfg>),
-    // Segment Routing configuration event.
-    SrCfgEvent(SrCfgEvent),
-    // BIER configuration update.
-    BierCfgUpd(Arc<BierCfg>),
-    // BIER configuration event.
-    BierCfgEvent(BierCfgEvent),
-    // Request to install an entry in the BIRT.
-    RouteBierAdd(BierNbrInstallMsg),
-    // Request to uninstall an entry in the BIRT.
-    RouteBierDel(BierNbrUninstallMsg),
+    // BFD session
+    BfdSession(BfdSessionMsg),
+    // Hostname
+    Hostname(HostnameMsg),
+    // Interface
+    Interface(InterfaceMsg),
+    // Interface Address
+    InterfaceAddress(InterfaceAddressMsg),
+    // Keychain
+    Keychain(KeychainMsg),
+    // Nexthop
+    Nexthop(NexthopMsg),
+    // policy
+    Policy(PolicyMsg),
+    // Router ID
+    RouterId(RouterIdMsg),
+    // Route Ip
+    RouteIp(RouteIpMsg),
+    // Route Mpls
+    RouteMpls(RouteMplsMsg),
+    // Route redistribute
+    RouteRedistribute(RouteRedistributeMsg),
+    // SrCfg
+    SrCfg(SrCfgMsg),
+    // BIER
+    BierCfg(BierCfgMsg),
+    // ROUTE BIER
+    RouteBier(RouteBierMsg),
     // Purge the BIRT.
     /* TODO: Add Protocol argument to BierPurge to specify which BIRT has to be purged.
      *  E.g., One could ask to purge the BIRT populated by a specific instance
@@ -123,6 +64,151 @@ pub enum IbusMsg {
      *  See https://github.com/holo-routing/holo/pull/16#discussion_r1729456621.
      */
     BierPurge,
+}
+
+// Bfd session ibus messages
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub enum BfdSessionMsg {
+    // BFD peer registration.
+    Registration {
+        sess_key: bfd::SessionKey,
+        client_id: bfd::ClientId,
+        client_config: Option<bfd::ClientCfg>,
+    },
+
+    // BFD peer unregistration.
+    Unregistration {
+        sess_key: bfd::SessionKey,
+        client_id: bfd::ClientId,
+    },
+
+    // BFD peer state update.
+    Update {
+        sess_key: bfd::SessionKey,
+        state: bfd::State,
+    },
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub enum HostnameMsg {
+    // Query the current hostname.
+    Query,
+    // Hostname update notification.
+    Update(Option<String>),
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub enum InterfaceMsg {
+    // Request to dump information about all interfaces.
+    Dump,
+    // Query information about a specific interface.
+    Query {
+        ifname: String,
+        af: Option<AddressFamily>,
+    },
+    // Interface update notification.
+    Update(InterfaceUpdateMsg),
+    // Interface delete notification.
+    Delete(String),
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub enum InterfaceAddressMsg {
+    // Interface address addition notification.
+    Add(AddressMsg),
+
+    // Interface address delete notification.
+    Delete(AddressMsg),
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub enum KeychainMsg {
+    // Keychain update notification.
+    Update(Arc<Keychain>),
+
+    // Keychain delete notification.
+    Delete(String),
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub enum NexthopMsg {
+    // Nexthop tracking registration
+    Track(IpAddr),
+
+    // Nexthop tracking unregistration
+    Untrack(IpAddr),
+
+    // Nexthop tracking update
+    Update { addr: IpAddr, metric: Option<u32> },
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub enum PolicyMsg {
+    // Policy match sets update notification.
+    MatchSetsUpdate(Arc<MatchSets>),
+    // Policy definition update notification.
+    Update(Arc<Policy>),
+    // Policy definition delete notification.
+    Delete(String),
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub enum RouterIdMsg {
+    // Query the current Router ID.
+    Query,
+    // Router ID update notification.
+    Update(Option<Ipv4Addr>),
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub enum RouteIpMsg {
+    Add(RouteMsg),
+    Delete(RouteKeyMsg),
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub enum RouteMplsMsg {
+    // Request to install MPLS route in the LIB.
+    Add(LabelInstallMsg),
+    // Request to uninstall MPLS route from the LIB.
+    Delete(LabelUninstallMsg),
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub enum RouteRedistributeMsg {
+    // Request to redistribute routes.
+    Dump {
+        protocol: Protocol,
+        af: Option<AddressFamily>,
+    },
+    // Route redistribute update notification.
+    Add(RouteMsg),
+    // Route redistribute delete notification.
+    Delete(RouteKeyMsg),
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub enum SrCfgMsg {
+    // Segment Routing configuration update.
+    Update(Arc<SrCfg>),
+    // Segment Routing configuration event.
+    Event(SrCfgEvent),
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub enum BierCfgMsg {
+    // BIER configuration update.
+    Update(Arc<BierCfg>),
+    // BIER configuration event.
+    Event(BierCfgEvent),
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub enum RouteBierMsg {
+    // Request to install an entry in the BIRT.
+    Add(BierNbrInstallMsg),
+    // Request to uninstall an entry in the BIRT.
+    Delete(BierNbrUninstallMsg),
 }
 
 // Type of Segment Routing configuration change.

--- a/holo-utils/src/ibus.rs
+++ b/holo-utils/src/ibus.rs
@@ -3,10 +3,10 @@
 //
 // SPDX-License-Identifier: MIT
 //
-
 use std::net::{IpAddr, Ipv4Addr};
 use std::sync::Arc;
 
+use derive_more::From;
 use serde::{Deserialize, Serialize};
 use tokio::sync::broadcast::{Receiver, Sender};
 
@@ -27,7 +27,7 @@ pub type IbusReceiver = Receiver<IbusMsg>;
 pub type IbusSender = Sender<IbusMsg>;
 
 // Ibus message for communication among the different Holo components.
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, From)]
 pub enum IbusMsg {
     // BFD session
     BfdSession(BfdSessionMsg),


### PR DESCRIPTION

IbusMsg had too many items (which can only keep growing). This commit restructures
the actions and categorize each item e.g Interface/RouteId and actions like add, delete, 
update etc...