### PR TITLE
Fix extract_if signature error

### DIFF
--- a/holo-bgp/src/events.rs
+++ b/holo-bgp/src/events.rs
@@ -718,7 +718,7 @@ where
         let mut nbr_reach = reach.clone();
         nbr_unreach.extend(
             nbr_reach
-                .extract_if(|(_, route)| !nbr.distribute_filter(route))
+                .extract_if(.., |(_, route)| !nbr.distribute_filter(route))
                 .map(|(prefix, _)| prefix),
         );
 

--- a/holo-northbound/src/configuration.rs
+++ b/holo-northbound/src/configuration.rs
@@ -681,7 +681,7 @@ where
     // Move to a separate vector the changes that need to be relayed.
     let callbacks = P::callbacks().unwrap();
     let relayed_changes = changes
-        .extract_if(|(cb_key, _)| !callbacks.0.contains_key(cb_key))
+        .extract_if(.., |(cb_key, _)| !callbacks.0.contains_key(cb_key))
         .collect();
 
     // Process local changes.


### PR DESCRIPTION
Vec's extract_if signature in nightly
introduces a RangeBound field, handled
in relevant calls.