### PR TITLE
Update prefix_trie crate to 0.9.2 version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -81,6 +81,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "array-const-fn-init"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8bcb85e548c05d407fa6faff46b750ba287714ef32afc0f5e15b4641ffd6affb"
+
+[[package]]
 name = "async-trait"
 version = "0.1.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -110,9 +116,9 @@ dependencies = [
 
 [[package]]
 name = "autocfg"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "axum"
@@ -194,10 +200,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "bumpalo"
-version = "3.20.2"
+name = "bs58"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+checksum = "bf88ba1141d185c399bee5288d850d63b8369520c1eafc32a0430b5b6c287bf4"
+dependencies = [
+ "tinyvec",
+]
+
+[[package]]
+name = "bumpalo"
+version = "3.20.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 
 [[package]]
 name = "byteorder"
@@ -233,9 +248,9 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.2.61"
+version = "1.2.62"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d16d90359e986641506914ba71350897565610e87ce0ad9e6f28569db3dd5c6d"
+checksum = "a1dce859f0832a7d088c4f1119888ab94ef4b5d6795d1ce05afb7fe159d79f98"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -399,7 +414,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b5a08d6ff3095fa91560f935dfefd6e942ff7693b3e1f57dca184df23fed128"
 dependencies = [
  "cfg-if",
- "ipnetwork",
+ "ipnetwork 0.20.0",
  "proc-macro-error",
  "proc-macro2",
  "quote",
@@ -640,9 +655,9 @@ checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
 name = "either"
-version = "1.15.0"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
 
 [[package]]
 name = "encoding_rs"
@@ -908,9 +923,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.13"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f44da3a8150a6703ed5d34e164b875fd14c2cdab9af1252a9a1020bde2bdc54"
+checksum = "171fefbc92fe4a4de27e0698d6a5b392d6a0e333506bc49133760b3bcf948733"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -953,9 +968,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.17.0"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 
 [[package]]
 name = "hdrhistogram"
@@ -1016,10 +1031,10 @@ dependencies = [
  "holo-protocol",
  "holo-utils",
  "holo-yang",
- "ipnetwork",
+ "ipnetwork 0.21.1",
  "itertools 0.14.0",
  "libc",
- "nix 0.31.2",
+ "nix 0.31.3",
  "num-derive",
  "num-traits",
  "phf 0.13.1",
@@ -1052,7 +1067,7 @@ dependencies = [
  "holo-protocol",
  "holo-utils",
  "holo-yang",
- "ipnetwork",
+ "ipnetwork 0.21.1",
  "itertools 0.14.0",
  "libc",
  "num-derive",
@@ -1097,7 +1112,7 @@ dependencies = [
  "holo-vrrp",
  "holo-yang",
  "itertools 0.14.0",
- "nix 0.31.2",
+ "nix 0.31.3",
  "pickledb",
  "prost",
  "prost-types",
@@ -1134,10 +1149,10 @@ dependencies = [
  "holo-utils",
  "holo-yang",
  "internet-checksum",
- "ipnetwork",
+ "ipnetwork 0.21.1",
  "itertools 0.14.0",
  "libc",
- "nix 0.31.2",
+ "nix 0.31.3",
  "num-derive",
  "num-traits",
  "phf 0.13.1",
@@ -1166,7 +1181,7 @@ dependencies = [
  "holo-utils",
  "holo-vrrp",
  "holo-yang",
- "ipnetwork",
+ "ipnetwork 0.21.1",
  "libc",
  "netlink-packet-core",
  "netlink-packet-route",
@@ -1199,12 +1214,12 @@ dependencies = [
  "holo-protocol",
  "holo-utils",
  "holo-yang",
- "ipnetwork",
+ "ipnetwork 0.21.1",
  "itertools 0.14.0",
  "libc",
  "maplit",
  "md-5",
- "nix 0.31.2",
+ "nix 0.31.3",
  "num-derive",
  "num-traits",
  "phf 0.13.1",
@@ -1255,7 +1270,7 @@ dependencies = [
  "holo-protocol",
  "holo-utils",
  "holo-yang",
- "ipnetwork",
+ "ipnetwork 0.21.1",
  "libc",
  "maplit",
  "num-derive",
@@ -1311,12 +1326,12 @@ dependencies = [
  "holo-utils",
  "holo-yang",
  "internet-checksum",
- "ipnetwork",
+ "ipnetwork 0.21.1",
  "itertools 0.14.0",
  "libc",
  "maplit",
  "md-5",
- "nix 0.31.2",
+ "nix 0.31.3",
  "num-derive",
  "num-traits",
  "phf 0.13.1",
@@ -1342,7 +1357,7 @@ dependencies = [
  "holo-northbound",
  "holo-utils",
  "holo-yang",
- "ipnetwork",
+ "ipnetwork 0.21.1",
  "phf 0.13.1",
  "tokio",
  "tracing",
@@ -1400,7 +1415,7 @@ dependencies = [
  "holo-rip",
  "holo-utils",
  "holo-yang",
- "ipnetwork",
+ "ipnetwork 0.21.1",
  "itertools 0.14.0",
  "libc",
  "md-5",
@@ -1437,7 +1452,7 @@ dependencies = [
  "holo-rip",
  "holo-utils",
  "holo-yang",
- "ipnetwork",
+ "ipnetwork 0.21.1",
  "libc",
  "netlink-packet-core",
  "netlink-packet-route",
@@ -1496,10 +1511,10 @@ dependencies = [
  "derive-new",
  "enum-as-inner 0.7.0",
  "holo-yang",
- "ipnetwork",
+ "ipnetwork 0.21.1",
  "itertools 0.14.0",
  "libc",
- "nix 0.31.2",
+ "nix 0.31.3",
  "num-derive",
  "num-traits",
  "pickledb",
@@ -1529,9 +1544,9 @@ dependencies = [
  "holo-vrrp",
  "holo-yang",
  "internet-checksum",
- "ipnetwork",
+ "ipnetwork 0.21.1",
  "libc",
- "nix 0.31.2",
+ "nix 0.31.3",
  "phf 0.13.1",
  "rand 0.9.4",
  "serde",
@@ -1548,7 +1563,7 @@ version = "0.5.6"
 dependencies = [
  "base64 0.22.1",
  "chrono",
- "ipnetwork",
+ "ipnetwork 0.21.1",
  "maplit",
  "serde",
  "tracing",
@@ -1557,9 +1572,9 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "1.4.0"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a"
+checksum = "8be7462df143984c4598a256ef469b251d7d7f9e271135073e78fc535414f3d0"
 dependencies = [
  "bytes",
  "itoa",
@@ -1828,9 +1843,9 @@ dependencies = [
 
 [[package]]
 name = "idna_adapter"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
+checksum = "cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714"
 dependencies = [
  "icu_normalizer",
  "icu_properties",
@@ -1854,7 +1869,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.17.0",
+ "hashbrown 0.17.1",
  "serde",
  "serde_core",
 ]
@@ -1891,12 +1906,11 @@ dependencies = [
 ]
 
 [[package]]
-name = "iri-string"
-version = "0.7.12"
+name = "ipnetwork"
+version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25e659a4bb38e810ebc252e53b5814ff908a8c58c2a9ce2fae1bbec24cbf4e20"
+checksum = "cf370abdafd54d13e54a620e8c3e1145f28e46cc9d704bc6d94414559df41763"
 dependencies = [
- "memchr",
  "serde",
 ]
 
@@ -1926,9 +1940,9 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "js-sys"
-version = "0.3.95"
+version = "0.3.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2964e92d1d9dc3364cae4d718d93f227e3abb088e747d92e0395bfdedf1c12ca"
+checksum = "142bc4740e452c1e57ade0cbc129f139c9093e354346f0872ef985f4f5cf5f11"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -1978,9 +1992,9 @@ checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
 name = "log"
-version = "0.4.29"
+version = "0.4.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+checksum = "616ec5685824bcc94416c6d4a7a446eea774a31efd7062c8480ba6fd06d7a6e5"
 
 [[package]]
 name = "maplit"
@@ -2146,9 +2160,9 @@ dependencies = [
 
 [[package]]
 name = "nix"
-version = "0.31.2"
+version = "0.31.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d6d0705320c1e6ba1d912b5e37cf18071b6c2e9b7fa8215a1e8a7651966f5d3"
+checksum = "cf20d2fde8ff38632c426f1165ed7436270b44f199fc55284c38276f9db47c3d"
 dependencies = [
  "bitflags 2.11.1",
  "cfg-if",
@@ -2187,9 +2201,9 @@ dependencies = [
 
 [[package]]
 name = "num-conv"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
+checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
 
 [[package]]
 name = "num-derive"
@@ -2244,15 +2258,14 @@ checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
 name = "openssl"
-version = "0.10.78"
+version = "0.10.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f38c4372413cdaaf3cc79dd92d29d7d9f5ab09b51b10dded508fb90bb70b9222"
+checksum = "a45fa2aa886c42762255da344f0a0d313e254066c46aad76f300c3d3da62d967"
 dependencies = [
  "bitflags 2.11.1",
  "cfg-if",
  "foreign-types",
  "libc",
- "once_cell",
  "openssl-macros",
  "openssl-sys",
 ]
@@ -2276,9 +2289,9 @@ checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.114"
+version = "0.9.116"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13ce1245cd07fcc4cfdb438f7507b0c7e4f3849a69fd84d52374c66d83741bb6"
+checksum = "f28a22dc7140cda5f096e5e7724a6962ca81a7f8bfd2979f9b18c11af56318c4"
 dependencies = [
  "cc",
  "libc",
@@ -2416,18 +2429,18 @@ dependencies = [
 
 [[package]]
 name = "pin-project"
-version = "1.1.11"
+version = "1.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1749c7ed4bcaf4c3d0a3efc28538844fb29bcdd7d2b67b2be7e20ba861ff517"
+checksum = "2466b2336ed02bcdca6b294417127b90ec92038d1d5c4fbeac971a922e0e0924"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "1.1.11"
+version = "1.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b20ed30f105399776b9c883e68e536ef602a16ae6f596d2c473591d6ad64c6"
+checksum = "c96395f0a926bc13b1c17622aaddda1ecb55d49c8f1bf9777e4d877800a43f8b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2500,12 +2513,13 @@ dependencies = [
 
 [[package]]
 name = "prefix-trie"
-version = "0.8.2"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23370be78b7e5bcbb0cab4a02047eb040279a693c78daad04c2c5f1c24a83503"
+checksum = "fbeb97a96d43f215f842f6ab81e8c7b5f6e9b912495c3178127f54f9dce28e32"
 dependencies = [
+ "array-const-fn-init",
  "either",
- "ipnetwork",
+ "ipnetwork 0.21.1",
  "num-traits",
 ]
 
@@ -2607,9 +2621,9 @@ dependencies = [
 
 [[package]]
 name = "pulldown-cmark"
-version = "0.13.3"
+version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c3a14896dfa883796f1cb410461aef38810ea05f2b2c33c5aded3649095fdad"
+checksum = "e9f068eba8e7071c5f9511831b44f32c740d5adf574e990f946ddb53db2f314e"
 dependencies = [
  "bitflags 2.11.1",
  "memchr",
@@ -2852,9 +2866,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.39"
+version = "0.23.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c2c118cb077cca2822033836dfb1b975355dfb784b5e8da48f7b6c5db74e60e"
+checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
 dependencies = [
  "log",
  "once_cell",
@@ -3000,9 +3014,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.149"
+version = "1.0.150"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
+checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
 dependencies = [
  "itoa",
  "memchr",
@@ -3034,11 +3048,12 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "3.18.0"
+version = "3.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd5414fad8e6907dbdd5bc441a50ae8d6e26151a03b1de04d89a5576de61d01f"
+checksum = "e72c1c2cb7b223fafb600a619537a871c2818583d619401b785e7c0b746ccde2"
 dependencies = [
  "base64 0.22.1",
+ "bs58",
  "chrono",
  "hex",
  "indexmap 1.9.3",
@@ -3053,9 +3068,9 @@ dependencies = [
 
 [[package]]
 name = "serde_with_macros"
-version = "3.18.0"
+version = "3.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3db8978e608f1fe7357e211969fd9abdcae80bac1ba7a3369bb7eb6b404eb65"
+checksum = "b90c488738ecb4fb0262f41f43bc40efc5868d9fb744319ddf5f5317f417bfac"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -3124,9 +3139,9 @@ checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
 
 [[package]]
 name = "siphasher"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2aa850e253778c88a04c3d7323b043aeda9d3e30d5971937c1855769763678e"
+checksum = "8ee5873ec9cce0195efcb7a4e9507a04cd49aec9c83d0389df45b1ef7ba2e649"
 
 [[package]]
 name = "slab"
@@ -3406,10 +3421,25 @@ dependencies = [
 ]
 
 [[package]]
-name = "tokio"
-version = "1.52.1"
+name = "tinyvec"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b67dee974fe86fd92cc45b7a95fdd2f99a36a6d7b0d431a231178d3d670bbcc6"
+checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
+name = "tokio"
+version = "1.52.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
 dependencies = [
  "bytes",
  "libc",
@@ -3521,7 +3551,7 @@ version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
 dependencies = [
- "winnow 1.0.2",
+ "winnow 1.0.3",
 ]
 
 [[package]]
@@ -3532,9 +3562,9 @@ checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
 
 [[package]]
 name = "tonic"
-version = "0.14.5"
+version = "0.14.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fec7c61a0695dc1887c1b53952990f3ad2e3a31453e1f49f10e75424943a93ec"
+checksum = "ac2a5518c70fa84342385732db33fb3f44bc4cc748936eb5833d2df34d6445ef"
 dependencies = [
  "async-trait",
  "axum",
@@ -3562,9 +3592,9 @@ dependencies = [
 
 [[package]]
 name = "tonic-build"
-version = "0.14.5"
+version = "0.14.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1882ac3bf5ef12877d7ed57aad87e75154c11931c2ba7e6cde5e22d63522c734"
+checksum = "c68f61875ac5293cf72e6c8cf0158086428c82c37229e98c840878f1706b0322"
 dependencies = [
  "prettyplease",
  "proc-macro2",
@@ -3574,9 +3604,9 @@ dependencies = [
 
 [[package]]
 name = "tonic-prost"
-version = "0.14.5"
+version = "0.14.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a55376a0bbaa4975a3f10d009ad763d8f4108f067c7c2e74f3001fb49778d309"
+checksum = "50849f68853be452acf590cde0b146665b8d507b3b8af17261df47e02c209ea0"
 dependencies = [
  "bytes",
  "prost",
@@ -3585,9 +3615,9 @@ dependencies = [
 
 [[package]]
 name = "tonic-prost-build"
-version = "0.14.5"
+version = "0.14.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3144df636917574672e93d0f56d7edec49f90305749c668df5101751bb8f95a"
+checksum = "654e5643eff75d7f8c99197ce1440ed19a3474eada74c12bbac488b2cafdae27"
 dependencies = [
  "prettyplease",
  "proc-macro2",
@@ -3620,20 +3650,20 @@ dependencies = [
 
 [[package]]
 name = "tower-http"
-version = "0.6.8"
+version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
+checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
 dependencies = [
  "bitflags 2.11.1",
  "bytes",
  "futures-util",
  "http",
  "http-body",
- "iri-string",
  "pin-project-lite",
  "tower",
  "tower-layer",
  "tower-service",
+ "url",
 ]
 
 [[package]]
@@ -3899,9 +3929,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.118"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bf938a0bacb0469e83c1e148908bd7d5a6010354cf4fb73279b7447422e3a89"
+checksum = "3ed04576f974d2b2fba0f38c51dbc5518011e38c36bf1143164be765528fd409"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -3912,9 +3942,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.68"
+version = "0.4.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f371d383f2fb139252e0bfac3b81b265689bf45b6874af544ffa4c975ac1ebf8"
+checksum = "9473dbd2991ae90b6291c3c32c30c6187ac49aa32f9905d1cce280ec1e110b0f"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -3922,9 +3952,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.118"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eeff24f84126c0ec2db7a449f0c2ec963c6a49efe0698c4242929da037ca28ed"
+checksum = "916151b09da36bd82f6615cbf3a419e2f0ba23a03c6160e8e92eb6bd4aa1dec6"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -3932,9 +3962,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.118"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d08065faf983b2b80a79fd87d8254c409281cf7de75fc4b773019824196c904"
+checksum = "299047362ccbfce148b67ab7e73349f77748e00c8296f9542adfad2ad82c5c5e"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -3945,9 +3975,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.118"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fd04d9e306f1907bd13c6361b5c6bfc7b3b3c095ed3f8a9246390f8dbdee129"
+checksum = "9a929b2c61f11ba3e9bc35b50c1f25cb38e0e892c0c231ae2b8cf78d5dad4437"
 dependencies = [
  "unicode-ident",
 ]
@@ -3988,9 +4018,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.95"
+version = "0.3.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f2dfbb17949fa2088e5d39408c48368947b86f7834484e87b73de55bc14d97d"
+checksum = "6d621441cfc37b84979402712047321980c178f299193a3589d05b99e8763436"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -4238,9 +4268,9 @@ checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
 
 [[package]]
 name = "winnow"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ee1708bef14716a11bae175f579062d4554d95be2c6829f518df847b7b3fdd0"
+checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
 
 [[package]]
 name = "wit-bindgen"
@@ -4401,9 +4431,9 @@ dependencies = [
 
 [[package]]
 name = "zerofrom"
-version = "0.1.7"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69faa1f2a1ea75661980b013019ed6687ed0e83d069bc1114e2cc74c6c04c4df"
+checksum = "0ec05a11813ea801ff6d75110ad09cd0824ddba17dfe17128ea0d5f68e6c5272"
 dependencies = [
  "zerofrom-derive",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,7 +53,7 @@ futures = "0.3"
 generational-arena = "0.2"
 hmac = "0.12"
 internet-checksum = "0.2"
-ipnetwork = "0.20"
+ipnetwork = { version = "0.21", features = ["serde"] }
 itertools = "0.14"
 libc = "0.2"
 maplit = "1.0"
@@ -66,7 +66,7 @@ num-derive = "0.4"
 num-traits = "0.2"
 phf = { version = "0.13", features = ["macros"] }
 pickledb = "0.5"
-prefix-trie = { version = "0.8", default-features = false, features = ["ipnetwork"]  }
+prefix-trie = { version = "0.9", default-features = false, features = ["ipnetwork"]  }
 prost = "0.14"
 rand = { version = "0.9", features = ["thread_rng"] }
 regex = { version = "1.12", default-features = false, features = ["std", "perf"] }

--- a/holo-bgp/src/events.rs
+++ b/holo-bgp/src/events.rs
@@ -750,7 +750,7 @@ where
 
     // Remove routing table entries that no longer hold any data.
     for prefix in queued_prefixes {
-        if let prefix_trie::map::Entry::Occupied(mut entry) =
+        if let prefix_trie::map::Entry::Occupied(entry) =
             table.prefixes.entry(prefix)
         {
             let dest = entry.get();

--- a/holo-bgp/src/neighbor.rs
+++ b/holo-bgp/src/neighbor.rs
@@ -922,7 +922,7 @@ impl Neighbor {
                         ineligible_reason: None,
                         reject_reason: None,
                     };
-                    (*prefix, Box::new(route))
+                    (prefix, Box::new(route))
                 })
             })
             .filter(|(_, route)| self.distribute_filter(route))
@@ -966,7 +966,7 @@ impl Neighbor {
 
             // Update neighbor's Tx queue.
             let update_queue = A::update_queue(&mut self.update_queues);
-            update_queue.reach.entry(attrs).or_default().insert(*prefix);
+            update_queue.reach.entry(attrs).or_default().insert(prefix);
         }
     }
 
@@ -983,7 +983,7 @@ impl Neighbor {
                 if let Some(adj_in_route) = adj_rib.in_post() {
                     rib::nexthop_untrack(
                         &mut table.nht,
-                        prefix,
+                        &prefix,
                         adj_in_route,
                         ibus_tx,
                     );
@@ -996,7 +996,7 @@ impl Neighbor {
             }
 
             // Enqueue prefix for the BGP Decision Process.
-            table.queued_prefixes.insert(*prefix);
+            table.queued_prefixes.insert(prefix);
         }
     }
 

--- a/holo-bgp/src/northbound/configuration.rs
+++ b/holo-bgp/src/northbound/configuration.rs
@@ -1695,7 +1695,7 @@ where
         dest.redistribute = None;
 
         // Enqueue prefix for the BGP Decision Process.
-        table.queued_prefixes.insert(*prefix);
+        table.queued_prefixes.insert(prefix);
     }
 
     // Schedule the BGP Decision Process.

--- a/holo-bgp/src/northbound/state.rs
+++ b/holo-bgp/src/northbound/state.rs
@@ -181,7 +181,10 @@ impl<'a> YangContainer<'a, Instance> for bgp::neighbors::neighbor::afi_safis::af
     fn new(instance: &'a Instance, list_entry: &ListEntry<'a>) -> Option<Self> {
         let (nbr, afi_safi) = list_entry.as_neighbor_afi_safi().unwrap();
         let rib = &instance.state.as_ref()?.rib;
-        fn count_stats<K>(prefixes: &PrefixMap<K, Destination>, addr: &IpAddr) -> (u32, u32, u32) {
+        fn count_stats<K>(prefixes: &PrefixMap<K, Destination>, addr: &IpAddr) -> (u32, u32, u32)
+        where
+            K: prefix_trie::Prefix,
+        {
             prefixes
                 .values()
                 .filter_map(|dest| dest.adj_rib.get(addr))
@@ -560,7 +563,7 @@ impl<'a> YangList<'a, Instance> for bgp::rib::afi_safis::afi_safi::ipv4_unicast:
         }
         let rib = &instance.state.as_ref()?.rib;
         let iter = rib.tables.ipv4_unicast.prefixes.iter();
-        let iter = iter.filter_map(|(prefix, dest)| dest.local.as_ref().map(|route| ListEntry::RibV4LocRoute(*prefix, route)));
+        let iter = iter.filter_map(|(prefix, dest)| dest.local.as_ref().map(|route| ListEntry::RibV4LocRoute(prefix, route)));
         Some(Box::new(iter))
     }
 
@@ -627,7 +630,7 @@ impl<'a> YangList<'a, Instance> for bgp::rib::afi_safis::afi_safi::ipv4_unicast:
         let nbr = list_entry.as_rib_neighbor().unwrap();
         let rib = &instance.state.as_ref()?.rib;
         let iter = rib.tables.ipv4_unicast.prefixes.iter();
-        let iter = iter.filter_map(|(prefix, dest)| dest.adj_rib.get(&nbr.remote_addr).and_then(|adj_rib| adj_rib.in_pre()).map(|route| ListEntry::RibV4Route(*prefix, route)));
+        let iter = iter.filter_map(|(prefix, dest)| dest.adj_rib.get(&nbr.remote_addr).and_then(|adj_rib| adj_rib.in_pre()).map(|route| ListEntry::RibV4Route(prefix, route)));
         Some(Box::new(iter))
     }
 
@@ -675,7 +678,7 @@ impl<'a> YangList<'a, Instance> for bgp::rib::afi_safis::afi_safi::ipv4_unicast:
         let nbr = list_entry.as_rib_neighbor().unwrap();
         let rib = &instance.state.as_ref()?.rib;
         let iter = rib.tables.ipv4_unicast.prefixes.iter();
-        let iter = iter.filter_map(|(prefix, dest)| dest.adj_rib.get(&nbr.remote_addr).and_then(|adj_rib| adj_rib.in_post()).map(|route| ListEntry::RibV4Route(*prefix, route)));
+        let iter = iter.filter_map(|(prefix, dest)| dest.adj_rib.get(&nbr.remote_addr).and_then(|adj_rib| adj_rib.in_post()).map(|route| ListEntry::RibV4Route(prefix, route)));
         Some(Box::new(iter))
     }
 
@@ -724,7 +727,7 @@ impl<'a> YangList<'a, Instance> for bgp::rib::afi_safis::afi_safi::ipv4_unicast:
         let nbr = list_entry.as_rib_neighbor().unwrap();
         let rib = &instance.state.as_ref()?.rib;
         let iter = rib.tables.ipv4_unicast.prefixes.iter();
-        let iter = iter.filter_map(|(prefix, dest)| dest.adj_rib.get(&nbr.remote_addr).and_then(|adj_rib| adj_rib.out_pre()).map(|route| ListEntry::RibV4Route(*prefix, route)));
+        let iter = iter.filter_map(|(prefix, dest)| dest.adj_rib.get(&nbr.remote_addr).and_then(|adj_rib| adj_rib.out_pre()).map(|route| ListEntry::RibV4Route(prefix, route)));
         Some(Box::new(iter))
     }
 
@@ -772,7 +775,7 @@ impl<'a> YangList<'a, Instance> for bgp::rib::afi_safis::afi_safi::ipv4_unicast:
         let nbr = list_entry.as_rib_neighbor().unwrap();
         let rib = &instance.state.as_ref()?.rib;
         let iter = rib.tables.ipv4_unicast.prefixes.iter();
-        let iter = iter.filter_map(|(prefix, dest)| dest.adj_rib.get(&nbr.remote_addr).and_then(|adj_rib| adj_rib.out_post()).map(|route| ListEntry::RibV4Route(*prefix, route)));
+        let iter = iter.filter_map(|(prefix, dest)| dest.adj_rib.get(&nbr.remote_addr).and_then(|adj_rib| adj_rib.out_post()).map(|route| ListEntry::RibV4Route(prefix, route)));
         Some(Box::new(iter))
     }
 
@@ -823,7 +826,7 @@ impl<'a> YangList<'a, Instance> for bgp::rib::afi_safis::afi_safi::ipv6_unicast:
         }
         let rib = &instance.state.as_ref()?.rib;
         let iter = rib.tables.ipv6_unicast.prefixes.iter();
-        let iter = iter.filter_map(|(prefix, dest)| dest.local.as_ref().map(|route| ListEntry::RibV6LocRoute(*prefix, route)));
+        let iter = iter.filter_map(|(prefix, dest)| dest.local.as_ref().map(|route| ListEntry::RibV6LocRoute(prefix, route)));
         Some(Box::new(iter))
     }
 
@@ -890,7 +893,7 @@ impl<'a> YangList<'a, Instance> for bgp::rib::afi_safis::afi_safi::ipv6_unicast:
         let nbr = list_entry.as_rib_neighbor().unwrap();
         let rib = &instance.state.as_ref()?.rib;
         let iter = rib.tables.ipv6_unicast.prefixes.iter();
-        let iter = iter.filter_map(|(prefix, dest)| dest.adj_rib.get(&nbr.remote_addr).and_then(|adj_rib| adj_rib.in_pre()).map(|route| ListEntry::RibV6Route(*prefix, route)));
+        let iter = iter.filter_map(|(prefix, dest)| dest.adj_rib.get(&nbr.remote_addr).and_then(|adj_rib| adj_rib.in_pre()).map(|route| ListEntry::RibV6Route(prefix, route)));
         Some(Box::new(iter))
     }
 
@@ -938,7 +941,7 @@ impl<'a> YangList<'a, Instance> for bgp::rib::afi_safis::afi_safi::ipv6_unicast:
         let nbr = list_entry.as_rib_neighbor().unwrap();
         let rib = &instance.state.as_ref()?.rib;
         let iter = rib.tables.ipv6_unicast.prefixes.iter();
-        let iter = iter.filter_map(|(prefix, dest)| dest.adj_rib.get(&nbr.remote_addr).and_then(|adj_rib| adj_rib.in_post()).map(|route| ListEntry::RibV6Route(*prefix, route)));
+        let iter = iter.filter_map(|(prefix, dest)| dest.adj_rib.get(&nbr.remote_addr).and_then(|adj_rib| adj_rib.in_post()).map(|route| ListEntry::RibV6Route(prefix, route)));
         Some(Box::new(iter))
     }
 
@@ -987,7 +990,7 @@ impl<'a> YangList<'a, Instance> for bgp::rib::afi_safis::afi_safi::ipv6_unicast:
         let nbr = list_entry.as_rib_neighbor().unwrap();
         let rib = &instance.state.as_ref()?.rib;
         let iter = rib.tables.ipv6_unicast.prefixes.iter();
-        let iter = iter.filter_map(|(prefix, dest)| dest.adj_rib.get(&nbr.remote_addr).and_then(|adj_rib| adj_rib.out_pre()).map(|route| ListEntry::RibV6Route(*prefix, route)));
+        let iter = iter.filter_map(|(prefix, dest)| dest.adj_rib.get(&nbr.remote_addr).and_then(|adj_rib| adj_rib.out_pre()).map(|route| ListEntry::RibV6Route(prefix, route)));
         Some(Box::new(iter))
     }
 
@@ -1035,7 +1038,7 @@ impl<'a> YangList<'a, Instance> for bgp::rib::afi_safis::afi_safi::ipv6_unicast:
         let nbr = list_entry.as_rib_neighbor().unwrap();
         let rib = &instance.state.as_ref()?.rib;
         let iter = rib.tables.ipv6_unicast.prefixes.iter();
-        let iter = iter.filter_map(|(prefix, dest)| dest.adj_rib.get(&nbr.remote_addr).and_then(|adj_rib| adj_rib.out_post()).map(|route| ListEntry::RibV6Route(*prefix, route)));
+        let iter = iter.filter_map(|(prefix, dest)| dest.adj_rib.get(&nbr.remote_addr).and_then(|adj_rib| adj_rib.out_post()).map(|route| ListEntry::RibV6Route(prefix, route)));
         Some(Box::new(iter))
     }
 

--- a/holo-isis/src/interface.rs
+++ b/holo-isis/src/interface.rs
@@ -12,14 +12,12 @@ use std::sync::Arc;
 use std::sync::atomic::{self, AtomicU32};
 
 use chrono::{DateTime, Utc};
-use holo_utils::ip::{AddressFamily, JointPrefixSetExt};
+use holo_utils::ip::{AddrList, AddressFamily};
 use holo_utils::mac_addr::MacAddr;
 use holo_utils::socket::{AsyncFd, Socket, SocketExt};
 use holo_utils::southbound::InterfaceFlags;
 use holo_utils::sr::MsdType;
 use holo_utils::task::{IntervalTask, Task, TimeoutTask};
-use ipnetwork::IpNetwork;
-use prefix_trie::joint::set::JointPrefixSet;
 use tokio::sync::mpsc;
 use tokio::sync::mpsc::UnboundedSender;
 
@@ -58,7 +56,7 @@ pub struct InterfaceSys {
     pub mtu: Option<u32>,
     pub msd: BTreeMap<MsdType, u8>,
     pub mac_addr: Option<MacAddr>,
-    pub addr_list: JointPrefixSet<IpNetwork>,
+    pub addr_list: AddrList,
 }
 
 #[derive(Debug, Default)]

--- a/holo-isis/src/lsdb.rs
+++ b/holo-isis/src/lsdb.rs
@@ -20,7 +20,6 @@ use holo_utils::bier::{
 };
 use holo_utils::ip::{
     AddressFamily, Ipv4NetworkExt, Ipv6NetworkExt, JointPrefixMapExt,
-    JointPrefixSetExt,
 };
 use holo_utils::mpls::Label;
 use holo_utils::sr::{IgpAlgoType, Sid, SidLastHopBehavior, SrCfgPrefixSid};

--- a/holo-routing/src/ibus.rs
+++ b/holo-routing/src/ibus.rs
@@ -174,12 +174,12 @@ pub(crate) fn process_msg(master: &mut Master, msg: IbusMsg) {
                 };
             if af.is_none() || af == Some(AddressFamily::Ipv4) {
                 for (prefix, routes) in master.rib.ip.ipv4().iter() {
-                    redistribute_prefix((*prefix).into(), routes);
+                    redistribute_prefix(prefix.into(), routes);
                 }
             }
             if af.is_none() || af == Some(AddressFamily::Ipv6) {
                 for (prefix, routes) in master.rib.ip.ipv6().iter() {
-                    redistribute_prefix((*prefix).into(), routes);
+                    redistribute_prefix(prefix.into(), routes);
                 }
             }
         }

--- a/holo-routing/src/northbound/state.rs
+++ b/holo-routing/src/northbound/state.rs
@@ -135,8 +135,8 @@ impl<'a> YangList<'a, Master> for routing::ribs::rib::routes::route::Route<'a> {
         match af {
             RibAddressFamily::Ipv4 => {
                 let iter = master.rib.ip.ipv4().iter().flat_map(|(dest, routes)| {
-                    routes.values().filter(|route| !route.flags.contains(RouteFlags::REMOVED)).map(|route| {
-                        let dest = RouteDestination::new_ipv4(*dest);
+                    routes.values().filter(|route| !route.flags.contains(RouteFlags::REMOVED)).map(move |route| {
+                        let dest = RouteDestination::new_ipv4(dest);
                         ListEntry::Route(dest, route)
                     })
                 });
@@ -144,8 +144,8 @@ impl<'a> YangList<'a, Master> for routing::ribs::rib::routes::route::Route<'a> {
             }
             RibAddressFamily::Ipv6 => {
                 let iter = master.rib.ip.ipv6().iter().flat_map(|(dest, routes)| {
-                    routes.values().filter(|route| !route.flags.contains(RouteFlags::REMOVED)).map(|route| {
-                        let dest = RouteDestination::new_ipv6(*dest);
+                    routes.values().filter(|route| !route.flags.contains(RouteFlags::REMOVED)).map(move |route| {
+                        let dest = RouteDestination::new_ipv6(dest);
                         ListEntry::Route(dest, route)
                     })
                 });

--- a/holo-utils/src/ip.rs
+++ b/holo-utils/src/ip.rs
@@ -5,6 +5,7 @@
 //
 
 use std::borrow::Cow;
+use std::collections::BTreeSet;
 use std::net::{
     IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr, SocketAddrV4, SocketAddrV6,
 };
@@ -231,6 +232,12 @@ pub trait JointPrefixSetExt {
 
     // Returns a mutable reference to the IPv6 prefix set.
     fn ipv6_mut(&mut self) -> &mut PrefixSet<Ipv6Network>;
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct AddrList {
+    v4: BTreeSet<Ipv4Network>,
+    v6: BTreeSet<Ipv6Network>,
 }
 
 // ===== impl AddressFamily =====
@@ -560,7 +567,7 @@ impl IpNetworkKind<Ipv4Addr> for Ipv4Network {
     }
 
     fn contains(&self, ip: Ipv4Addr) -> bool {
-        Ipv4Network::contains(*self, ip)
+        Ipv4Network::contains(self, ip)
     }
 
     fn is_supernet_of(self, other: Self) -> bool {
@@ -572,7 +579,7 @@ impl IpNetworkKind<Ipv4Addr> for Ipv4Network {
     }
 
     fn mask(&self) -> Ipv4Addr {
-        Ipv4Network::mask(*self)
+        Ipv4Network::mask(self)
     }
 
     fn apply_mask(&self) -> Self {
@@ -732,5 +739,30 @@ impl JointPrefixSetExt for JointPrefixSet<IpNetwork> {
 
     fn ipv6_mut(&mut self) -> &mut PrefixSet<Ipv6Network> {
         &mut self.t2
+    }
+}
+
+// ===== impl AddrList =====
+
+impl AddrList {
+    pub fn insert(&mut self, addr: IpNetwork) -> bool {
+        match addr {
+            IpNetwork::V4(n) => self.v4.insert(n),
+            IpNetwork::V6(n) => self.v6.insert(n),
+        }
+    }
+
+    pub fn remove(&mut self, addr: &IpNetwork) -> bool {
+        match addr {
+            IpNetwork::V4(n) => self.v4.remove(n),
+            IpNetwork::V6(n) => self.v6.remove(n),
+        }
+    }
+
+    pub fn ipv4(&self) -> &BTreeSet<Ipv4Network> {
+        &self.v4
+    }
+    pub fn ipv6(&self) -> &BTreeSet<Ipv6Network> {
+        &self.v6
     }
 }


### PR DESCRIPTION
Update the prefix_trie crate to version 0.9.2 (significant performance improvements and added support for the iter_from() iterator).

iter_from() - Return an iterator starting at the given prefix in lexicographic order, which could be used to implement "cursor" gRPC Get request.

Significant changes in the crate:

 Prefixes are reconstructed from the tree location and no longer stored. Consequently, information in the host part of an address is no longer maintained.
 Additionally, the function yields prefixes by value instead of by reference.

 Appropriate changes in the code were applied.

 In holo-isis, the addr_list type was replaced from JointPrefixSet<IpNetwork> to a custom implementation using BTreeSet due to the inability to store host bits.