### PR TITLE
bgp: give AddressFamily an associated Prefix key type

### DIFF
--- a/holo-bgp/src/af.rs
+++ b/holo-bgp/src/af.rs
@@ -8,7 +8,7 @@ use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 
 use holo_utils::bgp::AfiSafi;
 use holo_utils::ip::{IpAddrKind, IpNetworkKind, Ipv4AddrExt, Ipv6AddrExt};
-use ipnetwork::{Ipv4Network, Ipv6Network};
+use ipnetwork::{IpNetwork, Ipv4Network, Ipv6Network};
 use itertools::Itertools;
 
 use crate::neighbor::{
@@ -34,6 +34,8 @@ pub trait AddressFamily: Sized {
     type IpAddr: IpAddrKind;
     // The type of IP network used by this address family.
     type IpNetwork: IpNetworkKind<Self::IpAddr> + prefix_trie::Prefix;
+    // The NLRI key used by the BGP RIB for this address family.
+    type Prefix: Copy + Ord;
 
     // Get the routing table for this address family from the provided
     // `RoutingTables`.
@@ -50,6 +52,12 @@ pub trait AddressFamily: Sized {
 
     // Modify the next hop(s) for transmission.
     fn nexthop_tx_change(nbr: &Neighbor, local: bool, attrs: &mut BaseAttrs);
+
+    // Convert between generic IP prefixes used by policy/RIB APIs and the
+    // per-address-family NLRI key.
+    fn prefix_from_ip_network(prefix: IpNetwork) -> Option<Self::Prefix>;
+
+    fn prefix_to_ip_network(prefix: Self::Prefix) -> IpNetwork;
 
     // Build BGP UPDATE messages based on the provided update queue.
     fn build_updates(queue: &mut NeighborUpdateQueue<Self>) -> Vec<Message>;
@@ -70,6 +78,7 @@ impl AddressFamily for Ipv4Unicast {
 
     type IpAddr = Ipv4Addr;
     type IpNetwork = Ipv4Network;
+    type Prefix = Ipv4Network;
 
     fn table(tables: &mut RoutingTables) -> &mut RoutingTable<Self> {
         &mut tables.ipv4_unicast
@@ -120,6 +129,14 @@ impl AddressFamily for Ipv4Unicast {
                 }
             }
         }
+    }
+
+    fn prefix_from_ip_network(prefix: IpNetwork) -> Option<Self::Prefix> {
+        Ipv4Network::get(prefix)
+    }
+
+    fn prefix_to_ip_network(prefix: Self::Prefix) -> IpNetwork {
+        prefix.into()
     }
 
     fn build_updates(queue: &mut NeighborUpdateQueue<Self>) -> Vec<Message> {
@@ -191,6 +208,7 @@ impl AddressFamily for Ipv6Unicast {
 
     type IpAddr = Ipv6Addr;
     type IpNetwork = Ipv6Network;
+    type Prefix = Ipv6Network;
 
     fn table(tables: &mut RoutingTables) -> &mut RoutingTable<Self> {
         &mut tables.ipv6_unicast
@@ -253,6 +271,14 @@ impl AddressFamily for Ipv6Unicast {
                 }
             }
         }
+    }
+
+    fn prefix_from_ip_network(prefix: IpNetwork) -> Option<Self::Prefix> {
+        Ipv6Network::get(prefix)
+    }
+
+    fn prefix_to_ip_network(prefix: Self::Prefix) -> IpNetwork {
+        prefix.into()
     }
 
     fn build_updates(queue: &mut NeighborUpdateQueue<Self>) -> Vec<Message> {

--- a/holo-bgp/src/events.rs
+++ b/holo-bgp/src/events.rs
@@ -10,7 +10,7 @@ use chrono::Utc;
 use holo_protocol::InstanceShared;
 use holo_utils::bgp::RouteType;
 use holo_utils::ibus::IbusChannelsTx;
-use holo_utils::ip::{IpAddrKind, IpNetworkKind};
+use holo_utils::ip::IpAddrKind;
 use holo_utils::policy::{PolicyResult, PolicyType};
 use holo_utils::socket::{TcpConnInfo, TcpStream};
 use ipnetwork::IpNetwork;
@@ -272,7 +272,7 @@ fn process_nbr_update(
 fn process_nbr_reach_prefixes<A>(
     nbr: &Neighbor,
     rib: &mut Rib,
-    nlri_prefixes: Vec<A::IpNetwork>,
+    nlri_prefixes: Vec<A::Prefix>,
     mut attrs: Attrs,
     local_asn: u32,
     shared: &InstanceShared,
@@ -327,7 +327,7 @@ fn process_nbr_reach_prefixes<A>(
         afi_safi: A::AFI_SAFI,
         routes: nlri_prefixes
             .into_iter()
-            .map(|prefix| (prefix.into(), rpinfo.clone()))
+            .map(|prefix| (A::prefix_to_ip_network(prefix), rpinfo.clone()))
             .collect(),
         policies: apply_policy_cfg
             .import_policy
@@ -343,7 +343,7 @@ fn process_nbr_reach_prefixes<A>(
 fn process_nbr_unreach_prefixes<A>(
     nbr: &Neighbor,
     rib: &mut Rib,
-    nlri_prefixes: Vec<A::IpNetwork>,
+    nlri_prefixes: Vec<A::Prefix>,
     ibus_tx: &IbusChannelsTx,
 ) where
     A: AddressFamily,
@@ -461,7 +461,7 @@ where
     let table = A::table(&mut rib.tables);
     for (prefix, result) in prefixes {
         // Get RIB destination.
-        let prefix = A::IpNetwork::get(prefix).unwrap();
+        let prefix = A::prefix_from_ip_network(prefix).unwrap();
         let dest = table.prefixes.entry(prefix).or_default();
         let adj_rib = dest.adj_rib.entry(nbr.remote_addr).or_default();
 
@@ -538,7 +538,7 @@ where
     let table = A::table(&mut rib.tables);
     for (prefix, result) in prefixes {
         // Get RIB destination.
-        let prefix = A::IpNetwork::get(prefix).unwrap();
+        let prefix = A::prefix_from_ip_network(prefix).unwrap();
         let dest = table.prefixes.entry(prefix).or_default();
         let adj_rib = dest.adj_rib.entry(nbr.remote_addr).or_default();
 
@@ -607,7 +607,7 @@ where
 {
     let rib = &mut instance.state.rib;
     let table = A::table(&mut rib.tables);
-    let prefix = A::IpNetwork::get(prefix).unwrap();
+    let prefix = A::prefix_from_ip_network(prefix).unwrap();
 
     match result {
         PolicyResult::Accept(rpinfo) => {
@@ -750,7 +750,7 @@ where
 
     // Remove routing table entries that no longer hold any data.
     for prefix in queued_prefixes {
-        if let prefix_trie::map::Entry::Occupied(entry) =
+        if let std::collections::btree_map::Entry::Occupied(entry) =
             table.prefixes.entry(prefix)
         {
             let dest = entry.get();
@@ -773,7 +773,7 @@ where
 fn withdraw_routes<A>(
     nbr: &mut Neighbor,
     table: &mut RoutingTable<A>,
-    routes: &[A::IpNetwork],
+    routes: &[A::Prefix],
     attr_sets: &mut AttrSetsCxt,
 ) where
     A: AddressFamily,
@@ -802,7 +802,7 @@ fn withdraw_routes<A>(
 pub(crate) fn advertise_routes<A>(
     nbr: &mut Neighbor,
     table: &mut RoutingTable<A>,
-    routes: Vec<(A::IpNetwork, Box<Route>)>,
+    routes: Vec<(A::Prefix, Box<Route>)>,
     shared: &InstanceShared,
     attr_sets: &mut AttrSetsCxt,
     policy_apply_tasks: &PolicyApplyTasks,
@@ -827,7 +827,9 @@ pub(crate) fn advertise_routes<A>(
     // Enqueue export policy application.
     let routes = routes
         .into_iter()
-        .map(|(prefix, route)| (prefix.into(), route.policy_info()))
+        .map(|(prefix, route)| {
+            (A::prefix_to_ip_network(prefix), route.policy_info())
+        })
         .collect::<Vec<_>>();
     if !routes.is_empty() {
         let msg = PolicyApplyMsg::Neighbor {

--- a/holo-bgp/src/ibus/rx.rs
+++ b/holo-bgp/src/ibus/rx.rs
@@ -170,6 +170,7 @@ fn process_route_del_af<A>(
     // Get prefix RIB entry.
     let rib = &mut instance.state.rib;
     let table = A::table(&mut rib.tables);
+    let prefix = A::prefix_from_ip_network(prefix.into()).unwrap();
     let dest = table.prefixes.entry(prefix).or_default();
 
     // Remove redistributed route.

--- a/holo-bgp/src/neighbor.rs
+++ b/holo-bgp/src/neighbor.rs
@@ -118,8 +118,8 @@ pub struct NeighborUpdateQueues {
 // Neighbor Tx update queue.
 #[derive(Debug)]
 pub struct NeighborUpdateQueue<A: AddressFamily> {
-    pub reach: BTreeMap<Attrs, BTreeSet<A::IpNetwork>>,
-    pub unreach: BTreeSet<A::IpNetwork>,
+    pub reach: BTreeMap<Attrs, BTreeSet<A::Prefix>>,
+    pub unreach: BTreeSet<A::Prefix>,
 }
 
 // Type aliases.
@@ -922,7 +922,7 @@ impl Neighbor {
                         ineligible_reason: None,
                         reject_reason: None,
                     };
-                    (prefix, Box::new(route))
+                    (*prefix, Box::new(route))
                 })
             })
             .filter(|(_, route)| self.distribute_filter(route))
@@ -966,7 +966,7 @@ impl Neighbor {
 
             // Update neighbor's Tx queue.
             let update_queue = A::update_queue(&mut self.update_queues);
-            update_queue.reach.entry(attrs).or_default().insert(prefix);
+            update_queue.reach.entry(attrs).or_default().insert(*prefix);
         }
     }
 
@@ -983,7 +983,7 @@ impl Neighbor {
                 if let Some(adj_in_route) = adj_rib.in_post() {
                     rib::nexthop_untrack(
                         &mut table.nht,
-                        &prefix,
+                        prefix,
                         adj_in_route,
                         ibus_tx,
                     );
@@ -996,7 +996,7 @@ impl Neighbor {
             }
 
             // Enqueue prefix for the BGP Decision Process.
-            table.queued_prefixes.insert(prefix);
+            table.queued_prefixes.insert(*prefix);
         }
     }
 

--- a/holo-bgp/src/northbound/configuration.rs
+++ b/holo-bgp/src/northbound/configuration.rs
@@ -1695,7 +1695,7 @@ where
         dest.redistribute = None;
 
         // Enqueue prefix for the BGP Decision Process.
-        table.queued_prefixes.insert(prefix);
+        table.queued_prefixes.insert(*prefix);
     }
 
     // Schedule the BGP Decision Process.

--- a/holo-bgp/src/northbound/state.rs
+++ b/holo-bgp/src/northbound/state.rs
@@ -4,6 +4,7 @@
 // SPDX-License-Identifier: MIT
 //
 
+use std::collections::BTreeMap;
 use std::net::IpAddr;
 use std::sync::{Arc, atomic};
 
@@ -14,7 +15,6 @@ use holo_utils::protocol::Protocol;
 use holo_yang::ToYang;
 use holo_yang::types::{Base64Str, Timeticks};
 use ipnetwork::{Ipv4Network, Ipv6Network};
-use prefix_trie::PrefixMap;
 
 use crate::instance::Instance;
 use crate::neighbor::{Neighbor, fsm};
@@ -160,9 +160,9 @@ impl<'a> YangContainer<'a, Instance> for bgp::neighbors::neighbor::afi_safis::af
 
     fn new(instance: &'a Instance, (nbr, afi_safi): &Self::ParentListEntry) -> Option<Self> {
         let rib = &instance.state.as_ref()?.rib;
-        fn count_stats<K>(prefixes: &PrefixMap<K, Destination>, addr: &IpAddr) -> (u32, u32, u32)
+        fn count_stats<K>(prefixes: &BTreeMap<K, Destination>, addr: &IpAddr) -> (u32, u32, u32)
         where
-            K: prefix_trie::Prefix,
+            K: Ord,
         {
             prefixes
                 .values()
@@ -574,7 +574,7 @@ impl<'a> YangList<'a, Instance> for bgp::rib::afi_safis::afi_safi::ipv4_unicast:
         }
         let rib = &instance.state.as_ref()?.rib;
         let iter = rib.tables.ipv4_unicast.prefixes.iter();
-        let iter = iter.filter_map(|(prefix, dest)| dest.local.as_ref().map(|route| (prefix, route)));
+        let iter = iter.filter_map(|(prefix, dest)| dest.local.as_ref().map(|route| (*prefix, route)));
         Some(iter)
     }
 
@@ -644,7 +644,7 @@ impl<'a> YangList<'a, Instance> for bgp::rib::afi_safis::afi_safi::ipv4_unicast:
     fn iter(instance: &'a Instance, &nbr: &Self::ParentListEntry) -> Option<impl ListIterator<'a, Self::ListEntry>> {
         let rib = &instance.state.as_ref()?.rib;
         let iter = rib.tables.ipv4_unicast.prefixes.iter();
-        let iter = iter.filter_map(move |(prefix, dest)| dest.adj_rib.get(&nbr.remote_addr).and_then(|adj_rib| adj_rib.in_pre()).map(|route| (prefix, route)));
+        let iter = iter.filter_map(move |(prefix, dest)| dest.adj_rib.get(&nbr.remote_addr).and_then(|adj_rib| adj_rib.in_pre()).map(|route| (*prefix, route)));
         Some(iter)
     }
 
@@ -694,7 +694,7 @@ impl<'a> YangList<'a, Instance> for bgp::rib::afi_safis::afi_safi::ipv4_unicast:
     fn iter(instance: &'a Instance, &nbr: &Self::ParentListEntry) -> Option<impl ListIterator<'a, Self::ListEntry>> {
         let rib = &instance.state.as_ref()?.rib;
         let iter = rib.tables.ipv4_unicast.prefixes.iter();
-        let iter = iter.filter_map(move |(prefix, dest)| dest.adj_rib.get(&nbr.remote_addr).and_then(|adj_rib| adj_rib.in_post()).map(|route| (prefix, route)));
+        let iter = iter.filter_map(move |(prefix, dest)| dest.adj_rib.get(&nbr.remote_addr).and_then(|adj_rib| adj_rib.in_post()).map(|route| (*prefix, route)));
         Some(iter)
     }
 
@@ -745,7 +745,7 @@ impl<'a> YangList<'a, Instance> for bgp::rib::afi_safis::afi_safi::ipv4_unicast:
     fn iter(instance: &'a Instance, &nbr: &Self::ParentListEntry) -> Option<impl ListIterator<'a, Self::ListEntry>> {
         let rib = &instance.state.as_ref()?.rib;
         let iter = rib.tables.ipv4_unicast.prefixes.iter();
-        let iter = iter.filter_map(move |(prefix, dest)| dest.adj_rib.get(&nbr.remote_addr).and_then(|adj_rib| adj_rib.out_pre()).map(|route| (prefix, route)));
+        let iter = iter.filter_map(move |(prefix, dest)| dest.adj_rib.get(&nbr.remote_addr).and_then(|adj_rib| adj_rib.out_pre()).map(|route| (*prefix, route)));
         Some(iter)
     }
 
@@ -795,7 +795,7 @@ impl<'a> YangList<'a, Instance> for bgp::rib::afi_safis::afi_safi::ipv4_unicast:
     fn iter(instance: &'a Instance, &nbr: &Self::ParentListEntry) -> Option<impl ListIterator<'a, Self::ListEntry>> {
         let rib = &instance.state.as_ref()?.rib;
         let iter = rib.tables.ipv4_unicast.prefixes.iter();
-        let iter = iter.filter_map(move |(prefix, dest)| dest.adj_rib.get(&nbr.remote_addr).and_then(|adj_rib| adj_rib.out_post()).map(|route| (prefix, route)));
+        let iter = iter.filter_map(move |(prefix, dest)| dest.adj_rib.get(&nbr.remote_addr).and_then(|adj_rib| adj_rib.out_post()).map(|route| (*prefix, route)));
         Some(iter)
     }
 
@@ -848,7 +848,7 @@ impl<'a> YangList<'a, Instance> for bgp::rib::afi_safis::afi_safi::ipv6_unicast:
         }
         let rib = &instance.state.as_ref()?.rib;
         let iter = rib.tables.ipv6_unicast.prefixes.iter();
-        let iter = iter.filter_map(|(prefix, dest)| dest.local.as_ref().map(|route| (prefix, route)));
+        let iter = iter.filter_map(|(prefix, dest)| dest.local.as_ref().map(|route| (*prefix, route)));
         Some(iter)
     }
 
@@ -918,7 +918,7 @@ impl<'a> YangList<'a, Instance> for bgp::rib::afi_safis::afi_safi::ipv6_unicast:
     fn iter(instance: &'a Instance, &nbr: &Self::ParentListEntry) -> Option<impl ListIterator<'a, Self::ListEntry>> {
         let rib = &instance.state.as_ref()?.rib;
         let iter = rib.tables.ipv6_unicast.prefixes.iter();
-        let iter = iter.filter_map(move |(prefix, dest)| dest.adj_rib.get(&nbr.remote_addr).and_then(|adj_rib| adj_rib.in_pre()).map(|route| (prefix, route)));
+        let iter = iter.filter_map(move |(prefix, dest)| dest.adj_rib.get(&nbr.remote_addr).and_then(|adj_rib| adj_rib.in_pre()).map(|route| (*prefix, route)));
         Some(iter)
     }
 
@@ -968,7 +968,7 @@ impl<'a> YangList<'a, Instance> for bgp::rib::afi_safis::afi_safi::ipv6_unicast:
     fn iter(instance: &'a Instance, &nbr: &Self::ParentListEntry) -> Option<impl ListIterator<'a, Self::ListEntry>> {
         let rib = &instance.state.as_ref()?.rib;
         let iter = rib.tables.ipv6_unicast.prefixes.iter();
-        let iter = iter.filter_map(move |(prefix, dest)| dest.adj_rib.get(&nbr.remote_addr).and_then(|adj_rib| adj_rib.in_post()).map(|route| (prefix, route)));
+        let iter = iter.filter_map(move |(prefix, dest)| dest.adj_rib.get(&nbr.remote_addr).and_then(|adj_rib| adj_rib.in_post()).map(|route| (*prefix, route)));
         Some(iter)
     }
 
@@ -1019,7 +1019,7 @@ impl<'a> YangList<'a, Instance> for bgp::rib::afi_safis::afi_safi::ipv6_unicast:
     fn iter(instance: &'a Instance, &nbr: &Self::ParentListEntry) -> Option<impl ListIterator<'a, Self::ListEntry>> {
         let rib = &instance.state.as_ref()?.rib;
         let iter = rib.tables.ipv6_unicast.prefixes.iter();
-        let iter = iter.filter_map(move |(prefix, dest)| dest.adj_rib.get(&nbr.remote_addr).and_then(|adj_rib| adj_rib.out_pre()).map(|route| (prefix, route)));
+        let iter = iter.filter_map(move |(prefix, dest)| dest.adj_rib.get(&nbr.remote_addr).and_then(|adj_rib| adj_rib.out_pre()).map(|route| (*prefix, route)));
         Some(iter)
     }
 
@@ -1069,7 +1069,7 @@ impl<'a> YangList<'a, Instance> for bgp::rib::afi_safis::afi_safi::ipv6_unicast:
     fn iter(instance: &'a Instance, &nbr: &Self::ParentListEntry) -> Option<impl ListIterator<'a, Self::ListEntry>> {
         let rib = &instance.state.as_ref()?.rib;
         let iter = rib.tables.ipv6_unicast.prefixes.iter();
-        let iter = iter.filter_map(move |(prefix, dest)| dest.adj_rib.get(&nbr.remote_addr).and_then(|adj_rib| adj_rib.out_post()).map(|route| (prefix, route)));
+        let iter = iter.filter_map(move |(prefix, dest)| dest.adj_rib.get(&nbr.remote_addr).and_then(|adj_rib| adj_rib.out_post()).map(|route| (*prefix, route)));
         Some(iter)
     }
 

--- a/holo-bgp/src/rib.rs
+++ b/holo-bgp/src/rib.rs
@@ -13,7 +13,6 @@ use std::time::Instant;
 use holo_utils::bgp::RouteType;
 use holo_utils::ibus::IbusChannelsTx;
 use holo_utils::protocol::Protocol;
-use prefix_trie::map::PrefixMap;
 use serde::{Deserialize, Serialize};
 
 use crate::af::{AddressFamily, Ipv4Unicast, Ipv6Unicast};
@@ -48,8 +47,8 @@ pub struct RoutingTables {
 
 #[derive(Debug)]
 pub struct RoutingTable<A: AddressFamily> {
-    pub prefixes: PrefixMap<A::IpNetwork, Destination>,
-    pub queued_prefixes: BTreeSet<A::IpNetwork>,
+    pub prefixes: BTreeMap<A::Prefix, Destination>,
+    pub queued_prefixes: BTreeSet<A::Prefix>,
     pub nht: HashMap<IpAddr, NhtEntry<A>>,
 }
 
@@ -135,7 +134,7 @@ pub struct AttrSet<T> {
 #[derive(Debug, Eq, PartialEq)]
 pub struct NhtEntry<A: AddressFamily> {
     pub metric: Option<u32>,
-    pub prefixes: BTreeMap<A::IpNetwork, u32>,
+    pub prefixes: BTreeMap<A::Prefix, u32>,
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -774,7 +773,7 @@ where
 }
 
 pub(crate) fn loc_rib_update<A>(
-    prefix: A::IpNetwork,
+    prefix: A::Prefix,
     dest: &mut Destination,
     best_route: Option<Box<Route>>,
     attr_sets: &mut AttrSetsCxt,
@@ -788,7 +787,8 @@ pub(crate) fn loc_rib_update<A>(
 {
     if let Some(best_route) = best_route {
         if trace_opts.route {
-            Debug::BestPathFound(prefix.into(), &best_route).log();
+            Debug::BestPathFound(A::prefix_to_ip_network(prefix), &best_route)
+                .log();
         }
 
         // Compute route nexthops, considering multipath configuration.
@@ -818,7 +818,7 @@ pub(crate) fn loc_rib_update<A>(
         if !local_route.origin.is_local() {
             ibus::tx::route_install(
                 ibus_tx,
-                prefix,
+                A::prefix_to_ip_network(prefix),
                 &local_route,
                 match best_route.route_type {
                     RouteType::Internal => distance_cfg.internal,
@@ -831,7 +831,7 @@ pub(crate) fn loc_rib_update<A>(
         dest.local = Some(Box::new(local_route));
     } else {
         if trace_opts.route {
-            Debug::BestPathNotFound(prefix.into()).log();
+            Debug::BestPathNotFound(A::prefix_to_ip_network(prefix)).log();
         }
 
         // Remove route from the Loc-RIB.
@@ -841,7 +841,10 @@ pub(crate) fn loc_rib_update<A>(
 
             // Uninstall route from the global RIB.
             if !local_route.origin.is_local() {
-                ibus::tx::route_uninstall(ibus_tx, prefix);
+                ibus::tx::route_uninstall(
+                    ibus_tx,
+                    A::prefix_to_ip_network(prefix),
+                );
             }
         }
     }
@@ -880,7 +883,7 @@ pub(crate) fn attrs_tx_update<A>(
 
 pub(crate) fn nexthop_track<A>(
     nht: &mut HashMap<IpAddr, NhtEntry<A>>,
-    prefix: A::IpNetwork,
+    prefix: A::Prefix,
     route: &Route,
     ibus_tx: &IbusChannelsTx,
 ) where
@@ -896,7 +899,7 @@ pub(crate) fn nexthop_track<A>(
 
 pub(crate) fn nexthop_untrack<A>(
     nht: &mut HashMap<IpAddr, NhtEntry<A>>,
-    prefix: &A::IpNetwork,
+    prefix: &A::Prefix,
     route: &Route,
     ibus_tx: &IbusChannelsTx,
 ) where

--- a/holo-protocol/src/lib.rs
+++ b/holo-protocol/src/lib.rs
@@ -387,6 +387,60 @@ pub fn spawn_protocol_task<P>(
     ibus_instance_tx: IbusSender,
     ibus_instance_rx: IbusReceiver,
     agg_channels: InstanceAggChannels<P>,
+    shared: InstanceShared,
+) -> NbDaemonSender
+where
+    P: ProtocolInstance,
+{
+    #[cfg(feature = "testing")]
+    let (_test_tx, test_rx) = mpsc::channel(4);
+
+    spawn_protocol_task_impl::<P>(
+        name,
+        nb_provider_tx,
+        ibus_tx,
+        ibus_instance_tx,
+        ibus_instance_rx,
+        agg_channels,
+        #[cfg(feature = "testing")]
+        test_rx,
+        shared,
+    )
+}
+
+#[cfg(feature = "testing")]
+pub fn spawn_protocol_task_with_test<P>(
+    name: String,
+    nb_provider_tx: &NbProviderSender,
+    ibus_tx: &IbusChannelsTx,
+    ibus_instance_tx: IbusSender,
+    ibus_instance_rx: IbusReceiver,
+    agg_channels: InstanceAggChannels<P>,
+    test_rx: Receiver<TestMsg<P::ProtocolOutputMsg>>,
+    shared: InstanceShared,
+) -> NbDaemonSender
+where
+    P: ProtocolInstance,
+{
+    spawn_protocol_task_impl::<P>(
+        name,
+        nb_provider_tx,
+        ibus_tx,
+        ibus_instance_tx,
+        ibus_instance_rx,
+        agg_channels,
+        test_rx,
+        shared,
+    )
+}
+
+fn spawn_protocol_task_impl<P>(
+    name: String,
+    nb_provider_tx: &NbProviderSender,
+    ibus_tx: &IbusChannelsTx,
+    ibus_instance_tx: IbusSender,
+    ibus_instance_rx: IbusReceiver,
+    agg_channels: InstanceAggChannels<P>,
     #[cfg(feature = "testing")] test_rx: Receiver<
         TestMsg<P::ProtocolOutputMsg>,
     >,

--- a/holo-protocol/src/test/stub/mod.rs
+++ b/holo-protocol/src/test/stub/mod.rs
@@ -23,7 +23,6 @@ use crate::test::stub::northbound::NorthboundStub;
 use crate::test::{OutputChannelsRx, setup};
 use crate::{
     InstanceAggChannels, InstanceMsg, InstanceShared, ProtocolInstance,
-    spawn_protocol_task,
 };
 
 // Environment variable that controls if the test data needs to be updated or
@@ -277,7 +276,7 @@ where
     let channels = InstanceAggChannels::default();
     let instance_tx = channels.tx.clone();
     let (test_tx, test_rx) = mpsc::channel(4);
-    let nb_daemon_tx = spawn_protocol_task::<P>(
+    let nb_daemon_tx = crate::spawn_protocol_task_with_test::<P>(
         name.to_owned(),
         &nb_provider_tx,
         &ibus_tx,

--- a/holo-utils/src/task.rs
+++ b/holo-utils/src/task.rs
@@ -165,6 +165,16 @@ impl<T> Drop for Task<T> {
 // ===== impl TimeoutTask =====
 
 impl TimeoutTask {
+    /// Returns an inert timeout handle for deterministic protocol tests.
+    #[cfg(feature = "testing")]
+    pub fn new<F, Fut>(_timeout: Duration, _cb: F) -> TimeoutTask
+    where
+        F: FnOnce() -> Fut + Send + 'static,
+        Fut: Future<Output = ()> + Send,
+    {
+        TimeoutTask {}
+    }
+
     /// Spawns a new task that will call the provided async closure when the
     /// specified timeout expires.
     ///


### PR DESCRIPTION
Preparatory refactor for multiprotocol RIBs (VPN, labeled-unicast, EVPN). Adds an associated `Prefix` type to the `AddressFamily` trait, separating the RIB/NLRI key from the policy/wire IP-network type, with conversion hooks. IPv4/IPv6 unicast keep `Prefix = IpNetwork`; behavior is unchanged.

The BGP RIB container changes from `prefix_trie::PrefixMap` to an exact-key ordered map, because BGP uses exact lookup/iteration (not LPM); this also avoids forcing wider NLRI keys (e.g. VPNv6 = RD + IPv6) into a single primitive-integer representation.

Includes a small test-infrastructure commit so workspace tests build under the testing feature.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
