### PR TITLE
Purge thread_local from LDP tests

### DIFF
--- a/holo-ldp/tests/packet/address.rs
+++ b/holo-ldp/tests/packet/address.rs
@@ -55,7 +55,7 @@ fn test_encode_address1() {
 #[test]
 fn test_decode_address1() {
     let (ref bytes, ref msg) = *ADDRESS_MSG1;
-    IPV4_CXT.with(|cxt| test_decode_msg(cxt, bytes, msg));
+    test_decode_msg(&IPV4_CXT, bytes, msg);
 }
 
 #[test]
@@ -67,5 +67,5 @@ fn test_encode_address2() {
 #[test]
 fn test_decode_address2() {
     let (ref bytes, ref msg) = *ADDRESS_MSG2;
-    IPV4_CXT.with(|cxt| test_decode_msg(cxt, bytes, msg));
+    test_decode_msg(&IPV4_CXT, bytes, msg);
 }

--- a/holo-ldp/tests/packet/capability.rs
+++ b/holo-ldp/tests/packet/capability.rs
@@ -24,5 +24,5 @@ fn test_encode_capability1() {
 #[test]
 fn test_decode_capability1() {
     let (ref bytes, ref msg) = *CAPABILITY_MSG1;
-    IPV4_CXT.with(|cxt| test_decode_msg(cxt, bytes, msg));
+    test_decode_msg(&IPV4_CXT, bytes, msg);
 }

--- a/holo-ldp/tests/packet/hello.rs
+++ b/holo-ldp/tests/packet/hello.rs
@@ -54,7 +54,7 @@ fn test_encode_hello1() {
 #[test]
 fn test_decode_hello1() {
     let (ref bytes, ref msg) = *HELLO_MSG1;
-    IPV4_CXT.with(|cxt| test_decode_msg(cxt, bytes, msg));
+    test_decode_msg(&IPV4_CXT, bytes, msg);
 }
 
 #[test]
@@ -66,5 +66,5 @@ fn test_encode_hello2() {
 #[test]
 fn test_decode_hello2() {
     let (ref bytes, ref msg) = *HELLO_MSG2;
-    IPV6_CXT.with(|cxt| test_decode_msg(cxt, bytes, msg));
+    test_decode_msg(&IPV6_CXT, bytes, msg);
 }

--- a/holo-ldp/tests/packet/keepalive.rs
+++ b/holo-ldp/tests/packet/keepalive.rs
@@ -16,5 +16,5 @@ fn test_encode_keepalive() {
 #[test]
 fn test_decode_keepalive() {
     let (ref bytes, ref msg) = *KEEPALIVE_MSG1;
-    IPV4_CXT.with(|cxt| test_decode_msg(cxt, bytes, msg));
+    test_decode_msg(&IPV4_CXT, bytes, msg);
 }

--- a/holo-ldp/tests/packet/label.rs
+++ b/holo-ldp/tests/packet/label.rs
@@ -66,7 +66,7 @@ fn test_encode_label_mapping1() {
 #[test]
 fn test_decode_label_mapping1() {
     let (ref bytes, ref msg) = *LABEL_MAPPING_MSG1;
-    IPV4_CXT.with(|cxt| test_decode_msg(cxt, bytes, msg));
+    test_decode_msg(&IPV4_CXT, bytes, msg);
 }
 
 #[test]
@@ -78,7 +78,7 @@ fn test_encode_label_mapping2() {
 #[test]
 fn test_decode_label_mapping2() {
     let (ref bytes, ref msg) = *LABEL_MAPPING_MSG2;
-    IPV4_CXT.with(|cxt| test_decode_msg(cxt, bytes, msg));
+    test_decode_msg(&IPV4_CXT, bytes, msg);
 }
 
 #[test]
@@ -90,5 +90,5 @@ fn test_encode_label_request1() {
 #[test]
 fn test_decode_label_request1() {
     let (ref bytes, ref msg) = *LABEL_REQUEST_MSG1;
-    IPV4_CXT.with(|cxt| test_decode_msg(cxt, bytes, msg));
+    test_decode_msg(&IPV4_CXT, bytes, msg);
 }

--- a/holo-ldp/tests/packet/mod.rs
+++ b/holo-ldp/tests/packet/mod.rs
@@ -20,26 +20,25 @@ use const_addrs::{ip, ip4, ip6, net};
 use holo_ldp::packet::*;
 use holo_protocol::assert_eq_hex;
 
-thread_local! {
-    static IPV4_CXT: DecodeCxt = DecodeCxt {
-        pkt_info: PacketInfo {
-            src_addr: ip!("1.1.1.1"),
-            multicast: None,
-        },
-        pdu_max_len: Pdu::DFLT_MAX_LEN,
-        validate_pdu_hdr: None,
-        validate_msg_hdr: None,
-    };
-    static IPV6_CXT: DecodeCxt = DecodeCxt {
-        pkt_info: PacketInfo {
-            src_addr: ip!("2001:db8:1000::1"),
-            multicast: None,
-        },
-        pdu_max_len: Pdu::DFLT_MAX_LEN,
-        validate_pdu_hdr: None,
-        validate_msg_hdr: None,
-    };
-}
+const IPV4_CXT: DecodeCxt = DecodeCxt {
+    pkt_info: PacketInfo {
+        src_addr: ip!("1.1.1.1"),
+        multicast: None,
+    },
+    pdu_max_len: Pdu::DFLT_MAX_LEN,
+    validate_pdu_hdr: None,
+    validate_msg_hdr: None,
+};
+
+const IPV6_CXT: DecodeCxt = DecodeCxt {
+    pkt_info: PacketInfo {
+        src_addr: ip!("2001:db8:1000::1"),
+        multicast: None,
+    },
+    pdu_max_len: Pdu::DFLT_MAX_LEN,
+    validate_pdu_hdr: None,
+    validate_msg_hdr: None,
+};
 
 //
 // Helper functions.

--- a/holo-ldp/tests/packet/notification.rs
+++ b/holo-ldp/tests/packet/notification.rs
@@ -32,5 +32,5 @@ fn test_encode_notification1() {
 #[test]
 fn test_decode_notification1() {
     let (ref bytes, ref msg) = *NOTIFICATION_MSG1;
-    IPV4_CXT.with(|cxt| test_decode_msg(cxt, bytes, msg));
+    test_decode_msg(&IPV4_CXT, bytes, msg);
 }

--- a/holo-ldp/tests/packet/pdu.rs
+++ b/holo-ldp/tests/packet/pdu.rs
@@ -38,5 +38,5 @@ fn test_encode_pdu1() {
 #[test]
 fn test_decode_pdu1() {
     let (ref bytes, ref pdu) = *PDU1;
-    IPV4_CXT.with(|cxt| test_decode_pdu(cxt, bytes, pdu));
+    test_decode_pdu(&IPV4_CXT, bytes, pdu);
 }


### PR DESCRIPTION
Remove thread_local macro when
declaring IPV4_CXT and IPV6_CXT in
holo-ldp.

Rendered unnecessary since
commit [4ad39c616020ca2266835f95e62074bc0c7e079a](https://github.com/holo-routing/holo/commit/4ad39c616020ca2266835f95e62074bc0c7e079a) which ntroduces the [ip macro](https://docs.rs/const-addrs/latest/const_addrs/macro.ip.html) which parses the
address before compilation.