### PR TITLE
 create kernel multicast socket and basic read task

### DIFF
--- a/holo-igmp/src/error.rs
+++ b/holo-igmp/src/error.rs
@@ -20,6 +20,8 @@ pub enum Error {
 pub enum IoError {
     SocketError(std::io::Error),
     RecvError(std::io::Error),
+    RecvMissingSourceAddr,
+    RecvMissingAncillaryData,
     SendError(std::io::Error),
 }
 
@@ -76,6 +78,10 @@ impl IoError {
             IoError::RecvError(error) | IoError::SendError(error) => {
                 warn!(error = %with_source(error), "{}", self);
             }
+            IoError::RecvMissingSourceAddr
+            | IoError::RecvMissingAncillaryData => {
+                warn!("{}", self);
+            }
         }
     }
 }
@@ -88,6 +94,18 @@ impl std::fmt::Display for IoError {
             }
             IoError::RecvError(..) => {
                 write!(f, "failed to receive IP packet")
+            }
+            IoError::RecvMissingSourceAddr => {
+                write!(
+                    f,
+                    "failed to retrieve source address from received packet"
+                )
+            }
+            IoError::RecvMissingAncillaryData => {
+                write!(
+                    f,
+                    "failed to retrieve ancillary data from received packet"
+                )
             }
             IoError::SendError(..) => {
                 write!(f, "failed to send IP packet")

--- a/holo-igmp/src/events.rs
+++ b/holo-igmp/src/events.rs
@@ -14,17 +14,23 @@ use crate::packet::{DecodeResult, Packet};
 
 pub(crate) fn process_packet(
     instance: &mut Instance,
-    ifname: String,
+    ifindex: u32,
     src: Ipv4Addr,
     packet: DecodeResult<Packet>,
 ) -> Result<(), Error> {
     // Lookup interface.
-    let Some((_instance, _iface)) = instance.get_interface(&ifname) else {
+    let Some((_instance, interfaces)) = instance.as_up() else {
+        return Ok(());
+    };
+    let Some(iface) = interfaces
+        .values_mut()
+        .find(|iface| iface.system.ifindex == Some(ifindex))
+    else {
         return Ok(());
     };
 
     // TODO
-    tracing::debug!(%ifname, %src, "received packet: {:?}", packet);
+    tracing::debug!(ifname = %iface.name, %src, data = ?packet, "received packet");
 
     Ok(())
 }

--- a/holo-igmp/src/ibus/rx.rs
+++ b/holo-igmp/src/ibus/rx.rs
@@ -16,8 +16,10 @@ pub(crate) fn process_iface_update(
     msg: InterfaceUpdateMsg,
 ) -> Result<(), Error> {
     // Lookup interface.
-    let Some((mut instance, iface)) = instance.get_interface(&msg.ifname)
-    else {
+    let Some((mut instance, interfaces)) = instance.as_up() else {
+        return Ok(());
+    };
+    let Some(iface) = interfaces.get_mut(&msg.ifname) else {
         return Ok(());
     };
 

--- a/holo-igmp/src/northbound/configuration.rs
+++ b/holo-igmp/src/northbound/configuration.rs
@@ -160,16 +160,15 @@ impl Provider for Instance {
     fn process_event(&mut self, event: Event) {
         match event {
             Event::InterfaceUpdate(ifname) => {
-                let (mut instance, iface) =
-                    self.get_interface(&ifname).unwrap();
+                let Some((mut instance, interfaces)) = self.as_up() else {
+                    return;
+                };
+                let iface = interfaces.get_mut(&ifname).unwrap();
                 iface.update(&mut instance);
             }
             Event::InterfaceIbusSub(ifname) => {
-                let (instance, iface) = self.get_interface(&ifname).unwrap();
-                instance
-                    .tx
-                    .ibus
-                    .interface_sub(Some(iface.name.clone()), None);
+                let iface = self.interfaces.get(&ifname).unwrap();
+                self.tx.ibus.interface_sub(Some(iface.name.clone()), None);
             }
         }
     }

--- a/holo-igmp/src/northbound/state.rs
+++ b/holo-igmp/src/northbound/state.rs
@@ -43,57 +43,80 @@ fn load_callbacks() -> Callbacks<Instance> {
         .path(igmp::global::statistics::PATH)
         .get_object(|instance, _args| {
             use igmp::global::statistics::Statistics;
+            let mut discontinuity_time = None;
+            if let Some(state) = &instance.state {
+                discontinuity_time =
+                    Some(Cow::Borrowed(&state.statistics.discontinuity_time));
+            }
+
             Box::new(Statistics {
-                discontinuity_time: Some(Cow::Borrowed(
-                    &instance.state.statistics.discontinuity_time,
-                ))
-                .ignore_in_testing(),
+                discontinuity_time: discontinuity_time.ignore_in_testing(),
             })
         })
         .path(igmp::global::statistics::error::PATH)
         .get_object(|instance, _args| {
             use igmp::global::statistics::error::Error;
+            let mut total = None;
+            let mut query = None;
+            let mut report = None;
+            let mut leave = None;
+            let mut checksum = None;
+            let mut too_short = None;
+            if let Some(state) = &instance.state {
+                total = Some(state.statistics.errors.total);
+                query = Some(state.statistics.errors.query);
+                report = Some(state.statistics.errors.report);
+                leave = Some(state.statistics.errors.leave);
+                checksum = Some(state.statistics.errors.checksum);
+                too_short = Some(state.statistics.errors.too_short);
+            }
             Box::new(Error {
-                total: Some(instance.state.statistics.errors.total)
-                    .ignore_in_testing(),
-                query: Some(instance.state.statistics.errors.query)
-                    .ignore_in_testing(),
-                report: Some(instance.state.statistics.errors.report)
-                    .ignore_in_testing(),
-                leave: Some(instance.state.statistics.errors.leave)
-                    .ignore_in_testing(),
-                checksum: Some(instance.state.statistics.errors.checksum)
-                    .ignore_in_testing(),
-                too_short: Some(instance.state.statistics.errors.too_short)
-                    .ignore_in_testing(),
+                total: total.ignore_in_testing(),
+                query: query.ignore_in_testing(),
+                report: report.ignore_in_testing(),
+                leave: leave.ignore_in_testing(),
+                checksum: checksum.ignore_in_testing(),
+                too_short: too_short.ignore_in_testing(),
             })
         })
         .path(igmp::global::statistics::received::PATH)
         .get_object(|instance, _args| {
             use igmp::global::statistics::received::Received;
+            let mut total = None;
+            let mut query = None;
+            let mut report = None;
+            let mut leave = None;
+            if let Some(state) = &instance.state {
+                total = Some(state.statistics.msgs_rcvd.total);
+                query = Some(state.statistics.msgs_rcvd.query);
+                report = Some(state.statistics.msgs_rcvd.report);
+                leave = Some(state.statistics.msgs_rcvd.leave);
+            }
             Box::new(Received {
-                total: Some(instance.state.statistics.msgs_rcvd.total)
-                    .ignore_in_testing(),
-                query: Some(instance.state.statistics.msgs_rcvd.query)
-                    .ignore_in_testing(),
-                report: Some(instance.state.statistics.msgs_rcvd.report)
-                    .ignore_in_testing(),
-                leave: Some(instance.state.statistics.msgs_rcvd.leave)
-                    .ignore_in_testing(),
+                total: total.ignore_in_testing(),
+                query: query.ignore_in_testing(),
+                report: report.ignore_in_testing(),
+                leave: leave.ignore_in_testing(),
             })
         })
         .path(igmp::global::statistics::sent::PATH)
         .get_object(|instance, _args| {
             use igmp::global::statistics::sent::Sent;
+            let mut total = None;
+            let mut query = None;
+            let mut report = None;
+            let mut leave = None;
+            if let Some(state) = &instance.state {
+                total = Some(state.statistics.msgs_sent.total);
+                query = Some(state.statistics.msgs_sent.query);
+                report = Some(state.statistics.msgs_sent.report);
+                leave = Some(state.statistics.msgs_sent.leave);
+            }
             Box::new(Sent {
-                total: Some(instance.state.statistics.msgs_sent.total)
-                    .ignore_in_testing(),
-                query: Some(instance.state.statistics.msgs_sent.query)
-                    .ignore_in_testing(),
-                report: Some(instance.state.statistics.msgs_sent.report)
-                    .ignore_in_testing(),
-                leave: Some(instance.state.statistics.msgs_sent.leave)
-                    .ignore_in_testing(),
+                total: total.ignore_in_testing(),
+                query: query.ignore_in_testing(),
+                report: report.ignore_in_testing(),
+                leave: leave.ignore_in_testing(),
             })
         })
         .path(igmp::interfaces::interface::PATH)

--- a/holo-igmp/src/tasks.rs
+++ b/holo-igmp/src/tasks.rs
@@ -59,7 +59,7 @@ pub mod messages {
 
         #[derive(Debug, Deserialize, Serialize)]
         pub struct NetRxPacketMsg {
-            pub ifname: String,
+            pub ifindex: u32,
             pub src: Ipv4Addr,
             pub packet: DecodeResult<Packet>,
         }
@@ -89,7 +89,6 @@ pub mod messages {
 // Network Rx task.
 pub(crate) fn net_rx(
     socket: Arc<AsyncFd<Socket>>,
-    ifname: String,
     net_packet_rxp: &Sender<messages::input::NetRxPacketMsg>,
 ) -> Task<()> {
     #[cfg(not(feature = "testing"))]
@@ -103,8 +102,7 @@ pub(crate) fn net_rx(
 
         Task::spawn(
             async move {
-                let _ =
-                    network::read_loop(socket, ifname, net_packet_rxp).await;
+                let _ = network::read_loop(socket, net_packet_rxp).await;
             }
             .in_current_span(),
         )


### PR DESCRIPTION
Extending the IGMP prototype 
- have instance open kernel multicast socket
- create vif for each interface started on the router
- setup basic task for decoding.

Seeking advice for handling of errors on instance::new() want to gracefully stop the igmp daemon if cant open.

Work to do later down the track:
- decode packet info from kernel and get info
- consider what happens if we cant get packet_info may have to lookup based on addresses on packets and local interfaces.
- implement that state machine tasks for multicast groups