### PR TITLE
bgp: "clear bgp neighbor" fixes

### DIFF
--- a/holo-bgp/src/neighbor.rs
+++ b/holo-bgp/src/neighbor.rs
@@ -615,7 +615,6 @@ impl Neighbor {
         self.clear_routes::<Ipv6Unicast>(rib, &instance_tx.ibus);
         self.tasks = Default::default();
         self.msg_txp = None;
-        self.statistics = Default::default();
 
         // Trigger the BGP Decision Process.
         instance_tx.protocol_input.trigger_decision_process();


### PR DESCRIPTION
- Handle clear bgp neighbor request for a non-existing neighbor to prevent holo-bgp crash due to unwrap() call
