### PR TITLE
bgp: handle dynamic enable configuration for BGP neighbors

### DIFF
--- a/holo-bgp/src/northbound/configuration.rs
+++ b/holo-bgp/src/northbound/configuration.rs
@@ -808,6 +808,9 @@ fn load_callbacks() -> Callbacks<Instance> {
 
             let enabled = args.dnode.get_bool();
             nbr.config.enabled = enabled;
+
+            let event_queue = args.event_queue;
+            event_queue.insert(Event::NeighborUpdate(nbr_addr));
         })
         .path(bgp::neighbors::neighbor::peer_as::PATH)
         .modify_apply(|instance, args| {


### PR DESCRIPTION
Trigger NeighborUpdate event on bgp neighbour enable configuration changes to allow possibility dynamically shutdown/unshutdown bgp neighbours.