### PR TITLE
Introduce fuzzing tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ target
 **/*.rs.bk
 */rusty-tags.vi
 history.txt
+fuzz/Cargo.lock

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -63,6 +63,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dcfed56ad506cb2c684a14971b8861fdc3baaaae314b9e5f9bb532cbe3ba7a4f"
 
 [[package]]
+name = "arbitrary"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dde20b3d026af13f561bdd0f15edf01fc734f0dafcedbaf42bba506a9517f223"
+dependencies = [
+ "derive_arbitrary",
+]
+
+[[package]]
 name = "arc-swap"
 version = "1.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -615,6 +624,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "derive_arbitrary"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30542c1ad912e0e3d22a1935c290e12e8a29d704a420177a31faad4a601a0800"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.100",
+]
+
+[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -994,6 +1014,7 @@ dependencies = [
 name = "holo-bgp"
 version = "0.7.0"
 dependencies = [
+ "arbitrary",
  "arc-swap",
  "async-trait",
  "bitflags 2.9.0",
@@ -1395,6 +1416,7 @@ dependencies = [
 name = "holo-utils"
 version = "0.7.0"
 dependencies = [
+ "arbitrary",
  "async-trait",
  "bitflags 2.9.0",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ members = [
   "holo-vrrp",
   "holo-yang",
 ]
+exclude = ["fuzz"]
 default-members = ["holo-daemon"]
 resolver = "2"
 
@@ -30,6 +31,7 @@ edition = "2024"
 repository = "https://github.com/holo-routing/holo"
 
 [workspace.dependencies]
+arbitrary = { version = "1.4.1", features = ["derive"] }
 arc-swap = "1.7"
 async-trait = "0.1"
 base64 = "0.21"

--- a/fuzz/.gitignore
+++ b/fuzz/.gitignore
@@ -1,0 +1,4 @@
+target
+corpus
+artifacts
+coverage

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -17,16 +17,60 @@ holo-vrrp = { path = "../holo-vrrp/" }
 # ===== BGP fuzzers =====
 
 [[bin]]
+name = "bgp_aggregator_decode"
+path = "fuzz_targets/bgp/aggregator_decode.rs"
+
+[[bin]]
+name = "bgp_as_path_decode"
+path = "fuzz_targets/bgp/as_path_decode.rs"
+
+[[bin]]
+name = "bgp_as_path_segment_decode"
+path = "fuzz_targets/bgp/as_path_segment_decode.rs"
+
+[[bin]]
+name = "bgp_attrs_decode"
+path = "fuzz_targets/bgp/attrs_decode.rs"
+
+[[bin]]
 name = "bgp_capability_decode"
 path = "fuzz_targets/bgp/capability_decode.rs"
+
+[[bin]]
+name = "bgp_comm_decode"
+path = "fuzz_targets/bgp/comm_decode.rs"
+
+[[bin]]
+name = "bgp_ext_comm_decode"
+path = "fuzz_targets/bgp/ext_comm_decode.rs"
+
+[[bin]]
+name = "bgp_extv6_comm_decode"
+path = "fuzz_targets/bgp/extv6_comm_decode.rs"
+
+[[bin]]
+name = "bgp_ipv4_prefix_decode"
+path = "fuzz_targets/bgp/decode_ipv4_prefix.rs"
+
+[[bin]]
+name = "bgp_ipv6_prefix_decode"
+path = "fuzz_targets/bgp/decode_ipv6_prefix.rs"
 
 [[bin]]
 name = "bgp_keepalivemsg_decode"
 path = "fuzz_targets/bgp/keepalivemsg_decode.rs"
 
 [[bin]]
+name = "bgp_large_comm_decode"
+path = "fuzz_targets/bgp/large_comm_decode.rs"
+
+[[bin]]
 name = "bgp_message_decode"
 path = "fuzz_targets/bgp/message_decode.rs"
+
+[[bin]]
+name = "bgp_mpreachnlri_decode"
+path = "fuzz_targets/bgp/mpreachnlri_decode.rs"
 
 [[bin]]
 name = "bgp_notificationmsg_decode"

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -1,0 +1,55 @@
+[package]
+name = "fuzz"
+version = "0.1.0"
+publish = false
+edition = "2024"
+
+[package.metadata]
+cargo-fuzz = true
+
+[dependencies]
+libfuzzer-sys = "0.4"
+holo-bfd = { path = "../holo-bfd/" }
+holo-bgp = { path = "../holo-bgp/" }
+holo-utils = { path = "../holo-utils/" }
+holo-vrrp = { path = "../holo-vrrp/" }
+
+# ===== BGP fuzzers =====
+
+[[bin]]
+name = "bgp_capability_decode"
+path = "fuzz_targets/bgp/capability_decode.rs"
+
+[[bin]]
+name = "bgp_keepalivemsg_decode"
+path = "fuzz_targets/bgp/keepalivemsg_decode.rs"
+
+[[bin]]
+name = "bgp_message_decode"
+path = "fuzz_targets/bgp/message_decode.rs"
+
+[[bin]]
+name = "bgp_notificationmsg_decode"
+path = "fuzz_targets/bgp/notificationmsg_decode.rs"
+
+[[bin]]
+name = "bgp_openmsg_decode"
+path = "fuzz_targets/bgp/openmsg_decode.rs"
+
+[[bin]]
+name = "bgp_routerefreshmsg_decode"
+path = "fuzz_targets/bgp/routerefreshmsg_decode.rs"
+
+[[bin]]
+name = "bgp_updatemsg_decode"
+path = "fuzz_targets/bgp/updatemsg_decode.rs"
+
+# ===== VRRP fuzzers =====
+
+[[bin]]
+name = "vrrp_vrrphdr_ipv4_decode"
+path = "fuzz_targets/vrrp/vrrphdr_ipv4_decode.rs"
+
+[[bin]]
+name = "vrrp_vrrphdr_ipv6_decode"
+path = "fuzz_targets/vrrp/vrrphdr_ipv6_decode.rs"

--- a/fuzz/README.md
+++ b/fuzz/README.md
@@ -1,0 +1,75 @@
+## Fuzzing overview in holo
+
+Fuzzing is a security testing technique that involves sending random, malformed, or unexpected inputs to software to uncover vulnerabilities or bugs. It helps identify issues like crashes, memory leaks, and buffer overflows that attackers could exploit.
+
+Rust has a profile of being very secure when it comes to memory issues but that is not a complete shield from some other vectors of attack that could be used apart from memory. In Rust, two main tools exist for fuzzing: `cargo-fuzz` which is essentially a wrapper around libfuzzer and `afl.rs` which implement American Fuzzy Loop (AFL).  In holo, we use `cargo-fuzz` to do our fuzzing.
+
+The individual fuzzes are contained inside the `fuzz/fuzz_targets` directory. We mainly fuzz the packet decoders.
+
+Before we begin, you will need to have `cargo-fuzz` installed in your system. Therefore run:
+```
+$ cargo install cargo-fuzz
+```
+
+### Listing available fuzz targets
+
+To list all the fuzz targets that we currently have, go to the holo root directory and run:
+
+```
+$ cargo fuzz list
+```
+
+Output should be something like:
+
+```
+bgp_aggregator_decode
+bgp_as_path_decode
+bgp_as_path_segment_decode
+bgp_attrs_decode
+bgp_capability_decode
+bgp_comm_decode
+bgp_ext_comm_decode
+bgp_extv6_comm_decode
+bgp_ipv4_prefix_decode
+bgp_ipv6_prefix_decode
+bgp_keepalivemsg_decode
+bgp_large_comm_decode
+bgp_message_decode
+bgp_mpreachnlri_decode
+bgp_notificationmsg_decode
+bgp_openmsg_decode
+bgp_routerefreshmsg_decode
+bgp_updatemsg_decode
+vrrp_vrrphdr_ipv4_decode
+vrrp_vrrphdr_ipv6_decode
+```
+As said earlier, we primarily fuzz decoders in holo.
+
+### Fuzz a single target
+
+If we want to fuzz a single target, let's say `bgp_aggregator_decode` we'll run the following command (remember, still from holo's root directory):
+
+```
+$ cargo fuzz run bgp_aggregator_decode
+```
+The fuzzer will run infinitely until you stop it yourself (`Ctrl+C`).
+
+What if you want it to run for a specific amount of time. Say five minutes:
+
+```
+$ cargo fuzz run bgp_aggregator_decode -- -timeout=300
+```
+
+We'll add `-timeout={number-of-seconds}` as arguments for our run command.
+
+### Fuzzing all targets.
+
+Running individual targets, especially as they increase in number can be hectic.
+
+You can therefore run the following(still from the root directory) to fuzz all the targets:
+
+```
+./fuzz-all.sh
+```
+
+This will run each of the fuzz targets we have created for 5 minutes.

--- a/fuzz/fuzz-all.sh
+++ b/fuzz/fuzz-all.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+fuzz_list_cmd="cargo fuzz list"
+
+$fuzz_list_cmd | while read -r target; do
+  echo "----- fuzzing $target ------"
+  target_cmd="cargo fuzz run $target -- -timeout=300"
+  $target_cmd
+done

--- a/fuzz/fuzz_targets/bfd.rs
+++ b/fuzz/fuzz_targets/bfd.rs
@@ -1,0 +1,8 @@
+#![no_main]
+
+use holo_bfd::packet::Packet;
+use libfuzzer_sys::fuzz_target;
+
+fuzz_target!(|data: &[u8]| {
+    let _ = Packet::decode(data);
+});

--- a/fuzz/fuzz_targets/bgp/aggregator_decode.rs
+++ b/fuzz/fuzz_targets/bgp/aggregator_decode.rs
@@ -1,0 +1,23 @@
+#![no_main]
+
+use holo_bgp::packet::attribute::Aggregator;
+use holo_bgp::packet::consts::AttrType;
+use holo_utils::arbitrary::BytesArbitrary;
+use libfuzzer_sys::arbitrary::{Arbitrary, Unstructured};
+use libfuzzer_sys::fuzz_target;
+
+fuzz_target!(|data: &[u8]| {
+    let mut u = Unstructured::new(data);
+
+    if let Ok(mut buf) = BytesArbitrary::arbitrary(&mut u)
+        && let Ok(attr_type) = AttrType::arbitrary(&mut u)
+        && let Ok(four_byte_asn_cap) = bool::arbitrary(&mut u)
+    {
+        let _ = Aggregator::decode(
+            &mut buf.0,
+            attr_type,
+            four_byte_asn_cap,
+            &mut None,
+        );
+    }
+});

--- a/fuzz/fuzz_targets/bgp/as_path_decode.rs
+++ b/fuzz/fuzz_targets/bgp/as_path_decode.rs
@@ -1,0 +1,26 @@
+#![no_main]
+
+use holo_bgp::packet::attribute::AsPath;
+use holo_bgp::packet::consts::AttrType;
+use holo_bgp::packet::message::DecodeCxt;
+use holo_utils::arbitrary::BytesArbitrary;
+use libfuzzer_sys::arbitrary::{Arbitrary, Unstructured};
+use libfuzzer_sys::fuzz_target;
+
+fuzz_target!(|data: &[u8]| {
+    let mut u = Unstructured::new(data);
+
+    if let Ok(mut buf) = BytesArbitrary::arbitrary(&mut u)
+        && let Ok(cxt) = DecodeCxt::arbitrary(&mut u)
+        && let Ok(attr_type) = AttrType::arbitrary(&mut u)
+        && let Ok(four_byte_asn_cap) = bool::arbitrary(&mut u)
+    {
+        let _ = AsPath::decode(
+            &mut buf.0,
+            &cxt,
+            attr_type,
+            four_byte_asn_cap,
+            &mut None,
+        );
+    }
+});

--- a/fuzz/fuzz_targets/bgp/as_path_segment_decode.rs
+++ b/fuzz/fuzz_targets/bgp/as_path_segment_decode.rs
@@ -1,0 +1,18 @@
+#![no_main]
+
+use holo_bgp::packet::attribute::AsPathSegment;
+use holo_bgp::packet::consts::AttrType;
+use holo_utils::arbitrary::BytesArbitrary;
+use libfuzzer_sys::arbitrary::{Arbitrary, Unstructured};
+use libfuzzer_sys::fuzz_target;
+
+fuzz_target!(|data: &[u8]| {
+    let mut u = Unstructured::new(data);
+
+    if let Ok(mut buf) = BytesArbitrary::arbitrary(&mut u)
+        && let Ok(attr_type) = AttrType::arbitrary(&mut u)
+        && let Ok(four_byte_asn_cap) = bool::arbitrary(&mut u)
+    {
+        let _ = AsPathSegment::decode(&mut buf.0, attr_type, four_byte_asn_cap);
+    }
+});

--- a/fuzz/fuzz_targets/bgp/attrs_decode.rs
+++ b/fuzz/fuzz_targets/bgp/attrs_decode.rs
@@ -1,0 +1,28 @@
+#![no_main]
+
+use std::net::Ipv4Addr;
+
+use holo_bgp::packet::attribute::Attrs;
+use holo_bgp::packet::message::DecodeCxt;
+use holo_utils::arbitrary::BytesArbitrary;
+use libfuzzer_sys::arbitrary::{Arbitrary, Unstructured};
+use libfuzzer_sys::fuzz_target;
+
+fuzz_target!(|data: &[u8]| {
+    let mut u = Unstructured::new(data);
+
+    if let Ok(mut buf) = BytesArbitrary::arbitrary(&mut u)
+        && let Ok(cxt) = DecodeCxt::arbitrary(&mut u)
+        && let Ok(mut nexthop) = Option::<Ipv4Addr>::arbitrary(&mut u)
+        && let Ok(nlri_present) = bool::arbitrary(&mut u)
+    {
+        let _ = Attrs::decode(
+            &mut buf.0,
+            &cxt,
+            &mut nexthop,
+            nlri_present,
+            &mut None,
+            &mut None,
+        );
+    }
+});

--- a/fuzz/fuzz_targets/bgp/capability_decode.rs
+++ b/fuzz/fuzz_targets/bgp/capability_decode.rs
@@ -1,0 +1,14 @@
+#![no_main]
+
+use holo_bgp::packet::message::Capability;
+use holo_utils::arbitrary::BytesArbitrary;
+use libfuzzer_sys::arbitrary::{Arbitrary, Unstructured};
+use libfuzzer_sys::fuzz_target;
+
+fuzz_target!(|data: &[u8]| {
+    let mut u = Unstructured::new(data);
+
+    if let Ok(mut buf) = BytesArbitrary::arbitrary(&mut u) {
+        let _ = Capability::decode(&mut buf.0);
+    }
+});

--- a/fuzz/fuzz_targets/bgp/comm_decode.rs
+++ b/fuzz/fuzz_targets/bgp/comm_decode.rs
@@ -1,0 +1,14 @@
+#![no_main]
+
+use holo_bgp::packet::attribute::{Comm, CommList};
+use holo_utils::arbitrary::BytesArbitrary;
+use libfuzzer_sys::arbitrary::{Arbitrary, Unstructured};
+use libfuzzer_sys::fuzz_target;
+
+fuzz_target!(|data: &[u8]| {
+    let mut u = Unstructured::new(data);
+
+    if let Ok(mut buf) = BytesArbitrary::arbitrary(&mut u) {
+        let _ = CommList::<Comm>::decode(&mut buf.0, &mut None);
+    }
+});

--- a/fuzz/fuzz_targets/bgp/decode_ipv4_prefix.rs
+++ b/fuzz/fuzz_targets/bgp/decode_ipv4_prefix.rs
@@ -1,0 +1,14 @@
+#![no_main]
+
+use holo_bgp::packet::message::decode_ipv4_prefix;
+use holo_utils::arbitrary::BytesArbitrary;
+use libfuzzer_sys::arbitrary::{Arbitrary, Unstructured};
+use libfuzzer_sys::fuzz_target;
+
+fuzz_target!(|data: &[u8]| {
+    let mut u = Unstructured::new(data);
+
+    if let Ok(mut buf) = BytesArbitrary::arbitrary(&mut u) {
+        let _ = decode_ipv4_prefix(&mut buf.0);
+    }
+});

--- a/fuzz/fuzz_targets/bgp/decode_ipv6_prefix.rs
+++ b/fuzz/fuzz_targets/bgp/decode_ipv6_prefix.rs
@@ -1,0 +1,14 @@
+#![no_main]
+
+use holo_bgp::packet::message::decode_ipv6_prefix;
+use holo_utils::arbitrary::BytesArbitrary;
+use libfuzzer_sys::arbitrary::{Arbitrary, Unstructured};
+use libfuzzer_sys::fuzz_target;
+
+fuzz_target!(|data: &[u8]| {
+    let mut u = Unstructured::new(data);
+
+    if let Ok(mut buf) = BytesArbitrary::arbitrary(&mut u) {
+        let _ = decode_ipv6_prefix(&mut buf.0);
+    }
+});

--- a/fuzz/fuzz_targets/bgp/ext_comm_decode.rs
+++ b/fuzz/fuzz_targets/bgp/ext_comm_decode.rs
@@ -1,0 +1,14 @@
+#![no_main]
+
+use holo_bgp::packet::attribute::{CommList, ExtComm};
+use holo_utils::arbitrary::BytesArbitrary;
+use libfuzzer_sys::arbitrary::{Arbitrary, Unstructured};
+use libfuzzer_sys::fuzz_target;
+
+fuzz_target!(|data: &[u8]| {
+    let mut u = Unstructured::new(data);
+
+    if let Ok(mut buf) = BytesArbitrary::arbitrary(&mut u) {
+        let _ = CommList::<ExtComm>::decode(&mut buf.0, &mut None);
+    }
+});

--- a/fuzz/fuzz_targets/bgp/extv6_comm_decode.rs
+++ b/fuzz/fuzz_targets/bgp/extv6_comm_decode.rs
@@ -1,0 +1,14 @@
+#![no_main]
+
+use holo_bgp::packet::attribute::{CommList, Extv6Comm};
+use holo_utils::arbitrary::BytesArbitrary;
+use libfuzzer_sys::arbitrary::{Arbitrary, Unstructured};
+use libfuzzer_sys::fuzz_target;
+
+fuzz_target!(|data: &[u8]| {
+    let mut u = Unstructured::new(data);
+
+    if let Ok(mut buf) = BytesArbitrary::arbitrary(&mut u) {
+        let _ = CommList::<Extv6Comm>::decode(&mut buf.0, &mut None);
+    }
+});

--- a/fuzz/fuzz_targets/bgp/keepalivemsg_decode.rs
+++ b/fuzz/fuzz_targets/bgp/keepalivemsg_decode.rs
@@ -1,0 +1,16 @@
+#![no_main]
+
+use holo_bgp::packet::message::KeepaliveMsg;
+use holo_utils::arbitrary::BytesArbitrary;
+use libfuzzer_sys::arbitrary::{Arbitrary, Unstructured};
+use libfuzzer_sys::fuzz_target;
+
+fuzz_target!(|data: &[u8]| {
+    let mut u = Unstructured::new(data);
+
+    if let Ok(mut buf) = BytesArbitrary::arbitrary(&mut u)
+        && let Ok(msg_len) = u16::arbitrary(&mut u)
+    {
+        let _ = KeepaliveMsg::decode(&mut buf.0, msg_len);
+    }
+});

--- a/fuzz/fuzz_targets/bgp/large_comm_decode.rs
+++ b/fuzz/fuzz_targets/bgp/large_comm_decode.rs
@@ -1,0 +1,14 @@
+#![no_main]
+
+use holo_bgp::packet::attribute::{CommList, LargeComm};
+use holo_utils::arbitrary::BytesArbitrary;
+use libfuzzer_sys::arbitrary::{Arbitrary, Unstructured};
+use libfuzzer_sys::fuzz_target;
+
+fuzz_target!(|data: &[u8]| {
+    let mut u = Unstructured::new(data);
+
+    if let Ok(mut buf) = BytesArbitrary::arbitrary(&mut u) {
+        let _ = CommList::<LargeComm>::decode(&mut buf.0, &mut None);
+    }
+});

--- a/fuzz/fuzz_targets/bgp/message_decode.rs
+++ b/fuzz/fuzz_targets/bgp/message_decode.rs
@@ -1,0 +1,13 @@
+#![no_main]
+
+use holo_bgp::packet::message::{DecodeCxt, Message};
+use libfuzzer_sys::arbitrary::{Arbitrary, Unstructured};
+use libfuzzer_sys::fuzz_target;
+
+fuzz_target!(|data: &[u8]| {
+    let mut u = Unstructured::new(data);
+
+    if let Ok(cxt) = DecodeCxt::arbitrary(&mut u) {
+        let _ = Message::decode(data, &cxt);
+    }
+});

--- a/fuzz/fuzz_targets/bgp/mpreachnlri_decode.rs
+++ b/fuzz/fuzz_targets/bgp/mpreachnlri_decode.rs
@@ -1,0 +1,14 @@
+#![no_main]
+
+use holo_bgp::packet::message::MpReachNlri;
+use holo_utils::arbitrary::BytesArbitrary;
+use libfuzzer_sys::arbitrary::{Arbitrary, Unstructured};
+use libfuzzer_sys::fuzz_target;
+
+fuzz_target!(|data: &[u8]| {
+    let mut u = Unstructured::new(data);
+
+    if let Ok(mut buf) = BytesArbitrary::arbitrary(&mut u) {
+        let _ = MpReachNlri::decode(&mut buf.0, &mut None);
+    }
+});

--- a/fuzz/fuzz_targets/bgp/notificationmsg_decode.rs
+++ b/fuzz/fuzz_targets/bgp/notificationmsg_decode.rs
@@ -1,0 +1,16 @@
+#![no_main]
+
+use holo_bgp::packet::message::NotificationMsg;
+use holo_utils::arbitrary::BytesArbitrary;
+use libfuzzer_sys::arbitrary::{Arbitrary, Unstructured};
+use libfuzzer_sys::fuzz_target;
+
+fuzz_target!(|data: &[u8]| {
+    let mut u = Unstructured::new(data);
+
+    if let Ok(mut buf) = BytesArbitrary::arbitrary(&mut u)
+        && let Ok(msg_len) = u16::arbitrary(&mut u)
+    {
+        let _ = NotificationMsg::decode(&mut buf.0, msg_len);
+    }
+});

--- a/fuzz/fuzz_targets/bgp/openmsg_decode.rs
+++ b/fuzz/fuzz_targets/bgp/openmsg_decode.rs
@@ -1,0 +1,16 @@
+#![no_main]
+
+use holo_bgp::packet::message::OpenMsg;
+use holo_utils::arbitrary::BytesArbitrary;
+use libfuzzer_sys::arbitrary::{Arbitrary, Unstructured};
+use libfuzzer_sys::fuzz_target;
+
+fuzz_target!(|data: &[u8]| {
+    let mut u = Unstructured::new(data);
+
+    if let Ok(mut buf) = BytesArbitrary::arbitrary(&mut u)
+        && let Ok(msg_len) = u16::arbitrary(&mut u)
+    {
+        let _ = OpenMsg::decode(&mut buf.0, msg_len);
+    }
+});

--- a/fuzz/fuzz_targets/bgp/routerefreshmsg_decode.rs
+++ b/fuzz/fuzz_targets/bgp/routerefreshmsg_decode.rs
@@ -1,0 +1,16 @@
+#![no_main]
+
+use holo_bgp::packet::message::RouteRefreshMsg;
+use holo_utils::arbitrary::BytesArbitrary;
+use libfuzzer_sys::arbitrary::{Arbitrary, Unstructured};
+use libfuzzer_sys::fuzz_target;
+
+fuzz_target!(|data: &[u8]| {
+    let mut u = Unstructured::new(data);
+
+    if let Ok(mut buf) = BytesArbitrary::arbitrary(&mut u)
+        && let Ok(msg_len) = u16::arbitrary(&mut u)
+    {
+        let _ = RouteRefreshMsg::decode(&mut buf.0, msg_len);
+    }
+});

--- a/fuzz/fuzz_targets/bgp/updatemsg_decode.rs
+++ b/fuzz/fuzz_targets/bgp/updatemsg_decode.rs
@@ -1,0 +1,17 @@
+#![no_main]
+
+use holo_bgp::packet::message::{DecodeCxt, UpdateMsg};
+use holo_utils::arbitrary::BytesArbitrary;
+use libfuzzer_sys::arbitrary::{Arbitrary, Unstructured};
+use libfuzzer_sys::fuzz_target;
+
+fuzz_target!(|data: &[u8]| {
+    let mut u = Unstructured::new(data);
+
+    if let Ok(mut buf) = BytesArbitrary::arbitrary(&mut u)
+        && let Ok(msg_len) = u16::arbitrary(&mut u)
+        && let Ok(cxt) = DecodeCxt::arbitrary(&mut u)
+    {
+        let _ = UpdateMsg::decode(&mut buf.0, msg_len, &cxt);
+    }
+});

--- a/fuzz/fuzz_targets/vrrp/vrrphdr_ipv4_decode.rs
+++ b/fuzz/fuzz_targets/vrrp/vrrphdr_ipv4_decode.rs
@@ -1,0 +1,17 @@
+//
+// Copyright (c) The Holo Core Contributors
+//
+// SPDX-License-Identifier: MIT
+//
+// Sponsored by NLnet as part of the Next Generation Internet initiative.
+// See: https://nlnet.nl/NGI0
+//
+#![no_main]
+
+use holo_utils::ip::AddressFamily;
+use holo_vrrp::packet::VrrpHdr;
+use libfuzzer_sys::fuzz_target;
+
+fuzz_target!(|data: &[u8]| {
+    let _ = VrrpHdr::decode(data, AddressFamily::Ipv4);
+});

--- a/fuzz/fuzz_targets/vrrp/vrrphdr_ipv6_decode.rs
+++ b/fuzz/fuzz_targets/vrrp/vrrphdr_ipv6_decode.rs
@@ -1,0 +1,17 @@
+//
+// Copyright (c) The Holo Core Contributors
+//
+// SPDX-License-Identifier: MIT
+//
+// Sponsored by NLnet as part of the Next Generation Internet initiative.
+// See: https://nlnet.nl/NGI0
+//
+#![no_main]
+
+use holo_utils::ip::AddressFamily;
+use holo_vrrp::packet::VrrpHdr;
+use libfuzzer_sys::fuzz_target;
+
+fuzz_target!(|data: &[u8]| {
+    let _ = VrrpHdr::decode(data, AddressFamily::Ipv6);
+});

--- a/holo-bgp/Cargo.toml
+++ b/holo-bgp/Cargo.toml
@@ -8,6 +8,7 @@ edition.workspace = true
 [dependencies]
 twox-hash = { version = "2.0", optional = true }
 
+arbitrary.workspace = true
 arc-swap.workspace = true
 async-trait.workspace = true
 bitflags.workspace = true

--- a/holo-bgp/src/neighbor.rs
+++ b/holo-bgp/src/neighbor.rs
@@ -10,6 +10,7 @@ use std::sync::Arc;
 use std::sync::atomic::{self, AtomicU32};
 use std::time::Duration;
 
+use arbitrary::Arbitrary;
 use chrono::{DateTime, Utc};
 use holo_protocol::InstanceChannelsTx;
 use holo_utils::bgp::{AfiSafi, RouteType, WellKnownCommunities};
@@ -70,6 +71,7 @@ pub struct Neighbor {
 
 // BGP peer type.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[derive(Arbitrary)]
 pub enum PeerType {
     Internal,
     External,

--- a/holo-bgp/src/packet/attribute.rs
+++ b/holo-bgp/src/packet/attribute.rs
@@ -256,7 +256,7 @@ impl Attrs {
         }
     }
 
-    pub(crate) fn decode(
+    pub fn decode(
         buf: &mut Bytes,
         cxt: &DecodeCxt,
         nexthop: &mut Option<Ipv4Addr>,
@@ -633,7 +633,7 @@ impl AsPath {
         buf[start_pos..start_pos + 2].copy_from_slice(&attr_len.to_be_bytes());
     }
 
-    fn decode(
+    pub fn decode(
         buf: &mut Bytes,
         cxt: &DecodeCxt,
         attr_type: AttrType,
@@ -739,6 +739,8 @@ impl AsPath {
     }
 }
 
+// ===== impl AsPathSegment =====
+
 impl AsPathSegment {
     const MIN_LEN: u16 = 2;
 
@@ -750,7 +752,7 @@ impl AsPathSegment {
         }
     }
 
-    fn decode(
+    pub fn decode(
         buf: &mut Bytes,
         attr_type: AttrType,
         four_byte_asns: bool,
@@ -956,7 +958,7 @@ impl Aggregator {
         buf[start_pos] = attr_len as u8;
     }
 
-    fn decode(
+    pub fn decode(
         buf: &mut Bytes,
         attr_type: AttrType,
         four_byte_asn_cap: bool,
@@ -1128,7 +1130,7 @@ impl MpReachNlri {
         buf[start_pos..start_pos + 2].copy_from_slice(&attr_len.to_be_bytes());
     }
 
-    fn decode(
+    pub fn decode(
         buf: &mut Bytes,
         mp_reach: &mut Option<Self>,
     ) -> Result<(), AttrError> {
@@ -1251,7 +1253,7 @@ impl MpUnreachNlri {
         buf[start_pos..start_pos + 2].copy_from_slice(&attr_len.to_be_bytes());
     }
 
-    fn decode(
+    pub fn decode(
         buf: &mut Bytes,
         mp_unreach: &mut Option<Self>,
     ) -> Result<(), AttrError> {
@@ -1398,7 +1400,7 @@ impl<T: CommType> CommList<T> {
         buf[start_pos..start_pos + 2].copy_from_slice(&attr_len.to_be_bytes());
     }
 
-    fn decode(
+    pub fn decode(
         buf: &mut Bytes,
         comm: &mut Option<Self>,
     ) -> Result<(), AttrError> {

--- a/holo-bgp/src/packet/consts.rs
+++ b/holo-bgp/src/packet/consts.rs
@@ -4,6 +4,7 @@
 // SPDX-License-Identifier: MIT
 //
 
+use arbitrary::Arbitrary;
 use bitflags::bitflags;
 use holo_utils::ip::AddressFamily;
 use num_derive::{FromPrimitive, ToPrimitive};
@@ -213,6 +214,7 @@ pub type Afi = AddressFamily;
 #[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd)]
 #[derive(FromPrimitive, ToPrimitive)]
 #[derive(Deserialize, Serialize)]
+#[derive(Arbitrary)]
 pub enum Safi {
     Unicast = 1,
     Multicast = 2,

--- a/holo-bgp/src/packet/consts.rs
+++ b/holo-bgp/src/packet/consts.rs
@@ -262,6 +262,7 @@ bitflags! {
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 #[derive(FromPrimitive, ToPrimitive)]
 #[derive(Deserialize, Serialize)]
+#[derive(Arbitrary)]
 pub enum AttrType {
     Origin = 1,
     AsPath = 2,

--- a/holo-bgp/src/packet/message.rs
+++ b/holo-bgp/src/packet/message.rs
@@ -1005,7 +1005,7 @@ pub(crate) fn encode_ipv6_prefix(buf: &mut BytesMut, prefix: &Ipv6Network) {
     buf.put(&prefix_bytes[0..plen_wire]);
 }
 
-pub(crate) fn decode_ipv4_prefix(
+pub fn decode_ipv4_prefix(
     buf: &mut Bytes,
 ) -> DecodeResult<Option<Ipv4Network>> {
     // Parse prefix length.
@@ -1034,7 +1034,7 @@ pub(crate) fn decode_ipv4_prefix(
     Ok(Some(prefix))
 }
 
-pub(crate) fn decode_ipv6_prefix(
+pub fn decode_ipv6_prefix(
     buf: &mut Bytes,
 ) -> DecodeResult<Option<Ipv6Network>> {
     // Parse prefix length.

--- a/holo-utils/Cargo.toml
+++ b/holo-utils/Cargo.toml
@@ -8,6 +8,7 @@ edition.workspace = true
 [dependencies]
 vectorize = "0.2.0"
 
+arbitrary.workspace = true
 async-trait.workspace = true
 bitflags.workspace = true
 bytes.workspace = true

--- a/holo-utils/src/arbitrary.rs
+++ b/holo-utils/src/arbitrary.rs
@@ -1,0 +1,27 @@
+//
+// Copyright (c) The Holo Core Contributors
+//
+// SPDX-License-Identifier: MIT
+//
+// Sponsored by NLnet as part of the Next Generation Internet initiative.
+// See: https://nlnet.nl/NGI0
+//
+
+use arbitrary::{Arbitrary, Result as ArbitraryResult, Unstructured};
+use bytes::Bytes;
+
+// Used when implementing external traits on Bytes e.g Arbitrary.
+#[allow(dead_code)]
+#[derive(Debug)]
+pub struct BytesArbitrary(pub Bytes);
+
+// ====== impl BytesArbitrary =====
+
+impl Arbitrary<'_> for BytesArbitrary {
+    fn arbitrary(u: &mut Unstructured<'_>) -> ArbitraryResult<Self> {
+        let len = u.len();
+        let peeked_bytes = u.peek_bytes(len).unwrap();
+        let buf = Bytes::copy_from_slice(peeked_bytes);
+        Ok(Self(buf))
+    }
+}

--- a/holo-utils/src/ip.rs
+++ b/holo-utils/src/ip.rs
@@ -9,6 +9,7 @@ use std::net::{
     IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr, SocketAddrV4, SocketAddrV6,
 };
 
+use arbitrary::Arbitrary;
 use holo_yang::{ToYang, TryFromYang};
 use ipnetwork::{IpNetwork, IpNetworkError, Ipv4Network, Ipv6Network};
 use num_derive::{FromPrimitive, ToPrimitive};
@@ -22,6 +23,7 @@ use serde::{Deserialize, Serialize};
 #[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd)]
 #[derive(FromPrimitive, ToPrimitive)]
 #[derive(Deserialize, Serialize)]
+#[derive(Arbitrary)]
 pub enum AddressFamily {
     Ipv4 = 1,
     Ipv6 = 2,

--- a/holo-utils/src/lib.rs
+++ b/holo-utils/src/lib.rs
@@ -14,6 +14,7 @@ use std::sync::{Arc, Mutex};
 
 use pickledb::PickleDb;
 
+pub mod arbitrary;
 pub mod bfd;
 pub mod bgp;
 pub mod bier;


### PR DESCRIPTION
Introduces fuzzing tests into the codebase. 

This mainly involves:
- Setting up cargo-fuzz (libfuzzer's rust implementations). 
- Setting up necessary arbitrary derivations and where necessary custom Arbitrary implementations. 

Protocols where fuzzing has been initialized:
- BGP
- VRRP
- BFD

The rest will be fuzzed at a later time. 