### PR TITLE
isis: fix incorrect YANG data path

### DIFF
--- a/holo-isis/src/northbound/state.rs
+++ b/holo-isis/src/northbound/state.rs
@@ -718,7 +718,7 @@ fn load_callbacks() -> Callbacks<Instance> {
 // ===== impl Instance =====
 
 impl Provider for Instance {
-    const STATE_PATH: &'static str = "/ietf-routing:routing/control-plane-protocols/control-plane-protocol[type='ietf-bgp:bgp'][name='test']/ietf-isis:isis";
+    const STATE_PATH: &'static str = "/ietf-routing:routing/control-plane-protocols/control-plane-protocol[type='ietf-isis:isis'][name='test']/ietf-isis:isis";
 
     type ListEntry<'a> = ListEntry<'a>;
 


### PR DESCRIPTION
fix STATE_PATH in holo-isis which had ietf-bgp:bgp configured instead of ietf-isis:isis