### PR TITLE
northbound: fix panic when querying state of inactive BGP neighbor

### DIFF
--- a/holo-northbound/src/state.rs
+++ b/holo-northbound/src/state.rs
@@ -261,6 +261,10 @@ where
             });
 
         // Find the list entry associated to the provided path.
+        // If a matching entry isn't found (e.g. the neighbor session is
+        // not Established and the RIB iterator filters it out), return
+        // the default entry so callers produce empty output instead of
+        // panicking on a mismatched variant.
         if let Some(entry) = {
             (list_ops.iter)(provider, &list_entry).and_then(|mut list_iter| {
                 list_iter.find(|entry| {
@@ -270,6 +274,8 @@ where
             })
         } {
             list_entry = entry;
+        } else {
+            return Default::default();
         }
     }
 


### PR DESCRIPTION
When a gRPC Get request targets a RIB path under a specific neighbor that is not in Established state, lookup_list_entry() failed to find the neighbor (filtered out by the RIB iterator) but continued with a stale parent ListEntry variant. This caused an unwrap() panic in downstream iter() calls that expected a RibNeighbor variant.

Return the default (None) entry immediately when any ancestor list entry cannot be resolved, so callers produce empty output instead of panicking.