### PR TITLE
A proof-of-concept unit test for a panic caused by cargo fuzz.

### DIFF
--- a/holo-bgp/tests/packet/decode.rs
+++ b/holo-bgp/tests/packet/decode.rs
@@ -1,0 +1,32 @@
+use bytes::Bytes;
+use arbitrary::{Arbitrary, Unstructured};
+use holo_bgp::packet::attribute::AsPath;
+use holo_bgp::packet::consts::AttrType;
+use holo_bgp::packet::message::DecodeCxt;
+use holo_utils::bytes::BytesExt;
+
+#[test]
+fn small_buffer() {
+    // This reproduces a panic found using fuzz testing.
+    // It's a proof-of-concept to explore the feasibility of creating
+    // unit tests for issues found by fuzzing inputs. It should run much
+    // faster than the fuzz tests.
+    let mut u = Unstructured::new(&[4u8]);
+    let mut v = Unstructured::new(&[0u8]);
+    let mut w = Unstructured::new(&[0u8]);
+    let mut x = Unstructured::new(&[0u8]);
+
+    if let Ok(mut buf) = Bytes::arbitrary(&mut u)
+        && let Ok(cxt) = DecodeCxt::arbitrary(&mut v)
+        && let Ok(attr_type) = AttrType::arbitrary(&mut w)
+        && let Ok(four_byte_asn_cap) = bool::arbitrary(&mut x)
+    {
+        let _ = AsPath::decode(
+            &mut buf,
+            &cxt,
+            attr_type,
+            four_byte_asn_cap,
+            &mut None,
+        );
+    }
+}

--- a/holo-bgp/tests/packet/mod.rs
+++ b/holo-bgp/tests/packet/mod.rs
@@ -4,6 +4,7 @@
 // SPDX-License-Identifier: MIT
 //
 
+mod decode;
 mod keepalive;
 mod notification;
 mod open;


### PR DESCRIPTION
Context:
  Cargo fuzz tests were added several months ago to Holo and these found
various flaws which have since been fixed and tested. However the fixes may not have unit tests. I've reproduced one crash in https://github.com/julianharty/holo/tree/unit-tests-for-fuzz-crashes where the new test *fails* in the CI as it demonstrates the vulnerability exists in that snapshot of the codebase (from mid-May 2025). This commit migrates that failing test to the current state of the codebase and it *passes* as the vulnerability is now fixed.

The process to be able to create the unit test started with a crash such as those uploaded in https://github.com/holo-routing/holo/issues/71 then checking the contents of one of those files which happened to be a single byte in this instance. Running these crashes as input to `cargo fuzz` e.g.
```
cargo +nightly fuzz run bgp_attr_as_path_decode fuzz/artifacts/bgp_attr_as_path_decode/crash-a42c6cf1de3abfdea9b95f34687cbbe92b9a7383
```
means the previously arbitrary data is hard-coded and can be logged in the fuzz target script e.g. using: 
```
eprintln!("{}", hex::encode(data));
``` 
(It's also available in the file contents, this is for those who like hacking code) and in this case I effectively created hardcoded data by replacing the commented-out code as follows:
```
let mut u = Unstructured::new(&[4u8]); // Unstructured::new(data);
```

I then ran the individual fuzz target which immediately finds the panic using the hardcoded data. The code in the fuzz target code was then used to create the unit test.

Happy to walkthrough this on a call as I've probably missed out various details.