### PR TITLE
northbound: reject unknown input data nodes instead of silently ignoring them

### DIFF
--- a/holo-daemon/src/northbound/client/grpc.rs
+++ b/holo-daemon/src/northbound/client/grpc.rs
@@ -617,7 +617,7 @@ fn data_tree_get(
     let encoding = proto::Encoding::try_from(data_tree.encoding)
         .map_err(|_| Status::invalid_argument("Invalid data encoding"))?;
     let data_format = DataFormat::from(encoding);
-    let parser_flags = DataParserFlags::empty();
+    let parser_flags = DataParserFlags::STRICT;
     let validation_flags = DataValidationFlags::NO_STATE;
     let data = data_tree
         .data
@@ -649,7 +649,7 @@ fn data_diff_get(
     let encoding = proto::Encoding::try_from(data_tree.encoding)
         .map_err(|_| Status::invalid_argument("Invalid data encoding"))?;
     let data_format = DataFormat::from(encoding);
-    let parser_flags = DataParserFlags::NO_VALIDATION;
+    let parser_flags = DataParserFlags::NO_VALIDATION | DataParserFlags::STRICT;
     let validation_flags =
         DataValidationFlags::NO_STATE | DataValidationFlags::PRESENT;
     let data = data_tree
@@ -689,14 +689,14 @@ fn rpc_get(data_tree: &proto::DataTree) -> Result<DataTree<'static>, Status> {
             yang_ctx,
             data,
             data_format,
-            DataParserFlags::empty(),
+            DataParserFlags::STRICT,
             DataOperation::RpcYang,
         ),
         proto::data_tree::Data::DataBytes(data) => DataTree::parse_op_string(
             yang_ctx,
             data,
             data_format,
-            DataParserFlags::empty(),
+            DataParserFlags::STRICT,
             DataOperation::RpcYang,
         ),
     }


### PR DESCRIPTION
Input data parsing did not use libyang STRICT mode, so unknown or unprefixed JSON nodes in an edit were silently dropped rather than rejected. This enables STRICT parsing so callers get an explicit error instead of a silently-partial commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
