### PR TITLE
ospf: Add safe byte extradiction & error handling

### DIFF
--- a/holo-ospf/src/ospfv2/network.rs
+++ b/holo-ospf/src/ospfv2/network.rs
@@ -154,13 +154,13 @@ impl NetworkVersion<Self> for Ospfv2 {
         let buf_len = buf.len() as u16;
 
         // Parse IHL (header length).
-        let hdr_len = buf.get_u8() & 0x0F;
+        let hdr_len = buf.try_get_u8()? & 0x0F;
 
         // Ignore TOS.
-        let _ = buf.get_u8();
+        let _ = buf.try_get_u8()?;
 
         // Parse and validate the IP header total length.
-        let total_len = buf.get_u16();
+        let total_len = buf.try_get_u16()?;
         if buf_len != total_len {
             return Err(DecodeError::InvalidIpHdrLength(total_len));
         }

--- a/holo-ospf/src/ospfv2/packet/lsa.rs
+++ b/holo-ospf/src/ospfv2/packet/lsa.rs
@@ -374,14 +374,14 @@ impl LsaHdrVersion<Ospfv2> for LsaHdr {
     }
 
     fn decode(buf: &mut Bytes) -> DecodeResult<Self> {
-        let age = buf.get_u16();
-        let options = Options::from_bits_truncate(buf.get_u8());
-        let lsa_type = LsaType(buf.get_u8());
-        let lsa_id = buf.get_ipv4();
-        let adv_rtr = buf.get_ipv4();
-        let seq_no = buf.get_u32();
-        let cksum = buf.get_u16();
-        let length = buf.get_u16();
+        let age = buf.try_get_u16()?;
+        let options = Options::from_bits_truncate(buf.try_get_u8()?);
+        let lsa_type = LsaType(buf.try_get_u8()?);
+        let lsa_id = buf.try_get_ipv4()?;
+        let adv_rtr = buf.try_get_ipv4()?;
+        let seq_no = buf.try_get_u32()?;
+        let cksum = buf.try_get_u16()?;
+        let length = buf.try_get_u16()?;
 
         Ok(LsaHdr {
             age,
@@ -567,23 +567,23 @@ impl LsaRouter {
         if buf.remaining() < Self::BASE_LENGTH as usize {
             return Err(DecodeError::InvalidLsaLength);
         }
-        let flags = LsaRouterFlags::from_bits_truncate(buf.get_u8());
-        let _ = buf.get_u8();
-        let links_cnt = buf.get_u16();
+        let flags = LsaRouterFlags::from_bits_truncate(buf.try_get_u8()?);
+        let _ = buf.try_get_u8()?;
+        let links_cnt = buf.try_get_u16()?;
 
         let mut links = vec![];
         for _ in 0..links_cnt {
-            let link_id = buf.get_ipv4();
-            let link_data = buf.get_ipv4();
-            let link_type = buf.get_u8();
+            let link_id = buf.try_get_ipv4()?;
+            let link_data = buf.try_get_ipv4()?;
+            let link_type = buf.try_get_u8()?;
             let link_type = LsaRouterLinkType::from_u8(link_type)
                 .ok_or(DecodeError::UnknownRouterLinkType(link_type))?;
-            let num_tos = buf.get_u8();
-            let metric = buf.get_u16();
+            let num_tos = buf.try_get_u8()?;
+            let metric = buf.try_get_u16()?;
 
             // Ignore deprecated TOS metrics.
             for _ in 0..num_tos {
-                let _ = buf.get_u32();
+                let _ = buf.try_get_u32()?;
             }
 
             let link =
@@ -639,12 +639,12 @@ impl LsaNetwork {
         if buf.remaining() < Self::BASE_LENGTH as usize {
             return Err(DecodeError::InvalidLsaLength);
         }
-        let mask = buf.get_ipv4();
+        let mask = buf.try_get_ipv4()?;
 
         let mut attached_rtrs = BTreeSet::new();
         let rtrs_cnt = buf.remaining() / 4;
         for _ in 0..rtrs_cnt {
-            let rtr = buf.get_ipv4();
+            let rtr = buf.try_get_ipv4()?;
             attached_rtrs.insert(rtr);
         }
 
@@ -672,9 +672,9 @@ impl LsaSummary {
         if buf.remaining() < Self::BASE_LENGTH as usize {
             return Err(DecodeError::InvalidLsaLength);
         }
-        let mask = buf.get_ipv4();
-        let _ = buf.get_u8();
-        let metric = buf.get_u24();
+        let mask = buf.try_get_ipv4()?;
+        let _ = buf.try_get_u8()?;
+        let metric = buf.try_get_u24()?;
         // Ignore deprecated TOS metrics.
 
         Ok(LsaSummary { mask, metric })
@@ -697,11 +697,11 @@ impl LsaAsExternal {
         if buf.remaining() < Self::BASE_LENGTH as usize {
             return Err(DecodeError::InvalidLsaLength);
         }
-        let mask = buf.get_ipv4();
-        let flags = LsaAsExternalFlags::from_bits_truncate(buf.get_u8());
-        let metric = buf.get_u24();
-        let fwd_addr = buf.get_opt_ipv4();
-        let tag = buf.get_u32();
+        let mask = buf.try_get_ipv4()?;
+        let flags = LsaAsExternalFlags::from_bits_truncate(buf.try_get_u8()?);
+        let metric = buf.try_get_u24()?;
+        let fwd_addr = buf.try_get_opt_ipv4()?;
+        let tag = buf.try_get_u32()?;
         // Ignore deprecated TOS-specific information.
 
         Ok(LsaAsExternal {

--- a/holo-ospf/src/ospfv2/packet/mod.rs
+++ b/holo-ospf/src/ospfv2/packet/mod.rs
@@ -266,48 +266,48 @@ impl PacketHdrVersion<Ospfv2> for PacketHdr {
 
     fn decode(buf: &mut Bytes) -> DecodeResult<(Self, u16, PacketHdrAuth)> {
         // Parse version.
-        let version = buf.get_u8();
+        let version = buf.try_get_u8()?;
         if version != Self::VERSION {
             return Err(DecodeError::InvalidVersion(version));
         }
 
         // Parse packet type.
-        let pkt_type = buf.get_u8();
+        let pkt_type = buf.try_get_u8()?;
         let pkt_type = match PacketType::from_u8(pkt_type) {
             Some(pkt_type) => pkt_type,
             None => return Err(DecodeError::UnknownPacketType(pkt_type)),
         };
 
         // Parse and validate message length.
-        let pkt_len = buf.get_u16();
+        let pkt_len = buf.try_get_u16()?;
         if pkt_len < Self::LENGTH {
             return Err(DecodeError::InvalidLength(pkt_len));
         }
 
         // Parse Router-ID.
-        let router_id = buf.get_ipv4();
+        let router_id = buf.try_get_ipv4()?;
         if !router_id.is_usable() {
             return Err(DecodeError::InvalidRouterId(router_id));
         }
 
         // Parse Area ID.
-        let area_id = buf.get_ipv4();
+        let area_id = buf.try_get_ipv4()?;
 
         // Parse checksum (already verified).
-        let _cksum = buf.get_u16();
+        let _cksum = buf.try_get_u16()?;
 
         // Parse authentication data.
-        let au_type = buf.get_u16();
+        let au_type = buf.try_get_u16()?;
         let auth = match AuthType::from_u16(au_type) {
             Some(AuthType::Null) => {
-                let _ = buf.get_u64();
+                let _ = buf.try_get_u64()?;
                 PacketHdrAuth::Null
             }
             Some(AuthType::Cryptographic) => {
-                let _ = buf.get_u16();
-                let key_id = buf.get_u8();
-                let auth_len = buf.get_u8();
-                let seqno = buf.get_u32();
+                let _ = buf.try_get_u16()?;
+                let key_id = buf.try_get_u8()?;
+                let auth_len = buf.try_get_u8()?;
+                let seqno = buf.try_get_u32()?;
                 PacketHdrAuth::Cryptographic {
                     key_id,
                     auth_len,
@@ -428,20 +428,20 @@ impl PacketBase<Ospfv2> for Hello {
             return Err(DecodeError::InvalidLength(buf.len() as u16));
         }
 
-        let network_mask = buf.get_ipv4();
-        let hello_interval = buf.get_u16();
+        let network_mask = buf.try_get_ipv4()?;
+        let hello_interval = buf.try_get_u16()?;
         // Ignore unknown options.
-        let options = Options::from_bits_truncate(buf.get_u8());
-        let priority = buf.get_u8();
-        let dead_interval = buf.get_u32();
-        let dr = buf.get_opt_ipv4();
-        let bdr = buf.get_opt_ipv4();
+        let options = Options::from_bits_truncate(buf.try_get_u8()?);
+        let priority = buf.try_get_u8()?;
+        let dead_interval = buf.try_get_u32()?;
+        let dr = buf.try_get_opt_ipv4()?;
+        let bdr = buf.try_get_opt_ipv4()?;
 
         // Parse list of neighbors.
         let mut neighbors = BTreeSet::new();
         let nbrs_cnt = buf.remaining() / 4;
         for _ in 0..nbrs_cnt {
-            let nbr = buf.get_ipv4();
+            let nbr = buf.try_get_ipv4()?;
             neighbors.insert(nbr);
         }
 
@@ -538,10 +538,10 @@ impl PacketBase<Ospfv2> for DbDesc {
             return Err(DecodeError::InvalidLength(buf.len() as u16));
         }
 
-        let mtu = buf.get_u16();
-        let options = Options::from_bits_truncate(buf.get_u8());
-        let dd_flags = DbDescFlags::from_bits_truncate(buf.get_u8());
-        let dd_seq_no = buf.get_u32();
+        let mtu = buf.try_get_u16()?;
+        let options = Options::from_bits_truncate(buf.try_get_u8()?);
+        let dd_flags = DbDescFlags::from_bits_truncate(buf.try_get_u8()?);
+        let dd_seq_no = buf.try_get_u32()?;
 
         // Parse list of LSA headers.
         let mut lsa_hdrs = vec![];
@@ -636,9 +636,9 @@ impl PacketBase<Ospfv2> for LsRequest {
         let mut entries = vec![];
         let entries_cnt = buf.remaining() / LsRequest::ENTRY_LENGTH as usize;
         for _ in 0..entries_cnt {
-            let lsa_type = LsaType(buf.get_u32() as u8);
-            let lsa_id = buf.get_ipv4();
-            let adv_rtr = buf.get_ipv4();
+            let lsa_type = LsaType(buf.try_get_u32()? as u8);
+            let lsa_id = buf.try_get_ipv4()?;
+            let adv_rtr = buf.try_get_ipv4()?;
             let entry = LsaKey {
                 lsa_type,
                 adv_rtr,
@@ -702,7 +702,7 @@ impl PacketBase<Ospfv2> for LsUpdate {
 
         // Parse list of LSAs.
         let mut lsas = vec![];
-        let lsas_cnt = buf.get_u32();
+        let lsas_cnt = buf.try_get_u32()?;
         for _ in 0..lsas_cnt {
             let lsa = Lsa::decode(af, buf)?;
             lsas.push(lsa);

--- a/holo-ospf/src/packet/error.rs
+++ b/holo-ospf/src/packet/error.rs
@@ -6,14 +6,16 @@
 
 use std::net::Ipv4Addr;
 
+use bytes::TryGetError;
 use serde::{Deserialize, Serialize};
 
 // Type aliases.
 pub type DecodeResult<T> = Result<T, DecodeError>;
 
 // OSPFv2 decode errors.
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize)]
 pub enum DecodeError {
+    ReadOutOfBounds,
     InvalidIpHdrLength(u16),
     InvalidVersion(u8),
     UnknownPacketType(u8),
@@ -51,6 +53,9 @@ pub enum LsaValidationError {
 impl std::fmt::Display for DecodeError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
+            DecodeError::ReadOutOfBounds => {
+                write!(f, "attempt to read out of bounds")
+            }
             DecodeError::InvalidIpHdrLength(length) => {
                 write!(f, "invalid IP header length: {length}")
             }
@@ -107,6 +112,12 @@ impl std::fmt::Display for DecodeError {
 }
 
 impl std::error::Error for DecodeError {}
+
+impl From<TryGetError> for DecodeError {
+    fn from(_error: TryGetError) -> DecodeError {
+        DecodeError::ReadOutOfBounds
+    }
+}
 
 // ===== impl LsaValidationError =====
 


### PR DESCRIPTION
- replace buf.get_*() calls with buf.try_get_*() calls for sanity.
- add DecodeError::ReadOutOfBounds. impl From<TryGetError> for the variant.