### PR TITLE
vrrp: ipv4 header simplification.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1428,6 +1428,7 @@ dependencies = [
  "ipnetwork",
  "libc",
  "nix",
+ "rand 0.9.0",
  "serde",
  "serde_json",
  "socket2 0.5.8",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,7 +64,7 @@ num-traits = "0.2"
 pickledb = "0.5"
 prefix-trie = { version = "0.4.1", default-features = false, features = ["ipnetwork"]  }
 prost = "0.13"
-rand = "0.9"
+rand = { version = "0.9", features = ["thread_rng"] }
 regex = "1.10"
 rtnetlink = "0.15"
 serde = { version = "1.0", features = ["derive", "rc"] }

--- a/holo-vrrp/Cargo.toml
+++ b/holo-vrrp/Cargo.toml
@@ -14,6 +14,7 @@ internet-checksum.workspace = true
 ipnetwork.workspace = true
 libc.workspace = true
 nix.workspace = true
+rand.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 socket2.workspace = true

--- a/holo-vrrp/src/instance.rs
+++ b/holo-vrrp/src/instance.rs
@@ -25,7 +25,6 @@ use tokio::sync::mpsc;
 use crate::debug::Debug;
 use crate::error::{Error, IoError};
 use crate::interface::{InterfaceSys, InterfaceView};
-use crate::network::{VRRP_MULTICAST_ADDR_IPV4, VRRP_PROTO_NUMBER};
 use crate::northbound::configuration::InstanceCfg;
 use crate::packet::{
     ArpHdr, EthernetHdr, Ipv4Hdr, NeighborAdvertisement, Vrrp4Packet, VrrpHdr,
@@ -435,20 +434,8 @@ impl Instance {
         let total_length = (36 + (4 * addr_count)) as u16;
 
         Ipv4Hdr {
-            version: 4,
-            ihl: 5,
-            tos: 0xc0,
             total_length,
-            identification: 0x0007,
-            flags: 0x00,
-            offset: 0x00,
-            ttl: 255,
-            protocol: VRRP_PROTO_NUMBER as u8,
-            checksum: 0x00,
             src_address,
-            dst_address: *VRRP_MULTICAST_ADDR_IPV4,
-            options: None,
-            padding: None,
         }
     }
 
@@ -474,6 +461,7 @@ impl Instance {
                         ip: self.generate_ipv4_packet(addr),
                         vrrp: self.generate_vrrp_packet(),
                     };
+
                     let msg = NetTxPacketMsg::Vrrp { packet };
                     let net = self.net.as_ref().unwrap();
                     let _ = net.net_tx_packetp.send(msg);


### PR DESCRIPTION
- Remove fields on ipv4 header struct that can be manually generated.
- Adjust unit tests accordingly