### PR TITLE
holo-interface: fix UNNUMBERED flag — scope to IFF_POINTOPOINT only

### DIFF
--- a/holo-interface/src/interface.rs
+++ b/holo-interface/src/interface.rs
@@ -303,8 +303,15 @@ impl Interfaces {
         };
 
         // Add address to the interface.
+        //
+        // An IPv4 /32 address is flagged UNNUMBERED only on genuine
+        // point-to-point interfaces. On those, both ends share a /32
+        // borrowed from loopback, and a connected route for that /32
+        // would shadow the real route. On non-P2P interfaces (dummy,
+        // ethernet, loopback aliases), a /32 is a local host prefix
+        // that should generate a connected RIB entry.
         let mut flags = AddressFlags::empty();
-        if !iface.flags.contains(InterfaceFlags::LOOPBACK)
+        if iface.flags.contains(InterfaceFlags::POINT_TO_POINT)
             && let IpNetwork::V4(addr) = addr
             && addr.is_host_prefix()
         {

--- a/holo-interface/src/netlink.rs
+++ b/holo-interface/src/netlink.rs
@@ -109,6 +109,9 @@ fn process_newlink_msg(master: &mut Master, msg: LinkMessage) {
     if msg.header.flags.contains(LinkFlags::Broadcast) {
         flags.insert(InterfaceFlags::BROADCAST)
     }
+    if msg.header.flags.contains(LinkFlags::Pointopoint) {
+        flags.insert(InterfaceFlags::POINT_TO_POINT);
+    }
 
     for nla in msg.attributes.into_iter() {
         match nla {

--- a/holo-utils/src/southbound.rs
+++ b/holo-utils/src/southbound.rs
@@ -28,6 +28,12 @@ bitflags! {
         const LOOPBACK = 0x01;
         const OPERATIVE = 0x02;
         const BROADCAST = 0x04;
+        // Set for interfaces with IFF_POINTOPOINT (e.g. GRE, tunnels,
+        // unnumbered serial links). Used to scope the IPv4 UNNUMBERED
+        // address behavior to genuine P2P links, so that /32 addresses
+        // on dummy interfaces (anycast VIPs, loopback aliases) still
+        // generate connected RIB entries.
+        const POINT_TO_POINT = 0x08;
     }
 }
 


### PR DESCRIPTION
An IPv4 /32 address was flagged `AddressFlags::UNNUMBERED` on any non-loopback interface (`!LOOPBACK && is_host_prefix()`), and `Rib::connected_route_add` silently skips UNNUMBERED addresses. This meant that /32 host addresses on dummy interfaces — the standard Linux pattern for anycast VIPs, service addresses, and loopback-equivalent bindings (analogous to Cisco/Juniper loopback interfaces) — never produced a connected RIB entry and were invisible to `redistribute-direct`.

The UNNUMBERED flag exists for genuine unnumbered point-to-point interfaces (serial links, GRE tunnels, PPP) where both ends share a /32 borrowed from another interface and a connected route for that /32 would shadow the real route. That semantic applies only when `IFF_POINTOPOINT` is set in the kernel's netlink flags. Dummy interfaces do not set IFF_POINTOPOINT — they use normal Ethernet link-layer type.

Fix: introduce `InterfaceFlags::POINT_TO_POINT`, populated from `LinkFlags::Pointopoint` in the netlink RTM_NEWLINK handler, and require it (instead of `!LOOPBACK`) in the UNNUMBERED-marking condition in `Interfaces::addr_add`. Behavior matrix:

| Interface type | Before | After |                      
|---|---|---|                                                                                                                           
| lo (/32) | exempt (LOOPBACK flag) | exempt (no POINT_TO_POINT) |                                                                      
| dummy (/32) | UNNUMBERED — **bug** | exempt — **fix** |                                                                               
| ethernet (/32) | UNNUMBERED | exempt |                                                                                                
| GRE/PPP (/32) | UNNUMBERED | UNNUMBERED (has P2P flag) |

Dummy/ethernet /32 addresses now produce connected RIB entries; genuine P2P unnumbered behavior is preserved.