### PR TITLE
VRRP: change skew_time & master_down_interval calculation & state retrieval

### DIFF
--- a/holo-vrrp/src/northbound/configuration.rs
+++ b/holo-vrrp/src/northbound/configuration.rs
@@ -401,8 +401,8 @@ impl Provider for Interface {
 // ===== configuration helpers =====
 
 impl InstanceCfg {
-    pub(crate) const fn master_down_interval(&self) -> u32 {
-        (3 * self.advertise_interval as u32) + self.skew_time() as u32
+    pub(crate) const fn master_down_interval(&self) -> f32 {
+        (3 * self.advertise_interval) as f32 + self.skew_time()
     }
 
     pub(crate) const fn skew_time(&self) -> f32 {

--- a/holo-vrrp/src/northbound/state.rs
+++ b/holo-vrrp/src/northbound/state.rs
@@ -50,9 +50,10 @@ fn load_callbacks() -> Callbacks<Interface> {
                 is_owner: None,
                 last_adv_source: instance.state.last_adv_src.as_ref().map(Cow::Borrowed).ignore_in_testing(),
                 up_datetime: instance.state.up_time.as_ref().map(Cow::Borrowed).ignore_in_testing(),
-                master_down_interval: instance.state.timer.as_master_down_timer().map(|task| task.remaining().as_millis() as u32 / 10).ignore_in_testing(),
-                // TODO
-                skew_time: None,
+                // `master_down_interval` multiplied by 100 since it's in centiseconds.
+                master_down_interval: Some((instance.config.master_down_interval() * 100.0) as u32),
+                // `skew_time` multiplied by 1000 since it's in microseconds.
+                skew_time: Some((instance.config.skew_time() * 1000.0) as u32),
                 last_event: Some(instance.state.last_event.to_yang()).ignore_in_testing(),
                 new_master_reason: Some(instance.state.new_master_reason.to_yang()),
             })
@@ -89,9 +90,10 @@ fn load_callbacks() -> Callbacks<Interface> {
                 is_owner: None,
                 last_adv_source: instance.state.last_adv_src.as_ref().map(Cow::Borrowed).ignore_in_testing(),
                 up_datetime: instance.state.up_time.as_ref().map(Cow::Borrowed).ignore_in_testing(),
-                master_down_interval: instance.state.timer.as_master_down_timer().map(|task| task.remaining().as_millis() as u32 / 10).ignore_in_testing(),
-                // TODO
-                skew_time: None,
+                // `master_down_interval` multiplied by 100 since it's in centiseconds.
+                master_down_interval: Some((instance.config.master_down_interval() * 100.0) as u32),
+                // `skew_time` multiplied by 1000 since it's in microseconds.
+                skew_time: Some((instance.config.skew_time() * 1000.0) as u32),
                 last_event: Some(instance.state.last_event.to_yang()).ignore_in_testing(),
                 new_master_reason: Some(instance.state.new_master_reason.to_yang()),
             })


### PR DESCRIPTION
skew_time:
- Was not initially sent as part of state data, this has been changed. State retrieval being done in milliseconds.

master_down_interval:
- Changed calculation from u32 to f32 for more accurate calculation.
- Shared in state as centiseconds.