### PR TITLE
Add VRRP checks for if instance is an owner. 

### DIFF
--- a/holo-bgp/src/events.rs
+++ b/holo-bgp/src/events.rs
@@ -718,7 +718,7 @@ where
         let mut nbr_reach = reach.clone();
         nbr_unreach.extend(
             nbr_reach
-                .extract_if(|(_, route)| !nbr.distribute_filter(route))
+                .extract_if(.., |(_, route)| !nbr.distribute_filter(route))
                 .map(|(prefix, _)| prefix),
         );
 

--- a/holo-northbound/src/configuration.rs
+++ b/holo-northbound/src/configuration.rs
@@ -681,7 +681,7 @@ where
     // Move to a separate vector the changes that need to be relayed.
     let callbacks = P::callbacks().unwrap();
     let relayed_changes = changes
-        .extract_if(|(cb_key, _)| !callbacks.0.contains_key(cb_key))
+        .extract_if(.., |(cb_key, _)| !callbacks.0.contains_key(cb_key))
         .collect();
 
     // Process local changes.

--- a/holo-vrrp/src/events.rs
+++ b/holo-vrrp/src/events.rs
@@ -107,7 +107,8 @@ pub(crate) fn process_vrrp_packet(
         fsm::State::Master => {
             let primary_addr = interface.system.addresses.first().unwrap().ip();
             if packet.priority == 0 {
-                instance.send_vrrp_advertisement(primary_addr);
+                instance
+                    .send_vrrp_advertisement(primary_addr, interface.system);
                 instance.timer_reset();
             } else if packet.priority > instance.config.priority
                 || (packet.priority == instance.config.priority
@@ -142,7 +143,7 @@ pub(crate) fn handle_master_down_timer(
     };
 
     // RFC 3768: Section 6.4.2 ("If the Master_Down_timer fires")
-    instance.send_vrrp_advertisement(src_ip);
+    instance.send_vrrp_advertisement(src_ip, interface.system);
     instance.send_gratuitous_arp();
     instance.change_state(
         &interface,

--- a/holo-vrrp/src/northbound/configuration.rs
+++ b/holo-vrrp/src/northbound/configuration.rs
@@ -222,10 +222,6 @@ impl Provider for Interface {
                     );
                     instance.timer_set(&interface);
                 }
-
-                // owner status may change when virtual address is added
-                instance.state.is_owner =
-                    instance.check_is_owner(interface.system);
             }
             Event::VirtualAddressDelete { vrid, addr } => {
                 let (interface, instance) = self.get_instance(vrid).unwrap();
@@ -238,9 +234,6 @@ impl Provider for Interface {
                     );
                     instance.timer_set(&interface);
                 }
-                // owner status may change when virtual address is added
-                instance.state.is_owner =
-                    instance.check_is_owner(interface.system);
             }
             Event::ResetTimer { vrid } => {
                 let (_, instance) = self.get_instance(vrid).unwrap();

--- a/holo-vrrp/src/northbound/configuration.rs
+++ b/holo-vrrp/src/northbound/configuration.rs
@@ -222,6 +222,10 @@ impl Provider for Interface {
                     );
                     instance.timer_set(&interface);
                 }
+
+                // owner status may change when virtual address is added
+                instance.state.is_owner =
+                    instance.check_is_owner(interface.system);
             }
             Event::VirtualAddressDelete { vrid, addr } => {
                 let (interface, instance) = self.get_instance(vrid).unwrap();
@@ -234,6 +238,9 @@ impl Provider for Interface {
                     );
                     instance.timer_set(&interface);
                 }
+                // owner status may change when virtual address is added
+                instance.state.is_owner =
+                    instance.check_is_owner(interface.system);
             }
             Event::ResetTimer { vrid } => {
                 let (_, instance) = self.get_instance(vrid).unwrap();

--- a/holo-vrrp/src/northbound/state.rs
+++ b/holo-vrrp/src/northbound/state.rs
@@ -47,7 +47,7 @@ fn load_callbacks() -> Callbacks<Interface> {
                 vrid: *vrid,
                 state: Some(instance.state.state.to_yang()),
                 // TODO
-                is_owner: None,
+                is_owner: Some(instance.state.is_owner),
                 last_adv_source: instance.state.last_adv_src.map(std::convert::Into::into).map(Cow::Owned).ignore_in_testing(),
                 up_datetime: instance.state.up_time.as_ref().map(Cow::Borrowed).ignore_in_testing(),
                 master_down_interval: instance.state.timer.as_master_down_timer().map(|task| task.remaining().as_millis() as u32 / 10).ignore_in_testing(),

--- a/holo-vrrp/src/northbound/state.rs
+++ b/holo-vrrp/src/northbound/state.rs
@@ -40,13 +40,13 @@ fn load_callbacks() -> Callbacks<Interface> {
             let iter = interface.instances.iter().map(|(vrid, instance)| ListEntry::Instance(*vrid, instance));
             Some(Box::new(iter))
         })
-        .get_object(|_interface, args| {
+        .get_object(|interface, args| {
             use interfaces::interface::ipv4::vrrp::vrrp_instance::VrrpInstance;
             let (vrid, instance) = args.list_entry.as_instance().unwrap();
             Box::new(VrrpInstance {
                 vrid: *vrid,
                 state: Some(instance.state.state.to_yang()),
-                is_owner: Some(instance.state.is_owner),
+                is_owner: Some(instance.check_is_owner(&interface.system)),
                 last_adv_source: instance.state.last_adv_src.map(std::convert::Into::into).map(Cow::Owned).ignore_in_testing(),
                 up_datetime: instance.state.up_time.as_ref().map(Cow::Borrowed).ignore_in_testing(),
                 master_down_interval: instance.state.timer.as_master_down_timer().map(|task| task.remaining().as_millis() as u32 / 10).ignore_in_testing(),

--- a/holo-vrrp/src/northbound/state.rs
+++ b/holo-vrrp/src/northbound/state.rs
@@ -46,7 +46,6 @@ fn load_callbacks() -> Callbacks<Interface> {
             Box::new(VrrpInstance {
                 vrid: *vrid,
                 state: Some(instance.state.state.to_yang()),
-                // TODO
                 is_owner: Some(instance.state.is_owner),
                 last_adv_source: instance.state.last_adv_src.map(std::convert::Into::into).map(Cow::Owned).ignore_in_testing(),
                 up_datetime: instance.state.up_time.as_ref().map(Cow::Borrowed).ignore_in_testing(),

--- a/holo-vrrp/src/tasks.rs
+++ b/holo-vrrp/src/tasks.rs
@@ -20,6 +20,7 @@ use messages::output::NetTxPacketMsg;
 use tracing::{debug_span, Instrument};
 
 use crate::instance::Instance;
+use crate::interface::InterfaceSys;
 use crate::network;
 use crate::packet::VrrpPacket;
 
@@ -203,13 +204,14 @@ pub(crate) fn master_down_timer(
 pub(crate) fn advertisement_interval(
     instance: &Instance,
     src_ip: Ipv4Addr,
+    iface_system: &InterfaceSys,
     net_tx_packetp: &UnboundedSender<NetTxPacketMsg>,
 ) -> IntervalTask {
     #[cfg(not(feature = "testing"))]
     {
         let packet = VrrpPacket {
             ip: instance.generate_ipv4_packet(src_ip),
-            vrrp: instance.generate_vrrp_packet(),
+            vrrp: instance.generate_vrrp_packet(iface_system),
         };
         let adv_sent = instance.state.statistics.adv_sent.clone();
         let net_tx_packetp = net_tx_packetp.clone();


### PR DESCRIPTION
VRRP instance is an owner if it holds a virtual IP address as it's parent interface. Currently checked during virtual-address configuration and when the primary interface has change in addresses (addition / deletion) which may affect the is_owner state.

_Adding owner logic to FSM is work in progress_