### PR TITLE
bgp: add labeled unicast address families (RFC 8277)

### DIFF
--- a/holo-bgp/src/af.rs
+++ b/holo-bgp/src/af.rs
@@ -8,6 +8,7 @@ use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 
 use holo_utils::bgp::AfiSafi;
 use holo_utils::ip::{IpAddrKind, IpNetworkKind, Ipv4AddrExt, Ipv6AddrExt};
+use holo_utils::mpls::Label;
 use ipnetwork::{IpNetwork, Ipv4Network, Ipv6Network};
 use itertools::Itertools;
 
@@ -17,7 +18,8 @@ use crate::neighbor::{
 use crate::packet::attribute::{self, ATTR_MIN_LEN_EXT, BaseAttrs};
 use crate::packet::iana::{Afi, Safi};
 use crate::packet::message::{
-    Message, MpReachNlri, MpUnreachNlri, ReachNlri, UnreachNlri, UpdateMsg,
+    LabeledIpv4Nlri, LabeledIpv6Nlri, Message, MpReachNlri, MpUnreachNlri,
+    ReachNlri, UnreachNlri, UpdateMsg,
 };
 use crate::rib::{RoutingTable, RoutingTables};
 
@@ -68,6 +70,12 @@ pub struct Ipv4Unicast;
 
 #[derive(Debug)]
 pub struct Ipv6Unicast;
+
+#[derive(Debug)]
+pub struct Ipv4LabeledUnicast;
+
+#[derive(Debug)]
+pub struct Ipv6LabeledUnicast;
 
 // ===== impl Ipv4Unicast =====
 
@@ -157,7 +165,7 @@ impl AddressFamily for Ipv4Unicast {
                 prefixes.into_iter().chunks(max as usize).into_iter().map(
                     |chunk| {
                         let reach = ReachNlri {
-                            prefixes: chunk.collect(),
+                            prefixes: chunk.map(|(prefix, _)| prefix).collect(),
                             nexthop,
                         };
                         Message::Update(UpdateMsg {
@@ -303,7 +311,7 @@ impl AddressFamily for Ipv6Unicast {
                 prefixes.into_iter().chunks(max as usize).into_iter().map(
                     |chunk| {
                         let mp_reach = MpReachNlri::Ipv6Unicast {
-                            prefixes: chunk.collect(),
+                            prefixes: chunk.map(|(prefix, _)| prefix).collect(),
                             nexthop,
                             ll_nexthop,
                         };
@@ -333,6 +341,242 @@ impl AddressFamily for Ipv6Unicast {
                         let mp_unreach = MpUnreachNlri::Ipv6Unicast {
                             prefixes: chunk.collect(),
                         };
+                        Message::Update(UpdateMsg {
+                            reach: None,
+                            unreach: None,
+                            mp_reach: None,
+                            mp_unreach: Some(mp_unreach),
+                            attrs: None,
+                        })
+                    },
+                ),
+            );
+        }
+
+        msgs
+    }
+}
+
+// ===== impl Ipv4LabeledUnicast =====
+
+impl AddressFamily for Ipv4LabeledUnicast {
+    const AFI: Afi = Afi::Ipv4;
+    const SAFI: Safi = Safi::LabeledUnicast;
+    const AFI_SAFI: AfiSafi = AfiSafi::Ipv4LabeledUnicast;
+
+    type IpAddr = Ipv4Addr;
+    type IpNetwork = Ipv4Network;
+    type Prefix = Ipv4Network;
+
+    fn table(tables: &mut RoutingTables) -> &mut RoutingTable<Self> {
+        &mut tables.ipv4_labeled_unicast
+    }
+
+    fn update_queue(
+        queues: &mut NeighborUpdateQueues,
+    ) -> &mut NeighborUpdateQueue<Self> {
+        &mut queues.ipv4_labeled_unicast
+    }
+
+    fn nexthop_rx_extract(attrs: &BaseAttrs) -> IpAddr {
+        Ipv4Unicast::nexthop_rx_extract(attrs)
+    }
+
+    fn nexthop_tx_change(nbr: &Neighbor, local: bool, attrs: &mut BaseAttrs) {
+        Ipv4Unicast::nexthop_tx_change(nbr, local, attrs)
+    }
+
+    fn prefix_from_ip_network(prefix: IpNetwork) -> Option<Self::Prefix> {
+        Ipv4Network::get(prefix)
+    }
+
+    fn prefix_to_ip_network(prefix: Self::Prefix) -> IpNetwork {
+        prefix.into()
+    }
+
+    fn build_updates(queue: &mut NeighborUpdateQueue<Self>) -> Vec<Message> {
+        let mut msgs = vec![];
+        let reach = std::mem::take(&mut queue.reach);
+        let unreach = std::mem::take(&mut queue.unreach);
+
+        for (attrs, prefixes) in reach.into_iter() {
+            let nexthop = Ipv4Addr::get(attrs.base.nexthop.unwrap()).unwrap();
+            let max = (Message::MAX_LEN
+                - UpdateMsg::MIN_LEN
+                - attrs.length()
+                - ATTR_MIN_LEN_EXT
+                - MpReachNlri::MIN_LEN)
+                / 5;
+
+            msgs.extend(
+                prefixes.into_iter().chunks(max as usize).into_iter().map(
+                    |chunk| {
+                        let prefixes = chunk
+                            .map(|(prefix, label)| LabeledIpv4Nlri {
+                                label: label.unwrap_or_else(|| {
+                                    Label::explicit_null(
+                                        holo_utils::ip::AddressFamily::Ipv4,
+                                    )
+                                }),
+                                prefix,
+                            })
+                            .collect();
+                        let mp_reach = MpReachNlri::Ipv4LabeledUnicast {
+                            prefixes,
+                            nexthop,
+                        };
+                        Message::Update(UpdateMsg {
+                            reach: None,
+                            unreach: None,
+                            mp_reach: Some(mp_reach),
+                            mp_unreach: None,
+                            attrs: Some(attrs.clone()),
+                        })
+                    },
+                ),
+            );
+        }
+
+        if !unreach.is_empty() {
+            let max = (Message::MAX_LEN
+                - UpdateMsg::MIN_LEN
+                - ATTR_MIN_LEN_EXT
+                - MpUnreachNlri::MIN_LEN)
+                / 5;
+
+            msgs.extend(
+                unreach.into_iter().chunks(max as usize).into_iter().map(
+                    |chunk| {
+                        let prefixes = chunk
+                            .map(|prefix| LabeledIpv4Nlri {
+                                label: Label::explicit_null(
+                                    holo_utils::ip::AddressFamily::Ipv4,
+                                ),
+                                prefix,
+                            })
+                            .collect();
+                        let mp_unreach =
+                            MpUnreachNlri::Ipv4LabeledUnicast { prefixes };
+                        Message::Update(UpdateMsg {
+                            reach: None,
+                            unreach: None,
+                            mp_reach: None,
+                            mp_unreach: Some(mp_unreach),
+                            attrs: None,
+                        })
+                    },
+                ),
+            );
+        }
+
+        msgs
+    }
+}
+
+// ===== impl Ipv6LabeledUnicast =====
+
+impl AddressFamily for Ipv6LabeledUnicast {
+    const AFI: Afi = Afi::Ipv6;
+    const SAFI: Safi = Safi::LabeledUnicast;
+    const AFI_SAFI: AfiSafi = AfiSafi::Ipv6LabeledUnicast;
+
+    type IpAddr = Ipv6Addr;
+    type IpNetwork = Ipv6Network;
+    type Prefix = Ipv6Network;
+
+    fn table(tables: &mut RoutingTables) -> &mut RoutingTable<Self> {
+        &mut tables.ipv6_labeled_unicast
+    }
+
+    fn update_queue(
+        queues: &mut NeighborUpdateQueues,
+    ) -> &mut NeighborUpdateQueue<Self> {
+        &mut queues.ipv6_labeled_unicast
+    }
+
+    fn nexthop_rx_extract(attrs: &BaseAttrs) -> IpAddr {
+        Ipv6Unicast::nexthop_rx_extract(attrs)
+    }
+
+    fn nexthop_tx_change(nbr: &Neighbor, local: bool, attrs: &mut BaseAttrs) {
+        Ipv6Unicast::nexthop_tx_change(nbr, local, attrs)
+    }
+
+    fn prefix_from_ip_network(prefix: IpNetwork) -> Option<Self::Prefix> {
+        Ipv6Network::get(prefix)
+    }
+
+    fn prefix_to_ip_network(prefix: Self::Prefix) -> IpNetwork {
+        prefix.into()
+    }
+
+    fn build_updates(queue: &mut NeighborUpdateQueue<Self>) -> Vec<Message> {
+        let mut msgs = vec![];
+        let reach = std::mem::take(&mut queue.reach);
+        let unreach = std::mem::take(&mut queue.unreach);
+
+        for (attrs, prefixes) in reach.into_iter() {
+            let nexthop = Ipv6Addr::get(attrs.base.nexthop.unwrap()).unwrap();
+            let ll_nexthop = attrs.base.ll_nexthop;
+            let nexthop_len = if ll_nexthop.is_some() { 32 } else { 16 };
+            let max = (Message::MAX_LEN
+                - UpdateMsg::MIN_LEN
+                - attrs.length()
+                - ATTR_MIN_LEN_EXT
+                - MpReachNlri::MIN_LEN
+                - nexthop_len)
+                / 17;
+
+            msgs.extend(
+                prefixes.into_iter().chunks(max as usize).into_iter().map(
+                    |chunk| {
+                        let prefixes = chunk
+                            .map(|(prefix, label)| LabeledIpv6Nlri {
+                                label: label.unwrap_or_else(|| {
+                                    Label::explicit_null(
+                                        holo_utils::ip::AddressFamily::Ipv6,
+                                    )
+                                }),
+                                prefix,
+                            })
+                            .collect();
+                        let mp_reach = MpReachNlri::Ipv6LabeledUnicast {
+                            prefixes,
+                            nexthop,
+                            ll_nexthop,
+                        };
+                        Message::Update(UpdateMsg {
+                            reach: None,
+                            unreach: None,
+                            mp_reach: Some(mp_reach),
+                            mp_unreach: None,
+                            attrs: Some(attrs.clone()),
+                        })
+                    },
+                ),
+            );
+        }
+
+        if !unreach.is_empty() {
+            let max = (Message::MAX_LEN
+                - UpdateMsg::MIN_LEN
+                - ATTR_MIN_LEN_EXT
+                - MpUnreachNlri::MIN_LEN)
+                / 17;
+
+            msgs.extend(
+                unreach.into_iter().chunks(max as usize).into_iter().map(
+                    |chunk| {
+                        let prefixes = chunk
+                            .map(|prefix| LabeledIpv6Nlri {
+                                label: Label::explicit_null(
+                                    holo_utils::ip::AddressFamily::Ipv6,
+                                ),
+                                prefix,
+                            })
+                            .collect();
+                        let mp_unreach =
+                            MpUnreachNlri::Ipv6LabeledUnicast { prefixes };
                         Message::Update(UpdateMsg {
                             reach: None,
                             unreach: None,

--- a/holo-bgp/src/af.rs
+++ b/holo-bgp/src/af.rs
@@ -8,7 +8,7 @@ use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 
 use holo_utils::bgp::AfiSafi;
 use holo_utils::ip::{IpAddrKind, IpNetworkKind, Ipv4AddrExt, Ipv6AddrExt};
-use ipnetwork::{Ipv4Network, Ipv6Network};
+use ipnetwork::{IpNetwork, Ipv4Network, Ipv6Network};
 use itertools::Itertools;
 
 use crate::neighbor::{
@@ -34,6 +34,8 @@ pub trait AddressFamily: Sized {
     type IpAddr: IpAddrKind;
     // The type of IP network used by this address family.
     type IpNetwork: IpNetworkKind<Self::IpAddr> + prefix_trie::Prefix;
+    // The NLRI key used by the BGP RIB for this address family.
+    type Prefix: Copy + Ord;
 
     // Get the routing table for this address family from the provided
     // `RoutingTables`.
@@ -50,6 +52,12 @@ pub trait AddressFamily: Sized {
 
     // Modify the next hop(s) for transmission.
     fn nexthop_tx_change(nbr: &Neighbor, local: bool, attrs: &mut BaseAttrs);
+
+    // Convert between generic IP prefixes used by policy/RIB APIs and the
+    // per-address-family NLRI key.
+    fn prefix_from_ip_network(prefix: IpNetwork) -> Option<Self::Prefix>;
+
+    fn prefix_to_ip_network(prefix: Self::Prefix) -> IpNetwork;
 
     // Build BGP UPDATE messages based on the provided update queue.
     fn build_updates(queue: &mut NeighborUpdateQueue<Self>) -> Vec<Message>;
@@ -70,6 +78,7 @@ impl AddressFamily for Ipv4Unicast {
 
     type IpAddr = Ipv4Addr;
     type IpNetwork = Ipv4Network;
+    type Prefix = Ipv4Network;
 
     fn table(tables: &mut RoutingTables) -> &mut RoutingTable<Self> {
         &mut tables.ipv4_unicast
@@ -120,6 +129,14 @@ impl AddressFamily for Ipv4Unicast {
                 }
             }
         }
+    }
+
+    fn prefix_from_ip_network(prefix: IpNetwork) -> Option<Self::Prefix> {
+        Ipv4Network::get(prefix)
+    }
+
+    fn prefix_to_ip_network(prefix: Self::Prefix) -> IpNetwork {
+        prefix.into()
     }
 
     fn build_updates(queue: &mut NeighborUpdateQueue<Self>) -> Vec<Message> {
@@ -191,6 +208,7 @@ impl AddressFamily for Ipv6Unicast {
 
     type IpAddr = Ipv6Addr;
     type IpNetwork = Ipv6Network;
+    type Prefix = Ipv6Network;
 
     fn table(tables: &mut RoutingTables) -> &mut RoutingTable<Self> {
         &mut tables.ipv6_unicast
@@ -253,6 +271,14 @@ impl AddressFamily for Ipv6Unicast {
                 }
             }
         }
+    }
+
+    fn prefix_from_ip_network(prefix: IpNetwork) -> Option<Self::Prefix> {
+        Ipv6Network::get(prefix)
+    }
+
+    fn prefix_to_ip_network(prefix: Self::Prefix) -> IpNetwork {
+        prefix.into()
     }
 
     fn build_updates(queue: &mut NeighborUpdateQueue<Self>) -> Vec<Message> {

--- a/holo-bgp/src/events.rs
+++ b/holo-bgp/src/events.rs
@@ -16,7 +16,10 @@ use holo_utils::socket::{TcpConnInfo, TcpStream};
 use ipnetwork::IpNetwork;
 use num_traits::FromPrimitive;
 
-use crate::af::{AddressFamily, Ipv4Unicast, Ipv6Unicast};
+use crate::af::{
+    AddressFamily, Ipv4LabeledUnicast, Ipv4Unicast, Ipv6LabeledUnicast,
+    Ipv6Unicast,
+};
 use crate::debug::Debug;
 use crate::error::{Error, IoError, NbrRxError};
 use crate::instance::{InstanceUpView, PolicyApplyTasks};
@@ -219,6 +222,41 @@ fn process_nbr_update(
                         &instance.state.policy_apply_tasks,
                     );
                 }
+                MpReachNlri::Ipv4LabeledUnicast { prefixes, nexthop } => {
+                    attrs.base.nexthop = Some(nexthop.into());
+                    process_nbr_reach_nlris::<Ipv4LabeledUnicast>(
+                        nbr,
+                        rib,
+                        prefixes
+                            .into_iter()
+                            .map(|nlri| (nlri.prefix, Some(nlri.label)))
+                            .collect(),
+                        attrs,
+                        instance.config.asn,
+                        instance.shared,
+                        &instance.state.policy_apply_tasks,
+                    );
+                }
+                MpReachNlri::Ipv6LabeledUnicast {
+                    prefixes,
+                    nexthop,
+                    ll_nexthop,
+                } => {
+                    attrs.base.nexthop = Some(nexthop.into());
+                    attrs.base.ll_nexthop = ll_nexthop;
+                    process_nbr_reach_nlris::<Ipv6LabeledUnicast>(
+                        nbr,
+                        rib,
+                        prefixes
+                            .into_iter()
+                            .map(|nlri| (nlri.prefix, Some(nlri.label)))
+                            .collect(),
+                        attrs,
+                        instance.config.asn,
+                        instance.shared,
+                        &instance.state.policy_apply_tasks,
+                    );
+                }
             }
         } else {
             // Treat as withdraw.
@@ -231,6 +269,22 @@ fn process_nbr_update(
                 MpReachNlri::Ipv6Unicast { prefixes, .. } => {
                     process_nbr_unreach_prefixes::<Ipv6Unicast>(
                         nbr, rib, prefixes, ibus_tx,
+                    );
+                }
+                MpReachNlri::Ipv4LabeledUnicast { prefixes, .. } => {
+                    process_nbr_unreach_prefixes::<Ipv4LabeledUnicast>(
+                        nbr,
+                        rib,
+                        prefixes.into_iter().map(|nlri| nlri.prefix).collect(),
+                        ibus_tx,
+                    );
+                }
+                MpReachNlri::Ipv6LabeledUnicast { prefixes, .. } => {
+                    process_nbr_unreach_prefixes::<Ipv6LabeledUnicast>(
+                        nbr,
+                        rib,
+                        prefixes.into_iter().map(|nlri| nlri.prefix).collect(),
+                        ibus_tx,
                     );
                 }
             }
@@ -260,6 +314,22 @@ fn process_nbr_update(
                     nbr, rib, prefixes, ibus_tx,
                 );
             }
+            MpUnreachNlri::Ipv4LabeledUnicast { prefixes } => {
+                process_nbr_unreach_prefixes::<Ipv4LabeledUnicast>(
+                    nbr,
+                    rib,
+                    prefixes.into_iter().map(|nlri| nlri.prefix).collect(),
+                    ibus_tx,
+                );
+            }
+            MpUnreachNlri::Ipv6LabeledUnicast { prefixes } => {
+                process_nbr_unreach_prefixes::<Ipv6LabeledUnicast>(
+                    nbr,
+                    rib,
+                    prefixes.into_iter().map(|nlri| nlri.prefix).collect(),
+                    ibus_tx,
+                );
+            }
         }
     }
 
@@ -273,6 +343,31 @@ fn process_nbr_reach_prefixes<A>(
     nbr: &Neighbor,
     rib: &mut Rib,
     nlri_prefixes: Vec<A::Prefix>,
+    attrs: Attrs,
+    local_asn: u32,
+    shared: &InstanceShared,
+    policy_apply_tasks: &PolicyApplyTasks,
+) where
+    A: AddressFamily,
+{
+    process_nbr_reach_nlris::<A>(
+        nbr,
+        rib,
+        nlri_prefixes
+            .into_iter()
+            .map(|prefix| (prefix, None))
+            .collect(),
+        attrs,
+        local_asn,
+        shared,
+        policy_apply_tasks,
+    );
+}
+
+fn process_nbr_reach_nlris<A>(
+    nbr: &Neighbor,
+    rib: &mut Rib,
+    nlris: Vec<(A::Prefix, Option<holo_utils::mpls::Label>)>,
     mut attrs: Attrs,
     local_asn: u32,
     shared: &InstanceShared,
@@ -304,10 +399,11 @@ fn process_nbr_reach_prefixes<A>(
     // Update pre-policy Adj-RIB-In routes.
     let table = A::table(&mut rib.tables);
     let route_attrs = rib.attr_sets.get_route_attr_sets(&attrs);
-    for prefix in &nlri_prefixes {
+    for (prefix, label) in &nlris {
         let dest = table.prefixes.entry(*prefix).or_default();
         let adj_rib = dest.adj_rib.entry(nbr.remote_addr).or_default();
-        let route = Route::new(origin, route_attrs.clone(), route_type);
+        let mut route = Route::new(origin, route_attrs.clone(), route_type);
+        route.label = *label;
         adj_rib.update_in_pre(Box::new(route), &mut rib.attr_sets);
     }
 
@@ -320,14 +416,25 @@ fn process_nbr_reach_prefixes<A>(
         .unwrap_or(&nbr.config.apply_policy);
 
     // Enqueue import policy application.
-    let rpinfo = RoutePolicyInfo::new(origin, route_type, None, None, attrs);
     let msg = PolicyApplyMsg::Neighbor {
         policy_type: PolicyType::Import,
         nbr_addr: nbr.remote_addr,
         afi_safi: A::AFI_SAFI,
-        routes: nlri_prefixes
+        routes: nlris
             .into_iter()
-            .map(|prefix| (A::prefix_to_ip_network(prefix), rpinfo.clone()))
+            .map(|(prefix, label)| {
+                (
+                    A::prefix_to_ip_network(prefix),
+                    RoutePolicyInfo::new(
+                        origin,
+                        route_type,
+                        label,
+                        None,
+                        None,
+                        attrs.clone(),
+                    ),
+                )
+            })
             .collect(),
         policies: apply_policy_cfg
             .import_policy
@@ -404,6 +511,12 @@ fn process_nbr_route_refresh(
         (Afi::Ipv6, Safi::Unicast) => {
             nbr.resend_adj_rib_out::<Ipv6Unicast>(instance);
         }
+        (Afi::Ipv4, Safi::LabeledUnicast) => {
+            nbr.resend_adj_rib_out::<Ipv4LabeledUnicast>(instance);
+        }
+        (Afi::Ipv6, Safi::LabeledUnicast) => {
+            nbr.resend_adj_rib_out::<Ipv6LabeledUnicast>(instance);
+        }
         _ => {
             // Ignore unsupported AFI/SAFI combination.
             return Ok(());
@@ -468,11 +581,12 @@ where
         // Update post-policy Adj-RIB-In routes.
         match result {
             PolicyResult::Accept(rpinfo) => {
-                let route = Route::new(
+                let mut route = Route::new(
                     rpinfo.origin,
                     rib.attr_sets.get_route_attr_sets(&rpinfo.attrs),
                     rpinfo.route_type,
                 );
+                route.label = rpinfo.label;
 
                 // Update nexthop tracking.
                 if let Some(old_route) = adj_rib.in_post() {
@@ -545,20 +659,23 @@ where
         // Update post-policy Adj-RIB-Out routes.
         match result {
             PolicyResult::Accept(rpinfo) => {
-                let route = Route::new(
+                let mut route = Route::new(
                     rpinfo.origin,
                     rib.attr_sets.get_route_attr_sets(&rpinfo.attrs),
                     rpinfo.route_type,
                 );
+                route.label = rpinfo.label;
 
                 // Check if the Adj-RIB-Out was updated.
                 let update = if let Some(adj_rib_route) = adj_rib.out_post() {
                     adj_rib_route.attrs != route.attrs
+                        || adj_rib_route.label != route.label
                 } else {
                     true
                 };
 
                 if update {
+                    let label = route.label;
                     adj_rib
                         .update_out_post(Box::new(route), &mut rib.attr_sets);
 
@@ -573,7 +690,11 @@ where
 
                     // Update neighbor's Tx queue.
                     let update_queue = A::update_queue(&mut nbr.update_queues);
-                    update_queue.reach.entry(attrs).or_default().insert(prefix);
+                    update_queue
+                        .reach
+                        .entry(attrs)
+                        .or_default()
+                        .insert(prefix, label);
                 }
             }
             PolicyResult::Reject => {
@@ -616,11 +737,12 @@ where
 
             // Update redistributed route in the RIB.
             let route_attrs = rib.attr_sets.get_route_attr_sets(&rpinfo.attrs);
-            let route = Route::new(
+            let mut route = Route::new(
                 rpinfo.origin,
                 route_attrs.clone(),
                 RouteType::Internal,
             );
+            route.label = rpinfo.label;
             dest.redistribute = Some(Box::new(route));
         }
         PolicyResult::Reject => {

--- a/holo-bgp/src/events.rs
+++ b/holo-bgp/src/events.rs
@@ -10,7 +10,7 @@ use chrono::Utc;
 use holo_protocol::InstanceShared;
 use holo_utils::bgp::RouteType;
 use holo_utils::ibus::IbusChannelsTx;
-use holo_utils::ip::{IpAddrKind, IpNetworkKind};
+use holo_utils::ip::IpAddrKind;
 use holo_utils::policy::{PolicyResult, PolicyType};
 use holo_utils::socket::{TcpConnInfo, TcpStream};
 use ipnetwork::IpNetwork;
@@ -272,7 +272,7 @@ fn process_nbr_update(
 fn process_nbr_reach_prefixes<A>(
     nbr: &Neighbor,
     rib: &mut Rib,
-    nlri_prefixes: Vec<A::IpNetwork>,
+    nlri_prefixes: Vec<A::Prefix>,
     mut attrs: Attrs,
     local_asn: u32,
     shared: &InstanceShared,
@@ -327,7 +327,7 @@ fn process_nbr_reach_prefixes<A>(
         afi_safi: A::AFI_SAFI,
         routes: nlri_prefixes
             .into_iter()
-            .map(|prefix| (prefix.into(), rpinfo.clone()))
+            .map(|prefix| (A::prefix_to_ip_network(prefix), rpinfo.clone()))
             .collect(),
         policies: apply_policy_cfg
             .import_policy
@@ -343,7 +343,7 @@ fn process_nbr_reach_prefixes<A>(
 fn process_nbr_unreach_prefixes<A>(
     nbr: &Neighbor,
     rib: &mut Rib,
-    nlri_prefixes: Vec<A::IpNetwork>,
+    nlri_prefixes: Vec<A::Prefix>,
     ibus_tx: &IbusChannelsTx,
 ) where
     A: AddressFamily,
@@ -461,7 +461,7 @@ where
     let table = A::table(&mut rib.tables);
     for (prefix, result) in prefixes {
         // Get RIB destination.
-        let prefix = A::IpNetwork::get(prefix).unwrap();
+        let prefix = A::prefix_from_ip_network(prefix).unwrap();
         let dest = table.prefixes.entry(prefix).or_default();
         let adj_rib = dest.adj_rib.entry(nbr.remote_addr).or_default();
 
@@ -538,7 +538,7 @@ where
     let table = A::table(&mut rib.tables);
     for (prefix, result) in prefixes {
         // Get RIB destination.
-        let prefix = A::IpNetwork::get(prefix).unwrap();
+        let prefix = A::prefix_from_ip_network(prefix).unwrap();
         let dest = table.prefixes.entry(prefix).or_default();
         let adj_rib = dest.adj_rib.entry(nbr.remote_addr).or_default();
 
@@ -607,7 +607,7 @@ where
 {
     let rib = &mut instance.state.rib;
     let table = A::table(&mut rib.tables);
-    let prefix = A::IpNetwork::get(prefix).unwrap();
+    let prefix = A::prefix_from_ip_network(prefix).unwrap();
 
     match result {
         PolicyResult::Accept(rpinfo) => {
@@ -750,7 +750,7 @@ where
 
     // Remove routing table entries that no longer hold any data.
     for prefix in queued_prefixes {
-        if let prefix_trie::map::Entry::Occupied(entry) =
+        if let std::collections::btree_map::Entry::Occupied(entry) =
             table.prefixes.entry(prefix)
         {
             let dest = entry.get();
@@ -773,7 +773,7 @@ where
 fn withdraw_routes<A>(
     nbr: &mut Neighbor,
     table: &mut RoutingTable<A>,
-    routes: &[A::IpNetwork],
+    routes: &[A::Prefix],
     attr_sets: &mut AttrSetsCxt,
 ) where
     A: AddressFamily,
@@ -802,7 +802,7 @@ fn withdraw_routes<A>(
 pub(crate) fn advertise_routes<A>(
     nbr: &mut Neighbor,
     table: &mut RoutingTable<A>,
-    routes: Vec<(A::IpNetwork, Box<Route>)>,
+    routes: Vec<(A::Prefix, Box<Route>)>,
     shared: &InstanceShared,
     attr_sets: &mut AttrSetsCxt,
     policy_apply_tasks: &PolicyApplyTasks,
@@ -827,7 +827,9 @@ pub(crate) fn advertise_routes<A>(
     // Enqueue export policy application.
     let routes = routes
         .into_iter()
-        .map(|(prefix, route)| (prefix.into(), route.policy_info()))
+        .map(|(prefix, route)| {
+            (A::prefix_to_ip_network(prefix), route.policy_info())
+        })
         .collect::<Vec<_>>();
     if !routes.is_empty() {
         let msg = PolicyApplyMsg::Neighbor {

--- a/holo-bgp/src/events.rs
+++ b/holo-bgp/src/events.rs
@@ -816,6 +816,7 @@ where
             &instance.config.distance,
             &instance.config.trace_opts,
             &instance.tx.ibus,
+            instance.shared,
         );
 
         // Group best routes and unfeasible routes separately.

--- a/holo-bgp/src/ibus/rx.rs
+++ b/holo-bgp/src/ibus/rx.rs
@@ -12,7 +12,10 @@ use holo_utils::protocol::Protocol;
 use holo_utils::southbound::{RouteKeyMsg, RouteMsg};
 use ipnetwork::IpNetwork;
 
-use crate::af::{AddressFamily, Ipv4Unicast, Ipv6Unicast};
+use crate::af::{
+    AddressFamily, Ipv4LabeledUnicast, Ipv4Unicast, Ipv6LabeledUnicast,
+    Ipv6Unicast,
+};
 use crate::debug::Debug;
 use crate::instance::{Instance, InstanceUpView};
 use crate::policy::RoutePolicyInfo;
@@ -44,6 +47,8 @@ pub(crate) fn process_nht_update(
 
     process_nht_update_af::<Ipv4Unicast>(&mut instance, addr, metric);
     process_nht_update_af::<Ipv6Unicast>(&mut instance, addr, metric);
+    process_nht_update_af::<Ipv4LabeledUnicast>(&mut instance, addr, metric);
+    process_nht_update_af::<Ipv6LabeledUnicast>(&mut instance, addr, metric);
 }
 
 pub(crate) fn process_route_add(instance: &mut Instance, msg: RouteMsg) {
@@ -57,10 +62,12 @@ pub(crate) fn process_route_add(instance: &mut Instance, msg: RouteMsg) {
 
     match msg.prefix {
         IpNetwork::V4(..) => {
-            process_route_add_af::<Ipv4Unicast>(&mut instance, msg);
+            process_route_add_af::<Ipv4Unicast>(&mut instance, msg.clone());
+            process_route_add_af::<Ipv4LabeledUnicast>(&mut instance, msg);
         }
         IpNetwork::V6(..) => {
-            process_route_add_af::<Ipv6Unicast>(&mut instance, msg);
+            process_route_add_af::<Ipv6Unicast>(&mut instance, msg.clone());
+            process_route_add_af::<Ipv6LabeledUnicast>(&mut instance, msg);
         }
     }
 }
@@ -78,9 +85,19 @@ pub(crate) fn process_route_del(instance: &mut Instance, msg: RouteKeyMsg) {
     match msg.prefix {
         IpNetwork::V4(prefix) => {
             process_route_del_af::<Ipv4Unicast>(&mut instance, prefix, proto);
+            process_route_del_af::<Ipv4LabeledUnicast>(
+                &mut instance,
+                prefix,
+                proto,
+            );
         }
         IpNetwork::V6(prefix) => {
             process_route_del_af::<Ipv6Unicast>(&mut instance, prefix, proto);
+            process_route_del_af::<Ipv6LabeledUnicast>(
+                &mut instance,
+                prefix,
+                proto,
+            );
         }
     }
 }
@@ -133,6 +150,7 @@ where
         route: RoutePolicyInfo::new(
             RouteOrigin::Protocol(msg.protocol),
             RouteType::Internal,
+            None,
             msg.tag,
             Some(msg.opaque_attrs),
             Default::default(),

--- a/holo-bgp/src/ibus/rx.rs
+++ b/holo-bgp/src/ibus/rx.rs
@@ -170,6 +170,7 @@ fn process_route_del_af<A>(
     // Get prefix RIB entry.
     let rib = &mut instance.state.rib;
     let table = A::table(&mut rib.tables);
+    let prefix = A::prefix_from_ip_network(prefix.into()).unwrap();
     let dest = table.prefixes.entry(prefix).or_default();
 
     // Remove redistributed route.

--- a/holo-bgp/src/ibus/tx.rs
+++ b/holo-bgp/src/ibus/tx.rs
@@ -8,9 +8,11 @@ use std::collections::BTreeSet;
 use std::net::IpAddr;
 
 use holo_utils::ibus::IbusChannelsTx;
+use holo_utils::mpls::Label;
 use holo_utils::protocol::Protocol;
 use holo_utils::southbound::{
-    Nexthop, RouteKeyMsg, RouteKind, RouteMsg, RouteOpaqueAttrs,
+    LabelInstallMsg, LabelUninstallMsg, Nexthop, RouteKeyMsg, RouteKind,
+    RouteMsg, RouteOpaqueAttrs,
 };
 use ipnetwork::IpNetwork;
 
@@ -35,7 +37,10 @@ pub(crate) fn route_install(
         .flat_map(|nexthops| nexthops.iter())
         .map(|nexthop| Nexthop::Recursive {
             addr: *nexthop,
-            labels: vec![],
+            labels: route
+                .nexthop_label
+                .map(|label| vec![label])
+                .unwrap_or_default(),
             resolved: Default::default(),
         })
         .collect::<BTreeSet<_>>();
@@ -66,10 +71,79 @@ pub(crate) fn route_uninstall(
     ibus_tx.route_ip_del(msg);
 }
 
+pub(crate) fn label_install(
+    ibus_tx: &IbusChannelsTx,
+    prefix: IpNetwork,
+    route: &LocalRoute,
+    old_route: Option<&LocalRoute>,
+) {
+    let Some(label) = route.label else {
+        return;
+    };
+    if label.is_reserved() {
+        return;
+    }
+
+    if let Some(old_route) = old_route
+        && old_route.label == route.label
+        && old_route.nexthops == route.nexthops
+        && old_route.nexthop_label == route.nexthop_label
+    {
+        return;
+    }
+
+    let nexthops =
+        route_mpls_nexthops(route.nexthops.as_ref(), route.nexthop_label);
+    let msg = LabelInstallMsg {
+        protocol: Protocol::BGP,
+        label,
+        nexthops,
+        route: Some((Protocol::BGP, prefix)),
+        replace: true,
+    };
+    ibus_tx.route_mpls_add(msg);
+}
+
+pub(crate) fn label_uninstall(
+    ibus_tx: &IbusChannelsTx,
+    prefix: IpNetwork,
+    route: &LocalRoute,
+) {
+    let Some(label) = route.label else {
+        return;
+    };
+    if label.is_reserved() {
+        return;
+    }
+
+    let msg = LabelUninstallMsg {
+        protocol: Protocol::BGP,
+        label,
+        nexthops: Default::default(),
+        route: Some((Protocol::BGP, prefix)),
+    };
+    ibus_tx.route_mpls_del(msg);
+}
+
 pub(crate) fn nexthop_track(ibus_tx: &IbusChannelsTx, addr: IpAddr) {
     ibus_tx.nexthop_track(addr);
 }
 
 pub(crate) fn nexthop_untrack(ibus_tx: &IbusChannelsTx, addr: IpAddr) {
     ibus_tx.nexthop_untrack(addr);
+}
+
+fn route_mpls_nexthops(
+    nexthops: Option<&BTreeSet<IpAddr>>,
+    label: Option<Label>,
+) -> BTreeSet<Nexthop> {
+    nexthops
+        .into_iter()
+        .flat_map(|nexthops| nexthops.iter())
+        .map(|nexthop| Nexthop::Recursive {
+            addr: *nexthop,
+            labels: label.map(|label| vec![label]).unwrap_or_default(),
+            resolved: Default::default(),
+        })
+        .collect()
 }

--- a/holo-bgp/src/instance.rs
+++ b/holo-bgp/src/instance.rs
@@ -20,7 +20,9 @@ use holo_utils::task::{Task, TimeoutTask};
 use tokio::sync::mpsc;
 use tokio::sync::mpsc::{Receiver, Sender, UnboundedReceiver, UnboundedSender};
 
-use crate::af::{Ipv4Unicast, Ipv6Unicast};
+use crate::af::{
+    Ipv4LabeledUnicast, Ipv4Unicast, Ipv6LabeledUnicast, Ipv6Unicast,
+};
 use crate::debug::{Debug, InstanceInactiveReason};
 use crate::error::{Error, IoError};
 use crate::neighbor::{Neighbors, fsm};
@@ -545,6 +547,16 @@ fn process_protocol_msg(
                         instance, neighbors, nbr_addr, routes,
                     )?
                 }
+                (PolicyType::Import, AfiSafi::Ipv4LabeledUnicast) => {
+                    events::process_nbr_policy_import::<Ipv4LabeledUnicast>(
+                        instance, neighbors, nbr_addr, routes,
+                    )?
+                }
+                (PolicyType::Import, AfiSafi::Ipv6LabeledUnicast) => {
+                    events::process_nbr_policy_import::<Ipv6LabeledUnicast>(
+                        instance, neighbors, nbr_addr, routes,
+                    )?
+                }
                 (PolicyType::Export, AfiSafi::Ipv4Unicast) => {
                     events::process_nbr_policy_export::<Ipv4Unicast>(
                         instance, neighbors, nbr_addr, routes,
@@ -552,6 +564,16 @@ fn process_protocol_msg(
                 }
                 (PolicyType::Export, AfiSafi::Ipv6Unicast) => {
                     events::process_nbr_policy_export::<Ipv6Unicast>(
+                        instance, neighbors, nbr_addr, routes,
+                    )?
+                }
+                (PolicyType::Export, AfiSafi::Ipv4LabeledUnicast) => {
+                    events::process_nbr_policy_export::<Ipv4LabeledUnicast>(
+                        instance, neighbors, nbr_addr, routes,
+                    )?
+                }
+                (PolicyType::Export, AfiSafi::Ipv6LabeledUnicast) => {
+                    events::process_nbr_policy_export::<Ipv6LabeledUnicast>(
                         instance, neighbors, nbr_addr, routes,
                     )?
                 }
@@ -571,12 +593,28 @@ fn process_protocol_msg(
                         instance, prefix, result,
                     )?
                 }
+                AfiSafi::Ipv4LabeledUnicast => {
+                    events::process_redistribute_policy_import::<
+                        Ipv4LabeledUnicast,
+                    >(instance, prefix, result)?
+                }
+                AfiSafi::Ipv6LabeledUnicast => {
+                    events::process_redistribute_policy_import::<
+                        Ipv6LabeledUnicast,
+                    >(instance, prefix, result)?
+                }
             },
         },
         // Decision process.
         ProtocolInputMsg::TriggerDecisionProcess(_) => {
             events::decision_process::<Ipv4Unicast>(instance, neighbors)?;
             events::decision_process::<Ipv6Unicast>(instance, neighbors)?;
+            events::decision_process::<Ipv4LabeledUnicast>(
+                instance, neighbors,
+            )?;
+            events::decision_process::<Ipv6LabeledUnicast>(
+                instance, neighbors,
+            )?;
         }
     }
 

--- a/holo-bgp/src/neighbor.rs
+++ b/holo-bgp/src/neighbor.rs
@@ -15,13 +15,17 @@ use chrono::{DateTime, Utc};
 use holo_protocol::InstanceChannelsTx;
 use holo_utils::bgp::{AfiSafi, RouteType, WellKnownCommunities};
 use holo_utils::ibus::IbusChannelsTx;
+use holo_utils::mpls::Label;
 use holo_utils::socket::{TTL_MAX, TcpConnInfo, TcpStream};
 use holo_utils::task::{IntervalTask, Task, TimeoutTask};
 use num_traits::{FromPrimitive, ToPrimitive};
 use tokio::sync::mpsc;
 use tokio::sync::mpsc::{Sender, UnboundedSender};
 
-use crate::af::{AddressFamily, Ipv4Unicast, Ipv6Unicast};
+use crate::af::{
+    AddressFamily, Ipv4LabeledUnicast, Ipv4Unicast, Ipv6LabeledUnicast,
+    Ipv6Unicast,
+};
 use crate::debug::Debug;
 use crate::error::Error;
 use crate::instance::{Instance, InstanceUpView};
@@ -113,12 +117,14 @@ pub struct NeighborTasks {
 pub struct NeighborUpdateQueues {
     pub ipv4_unicast: NeighborUpdateQueue<Ipv4Unicast>,
     pub ipv6_unicast: NeighborUpdateQueue<Ipv6Unicast>,
+    pub ipv4_labeled_unicast: NeighborUpdateQueue<Ipv4LabeledUnicast>,
+    pub ipv6_labeled_unicast: NeighborUpdateQueue<Ipv6LabeledUnicast>,
 }
 
 // Neighbor Tx update queue.
 #[derive(Debug)]
 pub struct NeighborUpdateQueue<A: AddressFamily> {
-    pub reach: BTreeMap<Attrs, BTreeSet<A::Prefix>>,
+    pub reach: BTreeMap<Attrs, BTreeMap<A::Prefix, Option<Label>>>,
     pub unreach: BTreeSet<A::Prefix>,
 }
 
@@ -585,6 +591,8 @@ impl Neighbor {
         // Send initial routing updates.
         self.initial_routing_update::<Ipv4Unicast>(instance);
         self.initial_routing_update::<Ipv6Unicast>(instance);
+        self.initial_routing_update::<Ipv4LabeledUnicast>(instance);
+        self.initial_routing_update::<Ipv6LabeledUnicast>(instance);
     }
 
     // Closes the BGP session, performing necessary cleanup and releasing resources.
@@ -613,6 +621,8 @@ impl Neighbor {
         self.capabilities_nego.clear();
         self.clear_routes::<Ipv4Unicast>(rib, &instance_tx.ibus);
         self.clear_routes::<Ipv6Unicast>(rib, &instance_tx.ibus);
+        self.clear_routes::<Ipv4LabeledUnicast>(rib, &instance_tx.ibus);
+        self.clear_routes::<Ipv6LabeledUnicast>(rib, &instance_tx.ibus);
         self.tasks = Default::default();
         self.msg_txp = None;
 
@@ -693,6 +703,24 @@ impl Neighbor {
             capabilities.insert(Capability::MultiProtocol {
                 afi: Afi::Ipv6,
                 safi: Safi::Unicast,
+            });
+        }
+        if let Some(afi_safi) =
+            self.config.afi_safi.get(&AfiSafi::Ipv4LabeledUnicast)
+            && afi_safi.enabled
+        {
+            capabilities.insert(Capability::MultiProtocol {
+                afi: Afi::Ipv4,
+                safi: Safi::LabeledUnicast,
+            });
+        }
+        if let Some(afi_safi) =
+            self.config.afi_safi.get(&AfiSafi::Ipv6LabeledUnicast)
+            && afi_safi.enabled
+        {
+            capabilities.insert(Capability::MultiProtocol {
+                afi: Afi::Ipv6,
+                safi: Safi::LabeledUnicast,
             });
         }
 
@@ -917,6 +945,7 @@ impl Neighbor {
                         origin: route.origin,
                         attrs: route.attrs.clone(),
                         route_type: route.route_type,
+                        label: route.label,
                         igp_cost: None,
                         last_modified: route.last_modified,
                         ineligible_reason: None,
@@ -966,7 +995,11 @@ impl Neighbor {
 
             // Update neighbor's Tx queue.
             let update_queue = A::update_queue(&mut self.update_queues);
-            update_queue.reach.entry(attrs).or_default().insert(*prefix);
+            update_queue
+                .reach
+                .entry(attrs)
+                .or_default()
+                .insert(*prefix, route.label);
         }
     }
 
@@ -1027,6 +1060,8 @@ impl Neighbor {
                 // Re-send the current Adj-RIB-Out to this neighbor.
                 self.resend_adj_rib_out::<Ipv4Unicast>(instance);
                 self.resend_adj_rib_out::<Ipv6Unicast>(instance);
+                self.resend_adj_rib_out::<Ipv4LabeledUnicast>(instance);
+                self.resend_adj_rib_out::<Ipv6LabeledUnicast>(instance);
                 let msg_list = self.update_queues.build_updates();
                 if !msg_list.is_empty() {
                     self.message_list_send(msg_list);
@@ -1153,6 +1188,8 @@ impl NeighborUpdateQueues {
         [
             self.ipv4_unicast.build_updates(),
             self.ipv6_unicast.build_updates(),
+            self.ipv4_labeled_unicast.build_updates(),
+            self.ipv6_labeled_unicast.build_updates(),
         ]
         .concat()
     }

--- a/holo-bgp/src/neighbor.rs
+++ b/holo-bgp/src/neighbor.rs
@@ -118,8 +118,8 @@ pub struct NeighborUpdateQueues {
 // Neighbor Tx update queue.
 #[derive(Debug)]
 pub struct NeighborUpdateQueue<A: AddressFamily> {
-    pub reach: BTreeMap<Attrs, BTreeSet<A::IpNetwork>>,
-    pub unreach: BTreeSet<A::IpNetwork>,
+    pub reach: BTreeMap<Attrs, BTreeSet<A::Prefix>>,
+    pub unreach: BTreeSet<A::Prefix>,
 }
 
 // Type aliases.
@@ -922,7 +922,7 @@ impl Neighbor {
                         ineligible_reason: None,
                         reject_reason: None,
                     };
-                    (prefix, Box::new(route))
+                    (*prefix, Box::new(route))
                 })
             })
             .filter(|(_, route)| self.distribute_filter(route))
@@ -966,7 +966,7 @@ impl Neighbor {
 
             // Update neighbor's Tx queue.
             let update_queue = A::update_queue(&mut self.update_queues);
-            update_queue.reach.entry(attrs).or_default().insert(prefix);
+            update_queue.reach.entry(attrs).or_default().insert(*prefix);
         }
     }
 
@@ -983,7 +983,7 @@ impl Neighbor {
                 if let Some(adj_in_route) = adj_rib.in_post() {
                     rib::nexthop_untrack(
                         &mut table.nht,
-                        &prefix,
+                        prefix,
                         adj_in_route,
                         ibus_tx,
                     );
@@ -996,7 +996,7 @@ impl Neighbor {
             }
 
             // Enqueue prefix for the BGP Decision Process.
-            table.queued_prefixes.insert(prefix);
+            table.queued_prefixes.insert(*prefix);
         }
     }
 

--- a/holo-bgp/src/northbound/configuration.rs
+++ b/holo-bgp/src/northbound/configuration.rs
@@ -20,7 +20,9 @@ use holo_utils::protocol::Protocol;
 use holo_utils::yang::DataNodeRefExt;
 use holo_yang::TryFromYang;
 
-use crate::af::{Ipv4Unicast, Ipv6Unicast};
+use crate::af::{
+    Ipv4LabeledUnicast, Ipv4Unicast, Ipv6LabeledUnicast, Ipv6Unicast,
+};
 use crate::instance::{Instance, InstanceUpView};
 use crate::neighbor::{Neighbor, PeerType, fsm};
 use crate::network;
@@ -1589,6 +1591,12 @@ impl Provider for Instance {
                         }
                         AfiSafi::Ipv6Unicast => {
                             redistribute_delete::<Ipv6Unicast>(&mut instance, protocol);
+                        }
+                        AfiSafi::Ipv4LabeledUnicast => {
+                            redistribute_delete::<Ipv4LabeledUnicast>(&mut instance, protocol);
+                        }
+                        AfiSafi::Ipv6LabeledUnicast => {
+                            redistribute_delete::<Ipv6LabeledUnicast>(&mut instance, protocol);
                         }
                     }
                 }

--- a/holo-bgp/src/northbound/configuration.rs
+++ b/holo-bgp/src/northbound/configuration.rs
@@ -1695,7 +1695,7 @@ where
         dest.redistribute = None;
 
         // Enqueue prefix for the BGP Decision Process.
-        table.queued_prefixes.insert(prefix);
+        table.queued_prefixes.insert(*prefix);
     }
 
     // Schedule the BGP Decision Process.

--- a/holo-bgp/src/northbound/configuration.rs
+++ b/holo-bgp/src/northbound/configuration.rs
@@ -20,9 +20,7 @@ use holo_utils::protocol::Protocol;
 use holo_utils::yang::DataNodeRefExt;
 use holo_yang::TryFromYang;
 
-use crate::af::{
-    Ipv4LabeledUnicast, Ipv4Unicast, Ipv6LabeledUnicast, Ipv6Unicast,
-};
+use crate::af::{Ipv4LabeledUnicast, Ipv4Unicast, Ipv6LabeledUnicast, Ipv6Unicast};
 use crate::instance::{Instance, InstanceUpView};
 use crate::neighbor::{Neighbor, PeerType, fsm};
 use crate::network;

--- a/holo-bgp/src/northbound/state.rs
+++ b/holo-bgp/src/northbound/state.rs
@@ -24,7 +24,12 @@ use crate::packet::iana::{Afi, Safi};
 use crate::packet::message::{AddPathTuple, Capability};
 use crate::rib::{AttrSet, Destination, LocalRoute, Route};
 
-pub static AFI_SAFIS: [AfiSafi; 2] = [AfiSafi::Ipv4Unicast, AfiSafi::Ipv6Unicast];
+pub static AFI_SAFIS: [AfiSafi; 4] = [
+    AfiSafi::Ipv4Unicast,
+    AfiSafi::Ipv6Unicast,
+    AfiSafi::Ipv4LabeledUnicast,
+    AfiSafi::Ipv6LabeledUnicast,
+];
 
 impl Provider for Instance {
     type ListEntry<'a> = yang_gen::ops::ListEntry<'a>;
@@ -62,6 +67,12 @@ impl<'a> YangContainer<'a, Instance> for bgp::global::afi_safis::afi_safi::stati
         let total_prefixes = match afi_safi {
             AfiSafi::Ipv4Unicast => rib.tables.ipv4_unicast.prefixes.len(),
             AfiSafi::Ipv6Unicast => rib.tables.ipv6_unicast.prefixes.len(),
+            AfiSafi::Ipv4LabeledUnicast => {
+                rib.tables.ipv4_labeled_unicast.prefixes.len()
+            }
+            AfiSafi::Ipv6LabeledUnicast => {
+                rib.tables.ipv6_labeled_unicast.prefixes.len()
+            }
         };
         Some(Self {
             total_paths: None, // TODO
@@ -77,7 +88,12 @@ impl<'a> YangContainer<'a, Instance> for bgp::global::statistics::Statistics {
         let rib = &instance.state.as_ref()?.rib;
         let total_ipv4 = rib.tables.ipv4_unicast.prefixes.len();
         let total_ipv6 = rib.tables.ipv6_unicast.prefixes.len();
-        let total_prefixes = total_ipv4 as u32 + total_ipv6 as u32;
+        let total_ipv4_lu = rib.tables.ipv4_labeled_unicast.prefixes.len();
+        let total_ipv6_lu = rib.tables.ipv6_labeled_unicast.prefixes.len();
+        let total_prefixes = total_ipv4 as u32
+            + total_ipv6 as u32
+            + total_ipv4_lu as u32
+            + total_ipv6_lu as u32;
         Some(Self {
             total_paths: None, // TODO
             total_prefixes: Some(total_prefixes),
@@ -172,6 +188,12 @@ impl<'a> YangContainer<'a, Instance> for bgp::neighbors::neighbor::afi_safis::af
         let (r, s, i) = match afi_safi {
             AfiSafi::Ipv4Unicast => count_stats(&rib.tables.ipv4_unicast.prefixes, &nbr.remote_addr),
             AfiSafi::Ipv6Unicast => count_stats(&rib.tables.ipv6_unicast.prefixes, &nbr.remote_addr),
+            AfiSafi::Ipv4LabeledUnicast => {
+                count_stats(&rib.tables.ipv4_labeled_unicast.prefixes, &nbr.remote_addr)
+            }
+            AfiSafi::Ipv6LabeledUnicast => {
+                count_stats(&rib.tables.ipv6_labeled_unicast.prefixes, &nbr.remote_addr)
+            }
         };
         Some(Self {
             received: Some(r),
@@ -1118,6 +1140,12 @@ fn afi_safi_tuple(afi: Afi, safi: Safi) -> Option<AfiSafi> {
     match (afi, safi) {
         (Afi::Ipv4, Safi::Unicast) => Some(AfiSafi::Ipv4Unicast),
         (Afi::Ipv6, Safi::Unicast) => Some(AfiSafi::Ipv6Unicast),
+        (Afi::Ipv4, Safi::LabeledUnicast) => {
+            Some(AfiSafi::Ipv4LabeledUnicast)
+        }
+        (Afi::Ipv6, Safi::LabeledUnicast) => {
+            Some(AfiSafi::Ipv6LabeledUnicast)
+        }
         _ => None,
     }
 }

--- a/holo-bgp/src/northbound/state.rs
+++ b/holo-bgp/src/northbound/state.rs
@@ -24,12 +24,7 @@ use crate::packet::iana::{Afi, Safi};
 use crate::packet::message::{AddPathTuple, Capability};
 use crate::rib::{AttrSet, Destination, LocalRoute, Route};
 
-pub static AFI_SAFIS: [AfiSafi; 4] = [
-    AfiSafi::Ipv4Unicast,
-    AfiSafi::Ipv6Unicast,
-    AfiSafi::Ipv4LabeledUnicast,
-    AfiSafi::Ipv6LabeledUnicast,
-];
+pub static AFI_SAFIS: [AfiSafi; 4] = [AfiSafi::Ipv4Unicast, AfiSafi::Ipv6Unicast, AfiSafi::Ipv4LabeledUnicast, AfiSafi::Ipv6LabeledUnicast];
 
 impl Provider for Instance {
     type ListEntry<'a> = yang_gen::ops::ListEntry<'a>;
@@ -67,12 +62,8 @@ impl<'a> YangContainer<'a, Instance> for bgp::global::afi_safis::afi_safi::stati
         let total_prefixes = match afi_safi {
             AfiSafi::Ipv4Unicast => rib.tables.ipv4_unicast.prefixes.len(),
             AfiSafi::Ipv6Unicast => rib.tables.ipv6_unicast.prefixes.len(),
-            AfiSafi::Ipv4LabeledUnicast => {
-                rib.tables.ipv4_labeled_unicast.prefixes.len()
-            }
-            AfiSafi::Ipv6LabeledUnicast => {
-                rib.tables.ipv6_labeled_unicast.prefixes.len()
-            }
+            AfiSafi::Ipv4LabeledUnicast => rib.tables.ipv4_labeled_unicast.prefixes.len(),
+            AfiSafi::Ipv6LabeledUnicast => rib.tables.ipv6_labeled_unicast.prefixes.len(),
         };
         Some(Self {
             total_paths: None, // TODO
@@ -90,10 +81,7 @@ impl<'a> YangContainer<'a, Instance> for bgp::global::statistics::Statistics {
         let total_ipv6 = rib.tables.ipv6_unicast.prefixes.len();
         let total_ipv4_lu = rib.tables.ipv4_labeled_unicast.prefixes.len();
         let total_ipv6_lu = rib.tables.ipv6_labeled_unicast.prefixes.len();
-        let total_prefixes = total_ipv4 as u32
-            + total_ipv6 as u32
-            + total_ipv4_lu as u32
-            + total_ipv6_lu as u32;
+        let total_prefixes = total_ipv4 as u32 + total_ipv6 as u32 + total_ipv4_lu as u32 + total_ipv6_lu as u32;
         Some(Self {
             total_paths: None, // TODO
             total_prefixes: Some(total_prefixes),
@@ -188,12 +176,8 @@ impl<'a> YangContainer<'a, Instance> for bgp::neighbors::neighbor::afi_safis::af
         let (r, s, i) = match afi_safi {
             AfiSafi::Ipv4Unicast => count_stats(&rib.tables.ipv4_unicast.prefixes, &nbr.remote_addr),
             AfiSafi::Ipv6Unicast => count_stats(&rib.tables.ipv6_unicast.prefixes, &nbr.remote_addr),
-            AfiSafi::Ipv4LabeledUnicast => {
-                count_stats(&rib.tables.ipv4_labeled_unicast.prefixes, &nbr.remote_addr)
-            }
-            AfiSafi::Ipv6LabeledUnicast => {
-                count_stats(&rib.tables.ipv6_labeled_unicast.prefixes, &nbr.remote_addr)
-            }
+            AfiSafi::Ipv4LabeledUnicast => count_stats(&rib.tables.ipv4_labeled_unicast.prefixes, &nbr.remote_addr),
+            AfiSafi::Ipv6LabeledUnicast => count_stats(&rib.tables.ipv6_labeled_unicast.prefixes, &nbr.remote_addr),
         };
         Some(Self {
             received: Some(r),
@@ -1140,12 +1124,8 @@ fn afi_safi_tuple(afi: Afi, safi: Safi) -> Option<AfiSafi> {
     match (afi, safi) {
         (Afi::Ipv4, Safi::Unicast) => Some(AfiSafi::Ipv4Unicast),
         (Afi::Ipv6, Safi::Unicast) => Some(AfiSafi::Ipv6Unicast),
-        (Afi::Ipv4, Safi::LabeledUnicast) => {
-            Some(AfiSafi::Ipv4LabeledUnicast)
-        }
-        (Afi::Ipv6, Safi::LabeledUnicast) => {
-            Some(AfiSafi::Ipv6LabeledUnicast)
-        }
+        (Afi::Ipv4, Safi::LabeledUnicast) => Some(AfiSafi::Ipv4LabeledUnicast),
+        (Afi::Ipv6, Safi::LabeledUnicast) => Some(AfiSafi::Ipv6LabeledUnicast),
         _ => None,
     }
 }

--- a/holo-bgp/src/northbound/state.rs
+++ b/holo-bgp/src/northbound/state.rs
@@ -4,6 +4,7 @@
 // SPDX-License-Identifier: MIT
 //
 
+use std::collections::BTreeMap;
 use std::net::IpAddr;
 use std::sync::{Arc, atomic};
 
@@ -14,7 +15,6 @@ use holo_utils::protocol::Protocol;
 use holo_yang::ToYang;
 use holo_yang::types::{Base64Str, Timeticks};
 use ipnetwork::{Ipv4Network, Ipv6Network};
-use prefix_trie::PrefixMap;
 
 use crate::instance::Instance;
 use crate::neighbor::{Neighbor, fsm};
@@ -160,9 +160,9 @@ impl<'a> YangContainer<'a, Instance> for bgp::neighbors::neighbor::afi_safis::af
 
     fn new(instance: &'a Instance, (nbr, afi_safi): &Self::ParentListEntry) -> Option<Self> {
         let rib = &instance.state.as_ref()?.rib;
-        fn count_stats<K>(prefixes: &PrefixMap<K, Destination>, addr: &IpAddr) -> (u32, u32, u32)
+        fn count_stats<K>(prefixes: &BTreeMap<K, Destination>, addr: &IpAddr) -> (u32, u32, u32)
         where
-            K: prefix_trie::Prefix,
+            K: Ord,
         {
             prefixes
                 .values()
@@ -574,7 +574,7 @@ impl<'a> YangList<'a, Instance> for bgp::rib::afi_safis::afi_safi::ipv4_unicast:
         }
         let rib = &instance.state.as_ref()?.rib;
         let iter = rib.tables.ipv4_unicast.prefixes.iter();
-        let iter = iter.filter_map(|(prefix, dest)| dest.local.as_ref().map(|route| (prefix, route)));
+        let iter = iter.filter_map(|(prefix, dest)| dest.local.as_ref().map(|route| (*prefix, route)));
         Some(iter)
     }
 
@@ -644,7 +644,7 @@ impl<'a> YangList<'a, Instance> for bgp::rib::afi_safis::afi_safi::ipv4_unicast:
     fn iter(instance: &'a Instance, &nbr: &Self::ParentListEntry) -> Option<impl ListIterator<'a, Self::ListEntry>> {
         let rib = &instance.state.as_ref()?.rib;
         let iter = rib.tables.ipv4_unicast.prefixes.iter();
-        let iter = iter.filter_map(move |(prefix, dest)| dest.adj_rib.get(&nbr.remote_addr).and_then(|adj_rib| adj_rib.in_pre()).map(|route| (prefix, route)));
+        let iter = iter.filter_map(move |(prefix, dest)| dest.adj_rib.get(&nbr.remote_addr).and_then(|adj_rib| adj_rib.in_pre()).map(|route| (*prefix, route)));
         Some(iter)
     }
 
@@ -694,7 +694,7 @@ impl<'a> YangList<'a, Instance> for bgp::rib::afi_safis::afi_safi::ipv4_unicast:
     fn iter(instance: &'a Instance, &nbr: &Self::ParentListEntry) -> Option<impl ListIterator<'a, Self::ListEntry>> {
         let rib = &instance.state.as_ref()?.rib;
         let iter = rib.tables.ipv4_unicast.prefixes.iter();
-        let iter = iter.filter_map(move |(prefix, dest)| dest.adj_rib.get(&nbr.remote_addr).and_then(|adj_rib| adj_rib.in_post()).map(|route| (prefix, route)));
+        let iter = iter.filter_map(move |(prefix, dest)| dest.adj_rib.get(&nbr.remote_addr).and_then(|adj_rib| adj_rib.in_post()).map(|route| (*prefix, route)));
         Some(iter)
     }
 
@@ -745,7 +745,7 @@ impl<'a> YangList<'a, Instance> for bgp::rib::afi_safis::afi_safi::ipv4_unicast:
     fn iter(instance: &'a Instance, &nbr: &Self::ParentListEntry) -> Option<impl ListIterator<'a, Self::ListEntry>> {
         let rib = &instance.state.as_ref()?.rib;
         let iter = rib.tables.ipv4_unicast.prefixes.iter();
-        let iter = iter.filter_map(move |(prefix, dest)| dest.adj_rib.get(&nbr.remote_addr).and_then(|adj_rib| adj_rib.out_pre()).map(|route| (prefix, route)));
+        let iter = iter.filter_map(move |(prefix, dest)| dest.adj_rib.get(&nbr.remote_addr).and_then(|adj_rib| adj_rib.out_pre()).map(|route| (*prefix, route)));
         Some(iter)
     }
 
@@ -795,7 +795,7 @@ impl<'a> YangList<'a, Instance> for bgp::rib::afi_safis::afi_safi::ipv4_unicast:
     fn iter(instance: &'a Instance, &nbr: &Self::ParentListEntry) -> Option<impl ListIterator<'a, Self::ListEntry>> {
         let rib = &instance.state.as_ref()?.rib;
         let iter = rib.tables.ipv4_unicast.prefixes.iter();
-        let iter = iter.filter_map(move |(prefix, dest)| dest.adj_rib.get(&nbr.remote_addr).and_then(|adj_rib| adj_rib.out_post()).map(|route| (prefix, route)));
+        let iter = iter.filter_map(move |(prefix, dest)| dest.adj_rib.get(&nbr.remote_addr).and_then(|adj_rib| adj_rib.out_post()).map(|route| (*prefix, route)));
         Some(iter)
     }
 
@@ -848,7 +848,7 @@ impl<'a> YangList<'a, Instance> for bgp::rib::afi_safis::afi_safi::ipv6_unicast:
         }
         let rib = &instance.state.as_ref()?.rib;
         let iter = rib.tables.ipv6_unicast.prefixes.iter();
-        let iter = iter.filter_map(|(prefix, dest)| dest.local.as_ref().map(|route| (prefix, route)));
+        let iter = iter.filter_map(|(prefix, dest)| dest.local.as_ref().map(|route| (*prefix, route)));
         Some(iter)
     }
 
@@ -918,7 +918,7 @@ impl<'a> YangList<'a, Instance> for bgp::rib::afi_safis::afi_safi::ipv6_unicast:
     fn iter(instance: &'a Instance, &nbr: &Self::ParentListEntry) -> Option<impl ListIterator<'a, Self::ListEntry>> {
         let rib = &instance.state.as_ref()?.rib;
         let iter = rib.tables.ipv6_unicast.prefixes.iter();
-        let iter = iter.filter_map(move |(prefix, dest)| dest.adj_rib.get(&nbr.remote_addr).and_then(|adj_rib| adj_rib.in_pre()).map(|route| (prefix, route)));
+        let iter = iter.filter_map(move |(prefix, dest)| dest.adj_rib.get(&nbr.remote_addr).and_then(|adj_rib| adj_rib.in_pre()).map(|route| (*prefix, route)));
         Some(iter)
     }
 
@@ -968,7 +968,7 @@ impl<'a> YangList<'a, Instance> for bgp::rib::afi_safis::afi_safi::ipv6_unicast:
     fn iter(instance: &'a Instance, &nbr: &Self::ParentListEntry) -> Option<impl ListIterator<'a, Self::ListEntry>> {
         let rib = &instance.state.as_ref()?.rib;
         let iter = rib.tables.ipv6_unicast.prefixes.iter();
-        let iter = iter.filter_map(move |(prefix, dest)| dest.adj_rib.get(&nbr.remote_addr).and_then(|adj_rib| adj_rib.in_post()).map(|route| (prefix, route)));
+        let iter = iter.filter_map(move |(prefix, dest)| dest.adj_rib.get(&nbr.remote_addr).and_then(|adj_rib| adj_rib.in_post()).map(|route| (*prefix, route)));
         Some(iter)
     }
 
@@ -1019,7 +1019,7 @@ impl<'a> YangList<'a, Instance> for bgp::rib::afi_safis::afi_safi::ipv6_unicast:
     fn iter(instance: &'a Instance, &nbr: &Self::ParentListEntry) -> Option<impl ListIterator<'a, Self::ListEntry>> {
         let rib = &instance.state.as_ref()?.rib;
         let iter = rib.tables.ipv6_unicast.prefixes.iter();
-        let iter = iter.filter_map(move |(prefix, dest)| dest.adj_rib.get(&nbr.remote_addr).and_then(|adj_rib| adj_rib.out_pre()).map(|route| (prefix, route)));
+        let iter = iter.filter_map(move |(prefix, dest)| dest.adj_rib.get(&nbr.remote_addr).and_then(|adj_rib| adj_rib.out_pre()).map(|route| (*prefix, route)));
         Some(iter)
     }
 
@@ -1069,7 +1069,7 @@ impl<'a> YangList<'a, Instance> for bgp::rib::afi_safis::afi_safi::ipv6_unicast:
     fn iter(instance: &'a Instance, &nbr: &Self::ParentListEntry) -> Option<impl ListIterator<'a, Self::ListEntry>> {
         let rib = &instance.state.as_ref()?.rib;
         let iter = rib.tables.ipv6_unicast.prefixes.iter();
-        let iter = iter.filter_map(move |(prefix, dest)| dest.adj_rib.get(&nbr.remote_addr).and_then(|adj_rib| adj_rib.out_post()).map(|route| (prefix, route)));
+        let iter = iter.filter_map(move |(prefix, dest)| dest.adj_rib.get(&nbr.remote_addr).and_then(|adj_rib| adj_rib.out_post()).map(|route| (*prefix, route)));
         Some(iter)
     }
 

--- a/holo-bgp/src/packet/attribute.rs
+++ b/holo-bgp/src/packet/attribute.rs
@@ -23,8 +23,9 @@ use crate::packet::error::{AttrError, UpdateMessageError};
 use crate::packet::iana::{Afi, AttrType, Origin, Safi};
 use crate::packet::message::{
     DecodeCxt, EncodeCxt, MpReachNlri, MpUnreachNlri, NegotiatedCapability,
-    ReachNlri, decode_ipv4_prefix, decode_ipv6_prefix, encode_ipv4_prefix,
-    encode_ipv6_prefix,
+    ReachNlri, decode_ipv4_prefix, decode_ipv6_prefix,
+    decode_labeled_ipv4_prefix, decode_labeled_ipv6_prefix, encode_ipv4_prefix,
+    encode_ipv6_prefix, encode_labeled_ipv4_prefix, encode_labeled_ipv6_prefix,
 };
 
 pub const ATTR_MIN_LEN: u16 = 3;
@@ -1145,6 +1146,36 @@ impl MpReachNlri {
                     encode_ipv6_prefix(buf, prefix);
                 }
             }
+            MpReachNlri::Ipv4LabeledUnicast { prefixes, nexthop } => {
+                buf.put_u16(Afi::Ipv4 as u16);
+                buf.put_u8(Safi::LabeledUnicast as u8);
+                buf.put_u8(Ipv4Addr::LENGTH as u8);
+                buf.put_ipv4(nexthop);
+                buf.put_u8(0);
+                for prefix in prefixes {
+                    encode_labeled_ipv4_prefix(buf, prefix);
+                }
+            }
+            MpReachNlri::Ipv6LabeledUnicast {
+                prefixes,
+                nexthop,
+                ll_nexthop,
+            } => {
+                buf.put_u16(Afi::Ipv6 as u16);
+                buf.put_u8(Safi::LabeledUnicast as u8);
+                if let Some(ll_nexthop) = ll_nexthop {
+                    buf.put_u8((Ipv6Addr::LENGTH * 2) as u8);
+                    buf.put_ipv6(nexthop);
+                    buf.put_ipv6(ll_nexthop);
+                } else {
+                    buf.put_u8(Ipv6Addr::LENGTH as u8);
+                    buf.put_ipv6(nexthop);
+                }
+                buf.put_u8(0);
+                for prefix in prefixes {
+                    encode_labeled_ipv6_prefix(buf, prefix);
+                }
+            }
         }
 
         // Rewrite attribute length.
@@ -1169,13 +1200,13 @@ impl MpReachNlri {
 
         // Parse SAFI.
         let safi = buf.try_get_u8()?;
-        if Safi::from_u8(safi) != Some(Safi::Unicast) {
+        let Some(safi) = Safi::from_u8(safi) else {
             // Ignore unsupported SAFI.
             return Err(AttrError::Discard);
         };
 
-        match afi {
-            Afi::Ipv4 => {
+        match (afi, safi) {
+            (Afi::Ipv4, Safi::Unicast) => {
                 let mut prefixes = Vec::new();
 
                 // Parse nexthop.
@@ -1200,7 +1231,7 @@ impl MpReachNlri {
                 *mp_reach =
                     Some(MpReachNlri::Ipv4Unicast { prefixes, nexthop });
             }
-            Afi::Ipv6 => {
+            (Afi::Ipv6, Safi::Unicast) => {
                 let mut prefixes = Vec::new();
                 let mut ll_nexthop = None;
 
@@ -1233,6 +1264,61 @@ impl MpReachNlri {
                     ll_nexthop,
                 });
             }
+            (Afi::Ipv4, Safi::LabeledUnicast) => {
+                let mut prefixes = Vec::new();
+
+                let nexthop_len = buf.try_get_u8()?;
+                if nexthop_len as usize != Ipv4Addr::LENGTH
+                    || nexthop_len as usize > buf.remaining()
+                {
+                    return Err(AttrError::Reset);
+                }
+                let nexthop = buf.try_get_ipv4()?;
+
+                let _reserved = buf.try_get_u8()?;
+                while buf.remaining() > 0 {
+                    if let Some(prefix) = decode_labeled_ipv4_prefix(buf)
+                        .map_err(|_| AttrError::Reset)?
+                    {
+                        prefixes.push(prefix);
+                    }
+                }
+
+                *mp_reach =
+                    Some(MpReachNlri::Ipv4LabeledUnicast { prefixes, nexthop });
+            }
+            (Afi::Ipv6, Safi::LabeledUnicast) => {
+                let mut prefixes = Vec::new();
+                let mut ll_nexthop = None;
+
+                let nexthop_len = buf.try_get_u8()? as usize;
+                if (nexthop_len != Ipv6Addr::LENGTH
+                    && nexthop_len != Ipv6Addr::LENGTH * 2)
+                    || nexthop_len > buf.remaining()
+                {
+                    return Err(AttrError::Reset);
+                }
+                let nexthop = buf.try_get_ipv6()?;
+                if nexthop_len == Ipv6Addr::LENGTH * 2 {
+                    ll_nexthop = Some(buf.try_get_ipv6()?);
+                }
+
+                let _reserved = buf.try_get_u8()?;
+                while buf.remaining() > 0 {
+                    if let Some(prefix) = decode_labeled_ipv6_prefix(buf)
+                        .map_err(|_| AttrError::Reset)?
+                    {
+                        prefixes.push(prefix);
+                    }
+                }
+
+                *mp_reach = Some(MpReachNlri::Ipv6LabeledUnicast {
+                    prefixes,
+                    nexthop,
+                    ll_nexthop,
+                });
+            }
+            _ => return Err(AttrError::Discard),
         }
 
         Ok(())
@@ -1268,6 +1354,20 @@ impl MpUnreachNlri {
                     encode_ipv6_prefix(buf, prefix);
                 }
             }
+            MpUnreachNlri::Ipv4LabeledUnicast { prefixes } => {
+                buf.put_u16(Afi::Ipv4 as u16);
+                buf.put_u8(Safi::LabeledUnicast as u8);
+                for prefix in prefixes {
+                    encode_labeled_ipv4_prefix(buf, prefix);
+                }
+            }
+            MpUnreachNlri::Ipv6LabeledUnicast { prefixes } => {
+                buf.put_u16(Afi::Ipv6 as u16);
+                buf.put_u8(Safi::LabeledUnicast as u8);
+                for prefix in prefixes {
+                    encode_labeled_ipv6_prefix(buf, prefix);
+                }
+            }
         }
 
         // Rewrite attribute length.
@@ -1292,14 +1392,14 @@ impl MpUnreachNlri {
 
         // Parse SAFI.
         let safi = buf.try_get_u8()?;
-        if Safi::from_u8(safi) != Some(Safi::Unicast) {
+        let Some(safi) = Safi::from_u8(safi) else {
             // Ignore unsupported SAFI.
             return Err(AttrError::Discard);
         };
 
         // Parse prefixes.
-        match afi {
-            Afi::Ipv4 => {
+        match (afi, safi) {
+            (Afi::Ipv4, Safi::Unicast) => {
                 let mut prefixes = Vec::new();
 
                 while buf.remaining() > 0 {
@@ -1312,7 +1412,7 @@ impl MpUnreachNlri {
 
                 *mp_unreach = Some(MpUnreachNlri::Ipv4Unicast { prefixes });
             }
-            Afi::Ipv6 => {
+            (Afi::Ipv6, Safi::Unicast) => {
                 let mut prefixes = Vec::new();
 
                 while buf.remaining() > 0 {
@@ -1325,6 +1425,35 @@ impl MpUnreachNlri {
 
                 *mp_unreach = Some(MpUnreachNlri::Ipv6Unicast { prefixes });
             }
+            (Afi::Ipv4, Safi::LabeledUnicast) => {
+                let mut prefixes = Vec::new();
+
+                while buf.remaining() > 0 {
+                    if let Some(prefix) = decode_labeled_ipv4_prefix(buf)
+                        .map_err(|_| AttrError::Reset)?
+                    {
+                        prefixes.push(prefix);
+                    }
+                }
+
+                *mp_unreach =
+                    Some(MpUnreachNlri::Ipv4LabeledUnicast { prefixes });
+            }
+            (Afi::Ipv6, Safi::LabeledUnicast) => {
+                let mut prefixes = Vec::new();
+
+                while buf.remaining() > 0 {
+                    if let Some(prefix) = decode_labeled_ipv6_prefix(buf)
+                        .map_err(|_| AttrError::Reset)?
+                    {
+                        prefixes.push(prefix);
+                    }
+                }
+
+                *mp_unreach =
+                    Some(MpUnreachNlri::Ipv6LabeledUnicast { prefixes });
+            }
+            _ => return Err(AttrError::Discard),
         }
 
         Ok(())

--- a/holo-bgp/src/packet/message.rs
+++ b/holo-bgp/src/packet/message.rs
@@ -14,6 +14,7 @@ use holo_utils::bytes::{BytesExt, BytesMutExt, TLS_BUF};
 use holo_utils::ip::{
     Ipv4AddrExt, Ipv4NetworkExt, Ipv6AddrExt, Ipv6NetworkExt,
 };
+use holo_utils::mpls::Label;
 use ipnetwork::{Ipv4Network, Ipv6Network};
 use num_derive::{FromPrimitive, ToPrimitive};
 use num_traits::{FromPrimitive, ToPrimitive};
@@ -210,6 +211,15 @@ pub enum MpReachNlri {
         nexthop: Ipv6Addr,
         ll_nexthop: Option<Ipv6Addr>,
     },
+    Ipv4LabeledUnicast {
+        prefixes: Vec<LabeledIpv4Nlri>,
+        nexthop: Ipv4Addr,
+    },
+    Ipv6LabeledUnicast {
+        prefixes: Vec<LabeledIpv6Nlri>,
+        nexthop: Ipv6Addr,
+        ll_nexthop: Option<Ipv6Addr>,
+    },
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -217,6 +227,22 @@ pub enum MpReachNlri {
 pub enum MpUnreachNlri {
     Ipv4Unicast { prefixes: Vec<Ipv4Network> },
     Ipv6Unicast { prefixes: Vec<Ipv6Network> },
+    Ipv4LabeledUnicast { prefixes: Vec<LabeledIpv4Nlri> },
+    Ipv6LabeledUnicast { prefixes: Vec<LabeledIpv6Nlri> },
+}
+
+#[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd)]
+#[derive(Deserialize, Serialize)]
+pub struct LabeledIpv4Nlri {
+    pub label: Label,
+    pub prefix: Ipv4Network,
+}
+
+#[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd)]
+#[derive(Deserialize, Serialize)]
+pub struct LabeledIpv6Nlri {
+    pub label: Label,
+    pub prefix: Ipv6Network,
 }
 
 //
@@ -1025,6 +1051,43 @@ pub(crate) fn encode_ipv6_prefix(buf: &mut BytesMut, prefix: &Ipv6Network) {
     buf.put(&prefix_bytes[0..plen_wire]);
 }
 
+pub(crate) fn encode_labeled_ipv4_prefix(
+    buf: &mut BytesMut,
+    nlri: &LabeledIpv4Nlri,
+) {
+    encode_labeled_prefix(
+        buf,
+        nlri.label,
+        nlri.prefix.prefix(),
+        &nlri.prefix.ip().octets(),
+    );
+}
+
+pub(crate) fn encode_labeled_ipv6_prefix(
+    buf: &mut BytesMut,
+    nlri: &LabeledIpv6Nlri,
+) {
+    encode_labeled_prefix(
+        buf,
+        nlri.label,
+        nlri.prefix.prefix(),
+        &nlri.prefix.ip().octets(),
+    );
+}
+
+fn encode_labeled_prefix(
+    buf: &mut BytesMut,
+    label: Label,
+    plen: u8,
+    prefix_bytes: &[u8],
+) {
+    let label_entry = (label.get() << 4) | 1;
+    buf.put_u8(plen + 24);
+    buf.put_u24(label_entry);
+    let plen_wire = prefix_wire_len(plen);
+    buf.put(&prefix_bytes[0..plen_wire]);
+}
+
 pub fn decode_ipv4_prefix(
     buf: &mut Bytes,
 ) -> Result<Option<Ipv4Network>, UpdateMessageError> {
@@ -1081,6 +1144,90 @@ pub fn decode_ipv6_prefix(
     let prefix = prefix.apply_mask();
 
     Ok(Some(prefix))
+}
+
+pub fn decode_labeled_ipv4_prefix(
+    buf: &mut Bytes,
+) -> Result<Option<LabeledIpv4Nlri>, UpdateMessageError> {
+    let plen = buf.try_get_u8()?;
+    if plen < 24 {
+        return Err(UpdateMessageError::InvalidNetworkField);
+    }
+
+    let (label, label_len) = decode_label_stack(buf)?;
+    if plen < label_len {
+        return Err(UpdateMessageError::InvalidNetworkField);
+    }
+    let plen = plen - label_len;
+    let plen_wire = prefix_wire_len(plen);
+    if plen_wire > buf.remaining() || plen > Ipv4Network::MAX_PREFIXLEN {
+        return Err(UpdateMessageError::InvalidNetworkField);
+    }
+
+    let mut prefix_bytes = [0; Ipv4Addr::LENGTH];
+    buf.try_copy_to_slice(&mut prefix_bytes[..plen_wire])?;
+    let prefix = Ipv4Network::new(Ipv4Addr::from(prefix_bytes), plen)
+        .map(|prefix| prefix.apply_mask())
+        .map_err(|_| UpdateMessageError::InvalidNetworkField)?;
+
+    if !prefix.is_routable() {
+        return Ok(None);
+    }
+
+    Ok(Some(LabeledIpv4Nlri { label, prefix }))
+}
+
+pub fn decode_labeled_ipv6_prefix(
+    buf: &mut Bytes,
+) -> Result<Option<LabeledIpv6Nlri>, UpdateMessageError> {
+    let plen = buf.try_get_u8()?;
+    if plen < 24 {
+        return Err(UpdateMessageError::InvalidNetworkField);
+    }
+
+    let (label, label_len) = decode_label_stack(buf)?;
+    if plen < label_len {
+        return Err(UpdateMessageError::InvalidNetworkField);
+    }
+    let plen = plen - label_len;
+    let plen_wire = prefix_wire_len(plen);
+    if plen_wire > buf.remaining() || plen > Ipv6Network::MAX_PREFIXLEN {
+        return Err(UpdateMessageError::InvalidNetworkField);
+    }
+
+    let mut prefix_bytes = [0; Ipv6Addr::LENGTH];
+    buf.try_copy_to_slice(&mut prefix_bytes[..plen_wire])?;
+    let prefix = Ipv6Network::new(Ipv6Addr::from(prefix_bytes), plen)
+        .map(|prefix| prefix.apply_mask())
+        .map_err(|_| UpdateMessageError::InvalidNetworkField)?;
+
+    if !prefix.is_routable() {
+        return Ok(None);
+    }
+
+    Ok(Some(LabeledIpv6Nlri { label, prefix }))
+}
+
+fn decode_label_stack(
+    buf: &mut Bytes,
+) -> Result<(Label, u8), UpdateMessageError> {
+    let mut first_label = None;
+    let mut label_len = 0;
+    loop {
+        if buf.remaining() < 3 {
+            return Err(UpdateMessageError::InvalidNetworkField);
+        }
+
+        let entry = buf.try_get_u24()?;
+        label_len += 24;
+        let label = (entry >> 4) & Label::VALUE_MASK;
+        first_label.get_or_insert(Label::new(label));
+        if entry & 1 == 1 {
+            break;
+        }
+    }
+
+    Ok((first_label.unwrap(), label_len))
 }
 
 // Calculates the number of bytes required to encode a prefix.

--- a/holo-bgp/src/policy.rs
+++ b/holo-bgp/src/policy.rs
@@ -11,6 +11,7 @@ use std::sync::Arc;
 use derive_new::new;
 use holo_utils::bgp::{AfiSafi, RouteType};
 use holo_utils::ip::IpNetworkKind;
+use holo_utils::mpls::Label;
 use holo_utils::policy::{
     BgpNexthop, BgpPolicyAction, BgpPolicyCondition, BgpSetCommMethod,
     BgpSetCommOptions, BgpSetMed, DefaultPolicyType, MatchSets,
@@ -36,6 +37,7 @@ use crate::tasks::messages::input::PolicyResultMsg;
 pub struct RoutePolicyInfo {
     pub origin: RouteOrigin,
     pub route_type: RouteType,
+    pub label: Option<Label>,
     pub tag: Option<u32>,
     pub opaque_attrs: Option<RouteOpaqueAttrs>,
     pub attrs: Attrs,

--- a/holo-bgp/src/rib.rs
+++ b/holo-bgp/src/rib.rs
@@ -10,6 +10,7 @@ use std::net::{IpAddr, Ipv4Addr};
 use std::sync::Arc;
 use std::time::Instant;
 
+use holo_protocol::InstanceShared;
 use holo_utils::bgp::RouteType;
 use holo_utils::ibus::IbusChannelsTx;
 use holo_utils::mpls::Label;
@@ -79,6 +80,7 @@ pub struct LocalRoute {
     pub attrs: RouteAttrs,
     pub route_type: RouteType,
     pub label: Option<Label>,
+    pub nexthop_label: Option<Label>,
     pub last_modified: Instant,
     pub nexthops: Option<BTreeSet<IpAddr>>,
 }
@@ -792,6 +794,7 @@ pub(crate) fn loc_rib_update<A>(
     distance_cfg: &DistanceCfg,
     trace_opts: &InstanceTraceOptions,
     ibus_tx: &IbusChannelsTx,
+    shared: &InstanceShared,
 ) where
     A: AddressFamily,
 {
@@ -810,18 +813,22 @@ pub(crate) fn loc_rib_update<A>(
             && local_route.origin == best_route.origin
             && local_route.attrs == best_route.attrs
             && local_route.route_type == best_route.route_type
-            && local_route.label == best_route.label
+            && local_route.nexthop_label == best_route.label
             && local_route.nexthops == nexthops
         {
             return;
         }
+
+        let local_label = local_label_update::<A>(dest, shared);
+        let old_local_route = dest.local.as_ref().map(|route| &**route);
 
         // Create new local route.
         let local_route = LocalRoute {
             origin: best_route.origin,
             attrs: best_route.attrs,
             route_type: best_route.route_type,
-            label: best_route.label,
+            label: local_label,
+            nexthop_label: best_route.label,
             last_modified: best_route.last_modified,
             nexthops,
         };
@@ -836,6 +843,15 @@ pub(crate) fn loc_rib_update<A>(
                     RouteType::Internal => distance_cfg.internal,
                     RouteType::External => distance_cfg.external,
                 },
+            );
+        }
+
+        if local_route.label.is_some() {
+            ibus::tx::label_install(
+                ibus_tx,
+                A::prefix_to_ip_network(prefix),
+                &local_route,
+                old_local_route,
             );
         }
 
@@ -858,8 +874,39 @@ pub(crate) fn loc_rib_update<A>(
                     A::prefix_to_ip_network(prefix),
                 );
             }
+            if local_route.label.is_some() {
+                ibus::tx::label_uninstall(
+                    ibus_tx,
+                    A::prefix_to_ip_network(prefix),
+                    &local_route,
+                );
+                if let Some(label) = local_route.label {
+                    let mut label_manager =
+                        shared.label_manager.lock().unwrap();
+                    label_manager.label_release(label);
+                }
+            }
         }
     }
+}
+
+fn local_label_update<A>(
+    dest: &Destination,
+    shared: &InstanceShared,
+) -> Option<Label>
+where
+    A: AddressFamily,
+{
+    if A::SAFI != crate::packet::iana::Safi::LabeledUnicast {
+        return None;
+    }
+
+    if let Some(label) = dest.local.as_ref().and_then(|route| route.label) {
+        return Some(label);
+    }
+
+    let mut label_manager = shared.label_manager.lock().unwrap();
+    label_manager.label_request().ok()
 }
 
 pub(crate) fn attrs_tx_update<A>(

--- a/holo-bgp/src/rib.rs
+++ b/holo-bgp/src/rib.rs
@@ -13,7 +13,6 @@ use std::time::Instant;
 use holo_utils::bgp::RouteType;
 use holo_utils::ibus::IbusChannelsTx;
 use holo_utils::protocol::Protocol;
-use prefix_trie::map::PrefixMap;
 use serde::{Deserialize, Serialize};
 
 use crate::af::{AddressFamily, Ipv4Unicast, Ipv6Unicast};
@@ -48,8 +47,8 @@ pub struct RoutingTables {
 
 #[derive(Debug)]
 pub struct RoutingTable<A: AddressFamily> {
-    pub prefixes: PrefixMap<A::IpNetwork, Destination>,
-    pub queued_prefixes: BTreeSet<A::IpNetwork>,
+    pub prefixes: BTreeMap<A::Prefix, Destination>,
+    pub queued_prefixes: BTreeSet<A::Prefix>,
     pub nht: HashMap<IpAddr, NhtEntry<A>>,
 }
 
@@ -135,7 +134,7 @@ pub struct AttrSet<T> {
 #[derive(Debug, Eq, PartialEq)]
 pub struct NhtEntry<A: AddressFamily> {
     pub metric: Option<u32>,
-    pub prefixes: BTreeMap<A::IpNetwork, u32>,
+    pub prefixes: BTreeMap<A::Prefix, u32>,
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -774,7 +773,7 @@ where
 }
 
 pub(crate) fn loc_rib_update<A>(
-    prefix: A::IpNetwork,
+    prefix: A::Prefix,
     dest: &mut Destination,
     best_route: Option<Box<Route>>,
     attr_sets: &mut AttrSetsCxt,
@@ -788,7 +787,8 @@ pub(crate) fn loc_rib_update<A>(
 {
     if let Some(best_route) = best_route {
         if trace_opts.route {
-            Debug::BestPathFound(prefix.into(), &best_route).log();
+            Debug::BestPathFound(A::prefix_to_ip_network(prefix), &best_route)
+                .log();
         }
 
         // Compute route nexthops, considering multipath configuration.
@@ -818,7 +818,7 @@ pub(crate) fn loc_rib_update<A>(
         if !local_route.origin.is_local() {
             ibus::tx::route_install(
                 ibus_tx,
-                prefix,
+                A::prefix_to_ip_network(prefix),
                 &local_route,
                 match best_route.route_type {
                     RouteType::Internal => distance_cfg.internal,
@@ -831,7 +831,7 @@ pub(crate) fn loc_rib_update<A>(
         dest.local = Some(Box::new(local_route));
     } else {
         if trace_opts.route {
-            Debug::BestPathNotFound(prefix.into()).log();
+            Debug::BestPathNotFound(A::prefix_to_ip_network(prefix)).log();
         }
 
         // Remove route from the Loc-RIB.
@@ -841,7 +841,10 @@ pub(crate) fn loc_rib_update<A>(
 
             // Uninstall route from the global RIB.
             if !local_route.origin.is_local() {
-                ibus::tx::route_uninstall(ibus_tx, prefix);
+                ibus::tx::route_uninstall(
+                    ibus_tx,
+                    A::prefix_to_ip_network(prefix),
+                );
             }
         }
     }
@@ -880,7 +883,7 @@ pub(crate) fn attrs_tx_update<A>(
 
 pub(crate) fn nexthop_track<A>(
     nht: &mut HashMap<IpAddr, NhtEntry<A>>,
-    prefix: A::IpNetwork,
+    prefix: A::Prefix,
     route: &Route,
     ibus_tx: &IbusChannelsTx,
 ) where
@@ -896,7 +899,7 @@ pub(crate) fn nexthop_track<A>(
 
 pub(crate) fn nexthop_untrack<A>(
     nht: &mut HashMap<IpAddr, NhtEntry<A>>,
-    prefix: &A::IpNetwork,
+    prefix: &A::Prefix,
     route: &Route,
     ibus_tx: &IbusChannelsTx,
 ) where

--- a/holo-bgp/src/rib.rs
+++ b/holo-bgp/src/rib.rs
@@ -12,10 +12,14 @@ use std::time::Instant;
 
 use holo_utils::bgp::RouteType;
 use holo_utils::ibus::IbusChannelsTx;
+use holo_utils::mpls::Label;
 use holo_utils::protocol::Protocol;
 use serde::{Deserialize, Serialize};
 
-use crate::af::{AddressFamily, Ipv4Unicast, Ipv6Unicast};
+use crate::af::{
+    AddressFamily, Ipv4LabeledUnicast, Ipv4Unicast, Ipv6LabeledUnicast,
+    Ipv6Unicast,
+};
 use crate::debug::Debug;
 use crate::ibus;
 use crate::neighbor::{Neighbor, PeerType};
@@ -43,6 +47,8 @@ pub struct Rib {
 pub struct RoutingTables {
     pub ipv4_unicast: RoutingTable<Ipv4Unicast>,
     pub ipv6_unicast: RoutingTable<Ipv6Unicast>,
+    pub ipv4_labeled_unicast: RoutingTable<Ipv4LabeledUnicast>,
+    pub ipv6_labeled_unicast: RoutingTable<Ipv6LabeledUnicast>,
 }
 
 #[derive(Debug)]
@@ -72,6 +78,7 @@ pub struct LocalRoute {
     pub origin: RouteOrigin,
     pub attrs: RouteAttrs,
     pub route_type: RouteType,
+    pub label: Option<Label>,
     pub last_modified: Instant,
     pub nexthops: Option<BTreeSet<IpAddr>>,
 }
@@ -81,6 +88,7 @@ pub struct Route {
     pub origin: RouteOrigin,
     pub attrs: RouteAttrs,
     pub route_type: RouteType,
+    pub label: Option<Label>,
     pub igp_cost: Option<u32>,
     pub last_modified: Instant,
     pub ineligible_reason: Option<RouteIneligibleReason>,
@@ -303,6 +311,7 @@ impl Route {
             origin,
             attrs,
             route_type,
+            label: None,
             igp_cost: None,
             last_modified: Instant::now(),
             ineligible_reason: None,
@@ -314,6 +323,7 @@ impl Route {
         RoutePolicyInfo {
             origin: self.origin,
             route_type: self.route_type,
+            label: self.label,
             tag: None,
             opaque_attrs: None,
             attrs: self.attrs.get(),
@@ -800,6 +810,7 @@ pub(crate) fn loc_rib_update<A>(
             && local_route.origin == best_route.origin
             && local_route.attrs == best_route.attrs
             && local_route.route_type == best_route.route_type
+            && local_route.label == best_route.label
             && local_route.nexthops == nexthops
         {
             return;
@@ -810,6 +821,7 @@ pub(crate) fn loc_rib_update<A>(
             origin: best_route.origin,
             attrs: best_route.attrs,
             route_type: best_route.route_type,
+            label: best_route.label,
             last_modified: best_route.last_modified,
             nexthops,
         };
@@ -955,6 +967,7 @@ mod tests {
             origin,
             attrs,
             route_type,
+            label: None,
             igp_cost,
             last_modified: Instant::now(),
             ineligible_reason: None,

--- a/holo-bgp/tests/conformance/topologies/lu-1/rt1/config.json
+++ b/holo-bgp/tests/conformance/topologies/lu-1/rt1/config.json
@@ -1,0 +1,60 @@
+{
+  "ietf-interfaces:interfaces": {
+    "interface": [
+      {
+        "name": "lo",
+        "type": "iana-if-type:softwareLoopback",
+        "ietf-ip:ipv4": {}
+      },
+      {
+        "name": "eth-rt2",
+        "type": "iana-if-type:ethernetCsmacd",
+        "ietf-ip:ipv4": {}
+      }
+    ]
+  },
+  "ietf-routing:routing": {
+    "control-plane-protocols": {
+      "control-plane-protocol": [
+        {
+          "type": "ietf-bgp:bgp",
+          "name": "test",
+          "ietf-bgp:bgp": {
+            "global": {
+              "as": 65000,
+              "identifier": "192.0.2.1",
+              "afi-safis": {
+                "afi-safi": [
+                  {
+                    "name": "iana-bgp-types:ipv4-labeled-unicast",
+                    "enabled": true
+                  }
+                ]
+              }
+            },
+            "neighbors": {
+              "neighbor": [
+                {
+                  "remote-address": "198.51.100.2",
+                  "peer-as": 65000,
+                  "afi-safis": {
+                    "afi-safi": [
+                      {
+                        "name": "iana-bgp-types:ipv4-labeled-unicast",
+                        "enabled": true,
+                        "apply-policy": {
+                          "default-import-policy": "accept-route",
+                          "default-export-policy": "accept-route"
+                        }
+                      }
+                    ]
+                  }
+                }
+              ]
+            }
+          }
+        }
+      ]
+    }
+  }
+}

--- a/holo-bgp/tests/conformance/topologies/lu-1/rt1/config.json
+++ b/holo-bgp/tests/conformance/topologies/lu-1/rt1/config.json
@@ -4,12 +4,14 @@
       {
         "name": "lo",
         "type": "iana-if-type:softwareLoopback",
-        "ietf-ip:ipv4": {}
+        "ietf-ip:ipv4": {},
+        "ietf-ip:ipv6": {}
       },
       {
         "name": "eth-rt2",
         "type": "iana-if-type:ethernetCsmacd",
-        "ietf-ip:ipv4": {}
+        "ietf-ip:ipv4": {},
+        "ietf-ip:ipv6": {}
       }
     ]
   },
@@ -28,6 +30,10 @@
                   {
                     "name": "iana-bgp-types:ipv4-labeled-unicast",
                     "enabled": true
+                  },
+                  {
+                    "name": "iana-bgp-types:ipv6-labeled-unicast",
+                    "enabled": true
                   }
                 ]
               }
@@ -41,6 +47,14 @@
                     "afi-safi": [
                       {
                         "name": "iana-bgp-types:ipv4-labeled-unicast",
+                        "enabled": true,
+                        "apply-policy": {
+                          "default-import-policy": "accept-route",
+                          "default-export-policy": "accept-route"
+                        }
+                      },
+                      {
+                        "name": "iana-bgp-types:ipv6-labeled-unicast",
                         "enabled": true,
                         "apply-policy": {
                           "default-import-policy": "accept-route",

--- a/holo-bgp/tests/conformance/topologies/lu-1/rt1/events.jsonl
+++ b/holo-bgp/tests/conformance/topologies/lu-1/rt1/events.jsonl
@@ -2,9 +2,12 @@
 {"Protocol":{"TriggerDecisionProcess":null}}
 {"Protocol":{"NbrTimer":{"nbr_addr":"198.51.100.2","timer":"AutoStart"}}}
 {"Protocol":{"TcpAccept":{"conn_info":{"local_addr":"198.51.100.1","local_port":179,"remote_addr":"198.51.100.2","remote_port":41200}}}}
-{"Protocol":{"NbrRx":{"nbr_addr":"198.51.100.2","msg":{"Ok":{"Open":{"version":4,"my_as":65000,"holdtime":90,"identifier":"192.0.2.2","capabilities":[{"MultiProtocol":{"afi":"Ipv4","safi":"LabeledUnicast"}},{"FourOctetAsNumber":{"asn":65000}},"RouteRefresh"]}}}}}}
+{"Protocol":{"NbrRx":{"nbr_addr":"198.51.100.2","msg":{"Ok":{"Open":{"version":4,"my_as":65000,"holdtime":90,"identifier":"192.0.2.2","capabilities":[{"MultiProtocol":{"afi":"Ipv4","safi":"LabeledUnicast"}},{"MultiProtocol":{"afi":"Ipv6","safi":"LabeledUnicast"}},{"FourOctetAsNumber":{"asn":65000}},"RouteRefresh"]}}}}}}
 {"Protocol":{"NbrRx":{"nbr_addr":"198.51.100.2","msg":{"Ok":{"Keepalive":{}}}}}}
 {"Protocol":{"NbrRx":{"nbr_addr":"198.51.100.2","msg":{"Ok":{"Update":{"mp_reach":{"Ipv4LabeledUnicast":{"prefixes":[{"label":16000,"prefix":"192.0.2.0/24"}],"nexthop":"198.51.100.2"}},"attrs":{"base":{"origin":"Igp","as_path":{"segments":[]}}}}}}}}}
 {"Protocol":{"PolicyResult":{"Neighbor":{"policy_type":"Import","nbr_addr":"198.51.100.2","afi_safi":"Ipv4LabeledUnicast","routes":[["192.0.2.0/24",{"Accept":{"origin":{"Neighbor":{"identifier":"192.0.2.2","remote_addr":"198.51.100.2"}},"route_type":"Internal","attrs":{"base":{"origin":"Igp","as_path":{"segments":[]},"nexthop":"198.51.100.2"}},"label":16000}}]]}}}}
+{"Protocol":{"NbrRx":{"nbr_addr":"198.51.100.2","msg":{"Ok":{"Update":{"mp_reach":{"Ipv6LabeledUnicast":{"prefixes":[{"label":16001,"prefix":"2001:db8:100::/64"}],"nexthop":"2001:db8::2","ll_nexthop":null}},"attrs":{"base":{"origin":"Igp","as_path":{"segments":[]}}}}}}}}}
+{"Protocol":{"PolicyResult":{"Neighbor":{"policy_type":"Import","nbr_addr":"198.51.100.2","afi_safi":"Ipv6LabeledUnicast","routes":[["2001:db8:100::/64",{"Accept":{"origin":{"Neighbor":{"identifier":"192.0.2.2","remote_addr":"198.51.100.2"}},"route_type":"Internal","attrs":{"base":{"origin":"Igp","as_path":{"segments":[]},"nexthop":"2001:db8::2"}},"label":16001}}]]}}}}
 {"Ibus":{"NexthopUpd":{"addr":"198.51.100.2","metric":0}}}
+{"Ibus":{"NexthopUpd":{"addr":"2001:db8::2","metric":0}}}
 {"Protocol":{"TriggerDecisionProcess":null}}

--- a/holo-bgp/tests/conformance/topologies/lu-1/rt1/events.jsonl
+++ b/holo-bgp/tests/conformance/topologies/lu-1/rt1/events.jsonl
@@ -1,0 +1,10 @@
+{"Ibus":{"RouterIdUpdate":"192.0.2.1"}}
+{"Protocol":{"TriggerDecisionProcess":null}}
+{"Protocol":{"NbrTimer":{"nbr_addr":"198.51.100.2","timer":"AutoStart"}}}
+{"Protocol":{"TcpAccept":{"conn_info":{"local_addr":"198.51.100.1","local_port":179,"remote_addr":"198.51.100.2","remote_port":41200}}}}
+{"Protocol":{"NbrRx":{"nbr_addr":"198.51.100.2","msg":{"Ok":{"Open":{"version":4,"my_as":65000,"holdtime":90,"identifier":"192.0.2.2","capabilities":[{"MultiProtocol":{"afi":"Ipv4","safi":"LabeledUnicast"}},{"FourOctetAsNumber":{"asn":65000}},"RouteRefresh"]}}}}}}
+{"Protocol":{"NbrRx":{"nbr_addr":"198.51.100.2","msg":{"Ok":{"Keepalive":{}}}}}}
+{"Protocol":{"NbrRx":{"nbr_addr":"198.51.100.2","msg":{"Ok":{"Update":{"mp_reach":{"Ipv4LabeledUnicast":{"prefixes":[{"label":16000,"prefix":"192.0.2.0/24"}],"nexthop":"198.51.100.2"}},"attrs":{"base":{"origin":"Igp","as_path":{"segments":[]}}}}}}}}}
+{"Protocol":{"PolicyResult":{"Neighbor":{"policy_type":"Import","nbr_addr":"198.51.100.2","afi_safi":"Ipv4LabeledUnicast","routes":[["192.0.2.0/24",{"Accept":{"origin":{"Neighbor":{"identifier":"192.0.2.2","remote_addr":"198.51.100.2"}},"route_type":"Internal","attrs":{"base":{"origin":"Igp","as_path":{"segments":[]},"nexthop":"198.51.100.2"}},"label":16000}}]]}}}}
+{"Ibus":{"NexthopUpd":{"addr":"198.51.100.2","metric":0}}}
+{"Protocol":{"TriggerDecisionProcess":null}}

--- a/holo-bgp/tests/conformance/topologies/lu-1/rt1/output/ibus.jsonl
+++ b/holo-bgp/tests/conformance/topologies/lu-1/rt1/output/ibus.jsonl
@@ -1,4 +1,7 @@
 {"RouterIdSub":{}}
 {"NexthopTrack":{"addr":"198.51.100.2"}}
+{"NexthopTrack":{"addr":"2001:db8::2"}}
 {"RouteIpAdd":{"protocol":"bgp","prefix":"192.0.2.0/24","distance":200,"metric":0,"tag":null,"nexthops":[{"Recursive":{"addr":"198.51.100.2","labels":[16000],"resolved":[]}}]}}
 {"RouteMplsAdd":{"protocol":"bgp","label":16,"nexthops":[{"Recursive":{"addr":"198.51.100.2","labels":[16000],"resolved":[]}}],"route":["bgp","192.0.2.0/24"],"replace":true}}
+{"RouteIpAdd":{"protocol":"bgp","prefix":"2001:db8:100::/64","distance":200,"metric":0,"tag":null,"nexthops":[{"Recursive":{"addr":"2001:db8::2","labels":[16001],"resolved":[]}}]}}
+{"RouteMplsAdd":{"protocol":"bgp","label":17,"nexthops":[{"Recursive":{"addr":"2001:db8::2","labels":[16001],"resolved":[]}}],"route":["bgp","2001:db8:100::/64"],"replace":true}}

--- a/holo-bgp/tests/conformance/topologies/lu-1/rt1/output/ibus.jsonl
+++ b/holo-bgp/tests/conformance/topologies/lu-1/rt1/output/ibus.jsonl
@@ -1,0 +1,4 @@
+{"RouterIdSub":{}}
+{"NexthopTrack":{"addr":"198.51.100.2"}}
+{"RouteIpAdd":{"protocol":"bgp","prefix":"192.0.2.0/24","distance":200,"metric":0,"tag":null,"nexthops":[{"Recursive":{"addr":"198.51.100.2","labels":[16000],"resolved":[]}}]}}
+{"RouteMplsAdd":{"protocol":"bgp","label":16,"nexthops":[{"Recursive":{"addr":"198.51.100.2","labels":[16000],"resolved":[]}}],"route":["bgp","192.0.2.0/24"],"replace":true}}

--- a/holo-bgp/tests/conformance/topologies/lu-1/rt1/output/northbound-notif.jsonl
+++ b/holo-bgp/tests/conformance/topologies/lu-1/rt1/output/northbound-notif.jsonl
@@ -1,0 +1,1 @@
+{"ietf-routing:routing":{"control-plane-protocols":{"control-plane-protocol":[{"type":"ietf-bgp:bgp","name":"test","ietf-bgp:bgp":{"neighbors":{"established":{"remote-address":"198.51.100.2"}}}}]}}}

--- a/holo-bgp/tests/conformance/topologies/lu-1/rt1/output/northbound-state.json
+++ b/holo-bgp/tests/conformance/topologies/lu-1/rt1/output/northbound-state.json
@@ -1,0 +1,140 @@
+{
+  "ietf-routing:routing": {
+    "control-plane-protocols": {
+      "control-plane-protocol": [
+        {
+          "type": "ietf-bgp:bgp",
+          "name": "test",
+          "ietf-bgp:bgp": {
+            "global": {
+              "afi-safis": {
+                "afi-safi": [
+                  {
+                    "name": "iana-bgp-types:ipv4-labeled-unicast",
+                    "statistics": {
+                      "total-prefixes": 1
+                    }
+                  }
+                ]
+              },
+              "statistics": {
+                "total-prefixes": 1
+              }
+            },
+            "neighbors": {
+              "neighbor": [
+                {
+                  "remote-address": "198.51.100.2",
+                  "local-address": "198.51.100.1",
+                  "peer-type": "internal",
+                  "identifier": "192.0.2.2",
+                  "timers": {
+                    "negotiated-hold-time": 90
+                  },
+                  "afi-safis": {
+                    "afi-safi": [
+                      {
+                        "name": "iana-bgp-types:ipv4-labeled-unicast",
+                        "prefixes": {
+                          "received": 1,
+                          "sent": 0,
+                          "installed": 1
+                        }
+                      }
+                    ]
+                  },
+                  "session-state": "established",
+                  "capabilities": {
+                    "advertised-capabilities": [
+                      {
+                        "code": 1,
+                        "index": 0,
+                        "name": "iana-bgp-types:mp-bgp",
+                        "value": {
+                          "mpbgp": {
+                            "afi": "ipv4",
+                            "safi": "labeled-unicast-safi",
+                            "name": "iana-bgp-types:ipv4-labeled-unicast"
+                          }
+                        }
+                      },
+                      {
+                        "code": 65,
+                        "index": 1,
+                        "name": "iana-bgp-types:asn32",
+                        "value": {
+                          "asn32": {
+                            "as": 65000
+                          }
+                        }
+                      },
+                      {
+                        "code": 2,
+                        "index": 2,
+                        "name": "iana-bgp-types:route-refresh"
+                      }
+                    ],
+                    "received-capabilities": [
+                      {
+                        "code": 1,
+                        "index": 0,
+                        "name": "iana-bgp-types:mp-bgp",
+                        "value": {
+                          "mpbgp": {
+                            "afi": "ipv4",
+                            "safi": "labeled-unicast-safi",
+                            "name": "iana-bgp-types:ipv4-labeled-unicast"
+                          }
+                        }
+                      },
+                      {
+                        "code": 65,
+                        "index": 1,
+                        "name": "iana-bgp-types:asn32",
+                        "value": {
+                          "asn32": {
+                            "as": 65000
+                          }
+                        }
+                      },
+                      {
+                        "code": 2,
+                        "index": 2,
+                        "name": "iana-bgp-types:route-refresh"
+                      }
+                    ],
+                    "negotiated-capabilities": [
+                      "iana-bgp-types:mp-bgp",
+                      "iana-bgp-types:asn32",
+                      "iana-bgp-types:route-refresh"
+                    ]
+                  }
+                }
+              ]
+            },
+            "rib": {
+              "attr-sets": {
+                "attr-set": [
+                  {
+                    "index": "4952143682590189173",
+                    "attributes": {
+                      "origin": "igp",
+                      "next-hop": "198.51.100.2"
+                    }
+                  }
+                ]
+              },
+              "afi-safis": {
+                "afi-safi": [
+                  {
+                    "name": "iana-bgp-types:ipv4-labeled-unicast"
+                  }
+                ]
+              }
+            }
+          }
+        }
+      ]
+    }
+  }
+}

--- a/holo-bgp/tests/conformance/topologies/lu-1/rt1/output/northbound-state.json
+++ b/holo-bgp/tests/conformance/topologies/lu-1/rt1/output/northbound-state.json
@@ -14,11 +14,17 @@
                     "statistics": {
                       "total-prefixes": 1
                     }
+                  },
+                  {
+                    "name": "iana-bgp-types:ipv6-labeled-unicast",
+                    "statistics": {
+                      "total-prefixes": 1
+                    }
                   }
                 ]
               },
               "statistics": {
-                "total-prefixes": 1
+                "total-prefixes": 2
               }
             },
             "neighbors": {
@@ -35,6 +41,14 @@
                     "afi-safi": [
                       {
                         "name": "iana-bgp-types:ipv4-labeled-unicast",
+                        "prefixes": {
+                          "received": 1,
+                          "sent": 0,
+                          "installed": 1
+                        }
+                      },
+                      {
+                        "name": "iana-bgp-types:ipv6-labeled-unicast",
                         "prefixes": {
                           "received": 1,
                           "sent": 0,
@@ -59,8 +73,20 @@
                         }
                       },
                       {
-                        "code": 65,
+                        "code": 1,
                         "index": 1,
+                        "name": "iana-bgp-types:mp-bgp",
+                        "value": {
+                          "mpbgp": {
+                            "afi": "ipv6",
+                            "safi": "labeled-unicast-safi",
+                            "name": "iana-bgp-types:ipv6-labeled-unicast"
+                          }
+                        }
+                      },
+                      {
+                        "code": 65,
+                        "index": 2,
                         "name": "iana-bgp-types:asn32",
                         "value": {
                           "asn32": {
@@ -70,7 +96,7 @@
                       },
                       {
                         "code": 2,
-                        "index": 2,
+                        "index": 3,
                         "name": "iana-bgp-types:route-refresh"
                       }
                     ],
@@ -88,8 +114,20 @@
                         }
                       },
                       {
-                        "code": 65,
+                        "code": 1,
                         "index": 1,
+                        "name": "iana-bgp-types:mp-bgp",
+                        "value": {
+                          "mpbgp": {
+                            "afi": "ipv6",
+                            "safi": "labeled-unicast-safi",
+                            "name": "iana-bgp-types:ipv6-labeled-unicast"
+                          }
+                        }
+                      },
+                      {
+                        "code": 65,
+                        "index": 2,
                         "name": "iana-bgp-types:asn32",
                         "value": {
                           "asn32": {
@@ -99,11 +137,12 @@
                       },
                       {
                         "code": 2,
-                        "index": 2,
+                        "index": 3,
                         "name": "iana-bgp-types:route-refresh"
                       }
                     ],
                     "negotiated-capabilities": [
+                      "iana-bgp-types:mp-bgp",
                       "iana-bgp-types:mp-bgp",
                       "iana-bgp-types:asn32",
                       "iana-bgp-types:route-refresh"
@@ -121,6 +160,13 @@
                       "origin": "igp",
                       "next-hop": "198.51.100.2"
                     }
+                  },
+                  {
+                    "index": "18302804074931552809",
+                    "attributes": {
+                      "origin": "igp",
+                      "next-hop": "2001:db8::2"
+                    }
                   }
                 ]
               },
@@ -128,6 +174,9 @@
                 "afi-safi": [
                   {
                     "name": "iana-bgp-types:ipv4-labeled-unicast"
+                  },
+                  {
+                    "name": "iana-bgp-types:ipv6-labeled-unicast"
                   }
                 ]
               }

--- a/holo-bgp/tests/conformance/topologies/lu-1/rt1/output/protocol.jsonl
+++ b/holo-bgp/tests/conformance/topologies/lu-1/rt1/output/protocol.jsonl
@@ -1,3 +1,3 @@
-{"NbrTx":{"SendMessage":{"nbr_addr":"198.51.100.2","msg":{"Open":{"version":4,"my_as":65000,"holdtime":90,"identifier":"192.0.2.1","capabilities":[{"MultiProtocol":{"afi":"Ipv4","safi":"LabeledUnicast"}},{"FourOctetAsNumber":{"asn":65000}},"RouteRefresh"]}}}}}
+{"NbrTx":{"SendMessage":{"nbr_addr":"198.51.100.2","msg":{"Open":{"version":4,"my_as":65000,"holdtime":90,"identifier":"192.0.2.1","capabilities":[{"MultiProtocol":{"afi":"Ipv4","safi":"LabeledUnicast"}},{"MultiProtocol":{"afi":"Ipv6","safi":"LabeledUnicast"}},{"FourOctetAsNumber":{"asn":65000}},"RouteRefresh"]}}}}}
 {"NbrTx":{"SendMessage":{"nbr_addr":"198.51.100.2","msg":{"Keepalive":{}}}}}
-{"NbrTx":{"UpdateCapabilities":[{"MultiProtocol":{"afi":"Ipv4","safi":"LabeledUnicast"}},"FourOctetAsNumber","RouteRefresh"]}}
+{"NbrTx":{"UpdateCapabilities":[{"MultiProtocol":{"afi":"Ipv4","safi":"LabeledUnicast"}},{"MultiProtocol":{"afi":"Ipv6","safi":"LabeledUnicast"}},"FourOctetAsNumber","RouteRefresh"]}}

--- a/holo-bgp/tests/conformance/topologies/lu-1/rt1/output/protocol.jsonl
+++ b/holo-bgp/tests/conformance/topologies/lu-1/rt1/output/protocol.jsonl
@@ -1,0 +1,3 @@
+{"NbrTx":{"SendMessage":{"nbr_addr":"198.51.100.2","msg":{"Open":{"version":4,"my_as":65000,"holdtime":90,"identifier":"192.0.2.1","capabilities":[{"MultiProtocol":{"afi":"Ipv4","safi":"LabeledUnicast"}},{"FourOctetAsNumber":{"asn":65000}},"RouteRefresh"]}}}}}
+{"NbrTx":{"SendMessage":{"nbr_addr":"198.51.100.2","msg":{"Keepalive":{}}}}}
+{"NbrTx":{"UpdateCapabilities":[{"MultiProtocol":{"afi":"Ipv4","safi":"LabeledUnicast"}},"FourOctetAsNumber","RouteRefresh"]}}

--- a/holo-bgp/tests/conformance/topologies/mod.rs
+++ b/holo-bgp/tests/conformance/topologies/mod.rs
@@ -22,3 +22,8 @@ async fn topology2_1() {
         run_test_topology::<Instance>("topo2-1", &rt_name).await;
     }
 }
+
+#[tokio::test]
+async fn labeled_unicast_1() {
+    run_test_topology::<Instance>("lu-1", "rt1").await;
+}

--- a/holo-bgp/tests/packet/update.rs
+++ b/holo-bgp/tests/packet/update.rs
@@ -14,10 +14,11 @@ use holo_bgp::packet::attribute::{
 };
 use holo_bgp::packet::iana::Origin;
 use holo_bgp::packet::message::{
-    DecodeCxt, Message, MpReachNlri, MpUnreachNlri, NegotiatedCapability,
-    ReachNlri, UnreachNlri, UpdateMsg,
+    DecodeCxt, EncodeCxt, LabeledIpv4Nlri, Message, MpReachNlri, MpUnreachNlri,
+    NegotiatedCapability, ReachNlri, UnreachNlri, UpdateMsg,
 };
 use holo_utils::bgp::{Comm, ExtComm, Extv6Comm, LargeComm};
+use holo_utils::mpls::Label;
 
 use super::{test_decode_msg, test_encode_msg};
 
@@ -153,6 +154,71 @@ fn test_encode_update2() {
 fn test_decode_update2() {
     let (ref bytes, ref msg) = *UPDATE2;
     test_decode_msg(bytes, msg);
+}
+
+#[test]
+fn test_roundtrip_labeled_unicast_update() {
+    let msg = Message::Update(UpdateMsg {
+        reach: None,
+        unreach: None,
+        mp_reach: Some(MpReachNlri::Ipv4LabeledUnicast {
+            prefixes: vec![LabeledIpv4Nlri {
+                label: Label::new(16000),
+                prefix: net4!("192.0.2.0/24"),
+            }],
+            nexthop: ip4!("198.51.100.1"),
+        }),
+        mp_unreach: Some(MpUnreachNlri::Ipv4LabeledUnicast {
+            prefixes: vec![LabeledIpv4Nlri {
+                label: Label::new(16001),
+                prefix: net4!("192.0.2.128/25"),
+            }],
+        }),
+        attrs: Some(Attrs {
+            base: BaseAttrs {
+                origin: Origin::Igp,
+                ..Default::default()
+            },
+            ..Default::default()
+        }),
+    });
+
+    let encode_cxt = EncodeCxt {
+        capabilities: [NegotiatedCapability::FourOctetAsNumber].into(),
+    };
+    let decode_cxt = DecodeCxt {
+        peer_type: PeerType::Internal,
+        peer_as: 65550,
+        reject_as_sets: true,
+        capabilities: [NegotiatedCapability::FourOctetAsNumber].into(),
+    };
+    let bytes = msg.encode(&encode_cxt);
+    let msg_size = Message::get_message_len(&bytes)
+        .expect("Buffer doesn't contain a full BGP message");
+    let decoded = Message::decode(&bytes[..msg_size], &decode_cxt).unwrap();
+
+    let Message::Update(decoded) = decoded else {
+        panic!("expected UPDATE");
+    };
+    assert_eq!(
+        decoded.mp_reach,
+        Some(MpReachNlri::Ipv4LabeledUnicast {
+            prefixes: vec![LabeledIpv4Nlri {
+                label: Label::new(16000),
+                prefix: net4!("192.0.2.0/24"),
+            }],
+            nexthop: ip4!("198.51.100.1"),
+        })
+    );
+    assert_eq!(
+        decoded.mp_unreach,
+        Some(MpUnreachNlri::Ipv4LabeledUnicast {
+            prefixes: vec![LabeledIpv4Nlri {
+                label: Label::new(16001),
+                prefix: net4!("192.0.2.128/25"),
+            }],
+        })
+    );
 }
 
 #[test]

--- a/holo-protocol/src/lib.rs
+++ b/holo-protocol/src/lib.rs
@@ -387,6 +387,60 @@ pub fn spawn_protocol_task<P>(
     ibus_instance_tx: IbusSender,
     ibus_instance_rx: IbusReceiver,
     agg_channels: InstanceAggChannels<P>,
+    shared: InstanceShared,
+) -> NbDaemonSender
+where
+    P: ProtocolInstance,
+{
+    #[cfg(feature = "testing")]
+    let (_test_tx, test_rx) = mpsc::channel(4);
+
+    spawn_protocol_task_impl::<P>(
+        name,
+        nb_provider_tx,
+        ibus_tx,
+        ibus_instance_tx,
+        ibus_instance_rx,
+        agg_channels,
+        #[cfg(feature = "testing")]
+        test_rx,
+        shared,
+    )
+}
+
+#[cfg(feature = "testing")]
+pub fn spawn_protocol_task_with_test<P>(
+    name: String,
+    nb_provider_tx: &NbProviderSender,
+    ibus_tx: &IbusChannelsTx,
+    ibus_instance_tx: IbusSender,
+    ibus_instance_rx: IbusReceiver,
+    agg_channels: InstanceAggChannels<P>,
+    test_rx: Receiver<TestMsg<P::ProtocolOutputMsg>>,
+    shared: InstanceShared,
+) -> NbDaemonSender
+where
+    P: ProtocolInstance,
+{
+    spawn_protocol_task_impl::<P>(
+        name,
+        nb_provider_tx,
+        ibus_tx,
+        ibus_instance_tx,
+        ibus_instance_rx,
+        agg_channels,
+        test_rx,
+        shared,
+    )
+}
+
+fn spawn_protocol_task_impl<P>(
+    name: String,
+    nb_provider_tx: &NbProviderSender,
+    ibus_tx: &IbusChannelsTx,
+    ibus_instance_tx: IbusSender,
+    ibus_instance_rx: IbusReceiver,
+    agg_channels: InstanceAggChannels<P>,
     #[cfg(feature = "testing")] test_rx: Receiver<
         TestMsg<P::ProtocolOutputMsg>,
     >,

--- a/holo-protocol/src/test/stub/mod.rs
+++ b/holo-protocol/src/test/stub/mod.rs
@@ -23,7 +23,6 @@ use crate::test::stub::northbound::NorthboundStub;
 use crate::test::{OutputChannelsRx, setup};
 use crate::{
     InstanceAggChannels, InstanceMsg, InstanceShared, ProtocolInstance,
-    spawn_protocol_task,
 };
 
 // Environment variable that controls if the test data needs to be updated or
@@ -277,7 +276,7 @@ where
     let channels = InstanceAggChannels::default();
     let instance_tx = channels.tx.clone();
     let (test_tx, test_rx) = mpsc::channel(4);
-    let nb_daemon_tx = spawn_protocol_task::<P>(
+    let nb_daemon_tx = crate::spawn_protocol_task_with_test::<P>(
         name.to_owned(),
         &nb_provider_tx,
         &ibus_tx,

--- a/holo-utils/src/bgp.rs
+++ b/holo-utils/src/bgp.rs
@@ -28,6 +28,8 @@ use serde::{Deserialize, Serialize};
 pub enum AfiSafi {
     Ipv4Unicast,
     Ipv6Unicast,
+    Ipv4LabeledUnicast,
+    Ipv6LabeledUnicast,
 }
 
 #[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd)]
@@ -84,6 +86,12 @@ impl ToYang for AfiSafi {
         match self {
             AfiSafi::Ipv4Unicast => "iana-bgp-types:ipv4-unicast".into(),
             AfiSafi::Ipv6Unicast => "iana-bgp-types:ipv6-unicast".into(),
+            AfiSafi::Ipv4LabeledUnicast => {
+                "iana-bgp-types:ipv4-labeled-unicast".into()
+            }
+            AfiSafi::Ipv6LabeledUnicast => {
+                "iana-bgp-types:ipv6-labeled-unicast".into()
+            }
         }
     }
 }
@@ -93,6 +101,12 @@ impl TryFromYang for AfiSafi {
         match value {
             "iana-bgp-types:ipv4-unicast" => Some(AfiSafi::Ipv4Unicast),
             "iana-bgp-types:ipv6-unicast" => Some(AfiSafi::Ipv6Unicast),
+            "iana-bgp-types:ipv4-labeled-unicast" => {
+                Some(AfiSafi::Ipv4LabeledUnicast)
+            }
+            "iana-bgp-types:ipv6-labeled-unicast" => {
+                Some(AfiSafi::Ipv6LabeledUnicast)
+            }
             _ => None,
         }
     }

--- a/holo-utils/src/task.rs
+++ b/holo-utils/src/task.rs
@@ -165,6 +165,16 @@ impl<T> Drop for Task<T> {
 // ===== impl TimeoutTask =====
 
 impl TimeoutTask {
+    /// Returns an inert timeout handle for deterministic protocol tests.
+    #[cfg(feature = "testing")]
+    pub fn new<F, Fut>(_timeout: Duration, _cb: F) -> TimeoutTask
+    where
+        F: FnOnce() -> Fut + Send + 'static,
+        Fut: Future<Output = ()> + Send,
+    {
+        TimeoutTask {}
+    }
+
     /// Spawns a new task that will call the provided async closure when the
     /// specified timeout expires.
     ///

--- a/holo-yang/modules/deviations/holo-ietf-bgp-deviations.yang
+++ b/holo-yang/modules/deviations/holo-ietf-bgp-deviations.yang
@@ -90,11 +90,11 @@ module holo-ietf-bgp-deviations {
     deviate not-supported;
   }
 
-  deviation "/rt:routing/rt:control-plane-protocols/rt:control-plane-protocol/bgp:bgp/bgp:global/bgp:afi-safis/bgp:afi-safi/bgp:ipv4-labeled-unicast" {
+  deviation "/rt:routing/rt:control-plane-protocols/rt:control-plane-protocol/bgp:bgp/bgp:global/bgp:afi-safis/bgp:afi-safi/bgp:ipv4-labeled-unicast/bgp:prefix-limit/bgp:prefix-limit-exceeded" {
     deviate not-supported;
   }
 
-  deviation "/rt:routing/rt:control-plane-protocols/rt:control-plane-protocol/bgp:bgp/bgp:global/bgp:afi-safis/bgp:afi-safi/bgp:ipv6-labeled-unicast" {
+  deviation "/rt:routing/rt:control-plane-protocols/rt:control-plane-protocol/bgp:bgp/bgp:global/bgp:afi-safis/bgp:afi-safi/bgp:ipv6-labeled-unicast/bgp:prefix-limit/bgp:prefix-limit-exceeded" {
     deviate not-supported;
   }
 
@@ -198,11 +198,11 @@ module holo-ietf-bgp-deviations {
     deviate not-supported;
   }
 
-  deviation "/rt:routing/rt:control-plane-protocols/rt:control-plane-protocol/bgp:bgp/bgp:neighbors/bgp:neighbor/bgp:afi-safis/bgp:afi-safi/bgp:ipv4-labeled-unicast" {
+  deviation "/rt:routing/rt:control-plane-protocols/rt:control-plane-protocol/bgp:bgp/bgp:neighbors/bgp:neighbor/bgp:afi-safis/bgp:afi-safi/bgp:ipv4-labeled-unicast/bgp:prefix-limit/bgp:prefix-limit-exceeded" {
     deviate not-supported;
   }
 
-  deviation "/rt:routing/rt:control-plane-protocols/rt:control-plane-protocol/bgp:bgp/bgp:neighbors/bgp:neighbor/bgp:afi-safis/bgp:afi-safi/bgp:ipv6-labeled-unicast" {
+  deviation "/rt:routing/rt:control-plane-protocols/rt:control-plane-protocol/bgp:bgp/bgp:neighbors/bgp:neighbor/bgp:afi-safis/bgp:afi-safi/bgp:ipv6-labeled-unicast/bgp:prefix-limit/bgp:prefix-limit-exceeded" {
     deviate not-supported;
   }
 


### PR DESCRIPTION
Adds BGP labeled unicast (RFC 8277) for IPv4 and IPv6:

- `ipv4-labeled-unicast` / `ipv6-labeled-unicast` AFI/SAFI on the generalized `AddressFamily`.
- Labeled NLRI codec (label + prefix; no RD).
- Label allocation/programming.
- Packet round-trip test + a `labeled_unicast` conformance topology.

Stacked on #132 (AddressFamily Prefix key) — the `AddressFamily` commits drop out of this diff once #132 merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
