### PR TITLE
bgp: add guardrail for policy check

### DIFF
--- a/holo-bgp/src/policy.rs
+++ b/holo-bgp/src/policy.rs
@@ -181,12 +181,14 @@ fn process_stmt_condition(
         // "match-prefix-set"
         PolicyCondition::MatchPrefixSet(value) => {
             let af = prefix.address_family();
-            let set = match_sets.prefixes.get(&(value.clone(), af)).unwrap();
-            set.prefixes.iter().any(|range| {
-                prefix.ip() == range.prefix.ip()
-                    && prefix.prefix() >= range.masklen_lower
-                    && prefix.prefix() <= range.masklen_upper
-            })
+            match match_sets.prefixes.get(&(value.clone(), af)) {
+                Some(set) => set.prefixes.iter().any(|range| {
+                    prefix.ip() == range.prefix.ip()
+                        && prefix.prefix() >= range.masklen_lower
+                        && prefix.prefix() <= range.masklen_upper
+                }),
+                None => false,
+            }
         }
         // "match-neighbor-set"
         PolicyCondition::MatchNeighborSet(value) => {
@@ -195,13 +197,16 @@ fn process_stmt_condition(
                 return true;
             };
 
-            let set = match_sets.neighbors.get(value).unwrap();
-            set.addrs.contains(remote_addr)
+            match match_sets.neighbors.get(value) {
+                Some(set) => set.addrs.contains(remote_addr),
+                None => false,
+            }
         }
         // "match-tag-set"
         PolicyCondition::MatchTagSet(value) => {
-            if let Some(tag) = &rpinfo.tag {
-                let set = match_sets.tags.get(value).unwrap();
+            if let Some(tag) = &rpinfo.tag
+                && let Some(set) = match_sets.tags.get(value)
+            {
                 set.tags.contains(tag)
             } else {
                 false


### PR DESCRIPTION
Whenever the prefix-set has no prefix-list, a crash is experienced at the codition lookup:

```
thread 'tokio-runtime-worker' (42) panicked at holo-bgp/src/policy.rs:184:69:
called `Option::unwrap()` on a `None` value
stack backtrace:
note: Some details are omitted, run with `RUST_BACKTRACE=full` for a verbose backtrace.
```

Fixed in this PR.