### PR TITLE
Update Dockerfile to avoid warning

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,7 +1,7 @@
 # Build image
 # ==============================================================================
 
-FROM ghcr.io/rust-lang/rust:nightly-bookworm as build
+FROM ghcr.io/rust-lang/rust:nightly-bookworm AS build
 
 RUN apt-get update && \
     apt-get install -y build-essential \


### PR DESCRIPTION
Upper case, so we avoid the following warning when building:

1 warning found (use docker --debug to expand):
 - FromAsCasing: 'as' and 'FROM' keywords' casing do not match (line 4)