### PR TITLE
The fuzz-all.sh now runs each fuzz test for 20 mins (1200 seconds).

### DIFF
--- a/fuzz/fuzz-all.sh
+++ b/fuzz/fuzz-all.sh
@@ -4,5 +4,5 @@ fuzz_list_cmd="cargo fuzz list"
 
 $fuzz_list_cmd | while read -r target; do
   echo "----- fuzzing $target ------"
-  RUST_BACKTRACE=1 cargo fuzz run "$target" -- -timeout=300
+  RUST_BACKTRACE=1 cargo fuzz run "$target" -- -max_total_time="${1:-1200}"
 done


### PR DESCRIPTION
Optionally the period can be specified as a command-line parameter. as a number of seconds e.g. 3 seconds for testing this script.

`fuzz/fuzz-test.sh 3`

Thanks for the example of the default parameter to:
  https://coderwall.com/p/s8n9qa/default-parameter-value-in-bash