### PR TITLE
staticd: install static routes that specify only a next-hop-address

### DIFF
--- a/holo-routing/src/northbound/configuration.rs
+++ b/holo-routing/src/northbound/configuration.rs
@@ -1306,8 +1306,17 @@ fn instance_start(master: &mut Master, protocol: Protocol, name: String) {
 }
 
 fn static_nexthop_get(interfaces: &Interfaces, nexthop: &StaticRouteNexthop) -> Option<Nexthop> {
-    let ifname = nexthop.ifname.as_ref()?;
-    let iface = interfaces.get_by_name(ifname)?;
+    let iface = match &nexthop.ifname {
+        Some(ifname) => interfaces.get_by_name(ifname)?,
+        // No outgoing interface configured: resolve the nexthop address
+        // against the connected prefixes.
+        None => {
+            let addr = nexthop.addr?;
+            interfaces.iter().find(|iface| {
+                iface.addresses.keys().any(|prefix| prefix.contains(addr))
+            })?
+        }
+    };
     let ifindex = iface.ifindex;
     let nexthop = match nexthop.addr {
         Some(addr) => Nexthop::Address {

--- a/holo-routing/src/northbound/configuration.rs
+++ b/holo-routing/src/northbound/configuration.rs
@@ -1312,9 +1312,7 @@ fn static_nexthop_get(interfaces: &Interfaces, nexthop: &StaticRouteNexthop) -> 
         // against the connected prefixes.
         None => {
             let addr = nexthop.addr?;
-            interfaces.iter().find(|iface| {
-                iface.addresses.keys().any(|prefix| prefix.contains(addr))
-            })?
+            interfaces.iter().find(|iface| iface.addresses.keys().any(|prefix| prefix.contains(addr)))?
         }
     };
     let ifindex = iface.ifindex;


### PR DESCRIPTION
A static route configured with only a `next-hop-address` (no outgoing interface) was silently not installed, because next-hop resolution required an interface name. This resolves such next-hops against connected routes so the route installs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
