### PR TITLE
bgp: inbound soft-reconfiguration (re-apply import policy to retained Adj-RIB-In)

### DIFF
--- a/holo-bgp/src/events.rs
+++ b/holo-bgp/src/events.rs
@@ -11,7 +11,7 @@ use holo_protocol::InstanceShared;
 use holo_utils::bgp::RouteType;
 use holo_utils::ibus::IbusChannelsTx;
 use holo_utils::ip::{IpAddrKind, IpNetworkKind};
-use holo_utils::policy::{PolicyResult, PolicyType};
+use holo_utils::policy::{ApplyPolicyCfg, PolicyResult, PolicyType};
 use holo_utils::socket::{TcpConnInfo, TcpStream};
 use ipnetwork::IpNetwork;
 use num_traits::FromPrimitive;
@@ -19,7 +19,7 @@ use num_traits::FromPrimitive;
 use crate::af::{AddressFamily, Ipv4Unicast, Ipv6Unicast};
 use crate::debug::Debug;
 use crate::error::{Error, IoError, NbrRxError};
-use crate::instance::{InstanceUpView, PolicyApplyTasks};
+use crate::instance::{InstanceState, InstanceUpView, PolicyApplyTasks};
 use crate::neighbor::{Neighbor, Neighbors, PeerType, fsm};
 use crate::packet::attribute::Attrs;
 use crate::packet::iana::{Afi, Safi};
@@ -347,6 +347,224 @@ fn process_nbr_reach_prefixes<A>(
         default_policy: apply_policy_cfg.default_import_policy,
     };
     policy_apply_tasks.enqueue(msg);
+}
+
+fn collect_policies(
+    apply_policy_cfg: &ApplyPolicyCfg,
+    shared: &InstanceShared,
+) -> (bool, Vec<std::sync::Arc<holo_utils::policy::Policy>>) {
+    let mut missing_policy = false;
+    let policies = apply_policy_cfg
+        .import_policy
+        .iter()
+        .filter_map(|policy| match shared.policies.get(policy) {
+            Some(policy) => Some(policy.clone()),
+            None => {
+                missing_policy = true;
+                None
+            }
+        })
+        .collect();
+
+    (missing_policy, policies)
+}
+
+pub(crate) fn reapply_nbr_import_policy_for_nbr<A>(
+    state: &mut InstanceState,
+    shared: &InstanceShared,
+    nbr: &Neighbor,
+) where
+    A: AddressFamily,
+{
+    if nbr.state < fsm::State::Established
+        || !nbr.is_af_enabled(A::AFI, A::SAFI)
+    {
+        return;
+    }
+
+    // Get policy configuration for the address family.
+    let apply_policy_cfg = &nbr
+        .config
+        .afi_safi
+        .get(&A::AFI_SAFI)
+        .map(|afi_safi| &afi_safi.apply_policy)
+        .unwrap_or(&nbr.config.apply_policy);
+
+    let (missing_policy, policies) = collect_policies(apply_policy_cfg, shared);
+
+    // Re-evaluate the retained pre-policy Adj-RIB-In, never the previously
+    // policy-mutated post-policy copy.
+    let table = A::table(&mut state.rib.tables);
+    let routes = table
+        .prefixes
+        .iter()
+        .filter_map(|(prefix, dest)| {
+            dest.adj_rib
+                .get(&nbr.remote_addr)
+                .and_then(|adj_rib| adj_rib.in_pre())
+                .map(|route| (prefix.into(), route.policy_info()))
+        })
+        .collect::<Vec<_>>();
+
+    if routes.is_empty() {
+        return;
+    }
+
+    let msg = PolicyApplyMsg::Neighbor {
+        policy_type: PolicyType::Import,
+        nbr_addr: nbr.remote_addr,
+        afi_safi: A::AFI_SAFI,
+        routes,
+        missing_policy,
+        policies,
+        match_sets: shared.policy_match_sets.clone(),
+        default_policy: apply_policy_cfg.default_import_policy,
+    };
+    state.policy_apply_tasks.enqueue(msg);
+}
+
+pub(crate) fn reapply_nbr_import_policy<A>(
+    instance: &mut InstanceUpView<'_>,
+    neighbors: &mut Neighbors,
+    nbr_addr: IpAddr,
+) where
+    A: AddressFamily,
+{
+    let Some(nbr) = neighbors.get(&nbr_addr) else {
+        return;
+    };
+
+    reapply_nbr_import_policy_for_nbr::<A>(
+        instance.state,
+        instance.shared,
+        nbr,
+    );
+}
+
+pub(crate) fn reapply_import_policy_all<A>(
+    instance: &mut InstanceUpView<'_>,
+    neighbors: &mut Neighbors,
+) where
+    A: AddressFamily,
+{
+    let nbr_addrs = neighbors.keys().copied().collect::<Vec<_>>();
+    for nbr_addr in nbr_addrs {
+        reapply_nbr_import_policy::<A>(instance, neighbors, nbr_addr);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::net::{IpAddr, Ipv4Addr};
+    use std::sync::Arc;
+
+    use holo_protocol::InstanceShared;
+    use holo_utils::bgp::{AfiSafi, RouteType};
+    use holo_utils::policy::Policy;
+    use ipnetwork::Ipv4Network;
+
+    use super::*;
+    use crate::af::Ipv4Unicast;
+    use crate::instance::{InstanceState, PolicyApplyTasks};
+    use crate::neighbor::{Neighbor, PeerType, fsm};
+    use crate::northbound::configuration::NeighborAfiSafiCfg;
+    use crate::packet::attribute::Attrs;
+    use crate::rib::{Rib, RouteOrigin};
+
+    #[test]
+    fn import_reapply_uses_retained_adj_rib_in_pre() {
+        let remote_addr = IpAddr::V4(Ipv4Addr::new(192, 0, 2, 2));
+        let (tx, rx) = crossbeam_channel::unbounded();
+        let mut state = InstanceState {
+            router_id: Ipv4Addr::new(192, 0, 2, 1),
+            listening_sockets: Vec::new(),
+            policy_apply_tasks: PolicyApplyTasks::new_for_testing(tx),
+            decision_process_task: None,
+            rib: Rib::default(),
+        };
+        let mut shared = InstanceShared::default();
+        shared.policies.insert(
+            "SOFT-IN".to_owned(),
+            Arc::new(Policy::new("SOFT-IN".to_owned())),
+        );
+
+        let mut nbr = Neighbor::new(remote_addr, PeerType::External);
+        nbr.state = fsm::State::Established;
+        nbr.identifier = Some(Ipv4Addr::new(192, 0, 2, 2));
+        nbr.config
+            .afi_safi
+            .insert(AfiSafi::Ipv4Unicast, NeighborAfiSafiCfg::default());
+        let afi_safi =
+            nbr.config.afi_safi.get_mut(&AfiSafi::Ipv4Unicast).unwrap();
+        afi_safi.enabled = true;
+        afi_safi
+            .apply_policy
+            .import_policy
+            .insert("SOFT-IN".to_owned());
+
+        let origin = RouteOrigin::Neighbor {
+            identifier: nbr.identifier.unwrap(),
+            remote_addr,
+        };
+        let attrs = state.rib.attr_sets.get_route_attr_sets(&Attrs::default());
+        let table = Ipv4Unicast::table(&mut state.rib.tables);
+        for prefix in ["198.51.100.1/32", "198.51.100.2/32"] {
+            let prefix: Ipv4Network = prefix.parse().unwrap();
+            let route = Route::new(origin, attrs.clone(), RouteType::External);
+            table
+                .prefixes
+                .entry(prefix)
+                .or_default()
+                .adj_rib
+                .entry(remote_addr)
+                .or_default()
+                .update_in_pre(Box::new(route), &mut state.rib.attr_sets);
+        }
+
+        let accepted_prefix: Ipv4Network = "198.51.100.1/32".parse().unwrap();
+        let route = Route::new(origin, attrs, RouteType::External);
+        table
+            .prefixes
+            .entry(accepted_prefix)
+            .or_default()
+            .adj_rib
+            .entry(remote_addr)
+            .or_default()
+            .update_in_post(Box::new(route), &mut state.rib.attr_sets);
+
+        reapply_nbr_import_policy_for_nbr::<Ipv4Unicast>(
+            &mut state, &shared, &nbr,
+        );
+
+        let msg = rx.try_recv().unwrap();
+        let PolicyApplyMsg::Neighbor {
+            policy_type,
+            nbr_addr,
+            afi_safi,
+            routes,
+            missing_policy,
+            policies,
+            ..
+        } = msg
+        else {
+            panic!("unexpected policy apply message");
+        };
+        assert!(matches!(policy_type, PolicyType::Import));
+        assert_eq!(nbr_addr, remote_addr);
+        assert_eq!(afi_safi, AfiSafi::Ipv4Unicast);
+        assert!(!missing_policy);
+        assert_eq!(policies.len(), 1);
+        assert_eq!(
+            routes
+                .into_iter()
+                .map(|(prefix, _)| prefix)
+                .collect::<Vec<_>>(),
+            vec![
+                "198.51.100.1/32".parse().unwrap(),
+                "198.51.100.2/32".parse().unwrap(),
+            ]
+        );
+    }
 }
 
 fn process_nbr_unreach_prefixes<A>(

--- a/holo-bgp/src/events.rs
+++ b/holo-bgp/src/events.rs
@@ -321,6 +321,18 @@ fn process_nbr_reach_prefixes<A>(
 
     // Enqueue import policy application.
     let rpinfo = RoutePolicyInfo::new(origin, route_type, None, None, attrs);
+    let mut missing_policy = false;
+    let policies = apply_policy_cfg
+        .import_policy
+        .iter()
+        .filter_map(|policy| match shared.policies.get(policy) {
+            Some(policy) => Some(policy.clone()),
+            None => {
+                missing_policy = true;
+                None
+            }
+        })
+        .collect();
     let msg = PolicyApplyMsg::Neighbor {
         policy_type: PolicyType::Import,
         nbr_addr: nbr.remote_addr,
@@ -329,11 +341,8 @@ fn process_nbr_reach_prefixes<A>(
             .into_iter()
             .map(|prefix| (prefix.into(), rpinfo.clone()))
             .collect(),
-        policies: apply_policy_cfg
-            .import_policy
-            .iter()
-            .map(|policy| shared.policies.get(policy).unwrap().clone())
-            .collect(),
+        missing_policy,
+        policies,
         match_sets: shared.policy_match_sets.clone(),
         default_policy: apply_policy_cfg.default_import_policy,
     };
@@ -830,16 +839,25 @@ pub(crate) fn advertise_routes<A>(
         .map(|(prefix, route)| (prefix.into(), route.policy_info()))
         .collect::<Vec<_>>();
     if !routes.is_empty() {
+        let mut missing_policy = false;
+        let policies = apply_policy_cfg
+            .export_policy
+            .iter()
+            .filter_map(|policy| match shared.policies.get(policy) {
+                Some(policy) => Some(policy.clone()),
+                None => {
+                    missing_policy = true;
+                    None
+                }
+            })
+            .collect();
         let msg = PolicyApplyMsg::Neighbor {
             policy_type: PolicyType::Export,
             nbr_addr: nbr.remote_addr,
             afi_safi: A::AFI_SAFI,
             routes,
-            policies: apply_policy_cfg
-                .export_policy
-                .iter()
-                .map(|policy| shared.policies.get(policy).unwrap().clone())
-                .collect(),
+            missing_policy,
+            policies,
             match_sets: shared.policy_match_sets.clone(),
             default_policy: apply_policy_cfg.default_export_policy,
         };

--- a/holo-bgp/src/ibus/rx.rs
+++ b/holo-bgp/src/ibus/rx.rs
@@ -127,6 +127,18 @@ where
         .unwrap_or(&instance.config.apply_policy);
 
     // Enqueue import policy application.
+    let mut missing_policy = false;
+    let policies = apply_policy_cfg
+        .import_policy
+        .iter()
+        .filter_map(|policy| match instance.shared.policies.get(policy) {
+            Some(policy) => Some(policy.clone()),
+            None => {
+                missing_policy = true;
+                None
+            }
+        })
+        .collect();
     let msg = PolicyApplyMsg::Redistribute {
         afi_safi: A::AFI_SAFI,
         prefix: msg.prefix,
@@ -137,11 +149,8 @@ where
             Some(msg.opaque_attrs),
             Default::default(),
         ),
-        policies: apply_policy_cfg
-            .import_policy
-            .iter()
-            .map(|policy| instance.shared.policies.get(policy).unwrap().clone())
-            .collect(),
+        missing_policy,
+        policies,
         match_sets: instance.shared.policy_match_sets.clone(),
         default_policy: apply_policy_cfg.default_import_policy,
     };

--- a/holo-bgp/src/instance.rs
+++ b/holo-bgp/src/instance.rs
@@ -434,6 +434,16 @@ impl PolicyApplyTasks {
     pub(crate) fn enqueue(&self, msg: PolicyApplyMsg) {
         let _ = self.tx.send(msg);
     }
+
+    #[cfg(test)]
+    pub(crate) fn new_for_testing(
+        tx: crossbeam_channel::Sender<PolicyApplyMsg>,
+    ) -> Self {
+        Self {
+            tx,
+            _tasks: Vec::new(),
+        }
+    }
 }
 
 // ===== helper functions =====
@@ -458,6 +468,17 @@ fn process_ibus_msg(
         IbusMsg::PolicyMatchSetsUpd(match_sets) => {
             // Update the local copy of the policy match sets.
             instance.shared.policy_match_sets = match_sets;
+
+            if let Some((mut instance, neighbors)) = instance.as_up() {
+                events::reapply_import_policy_all::<Ipv4Unicast>(
+                    &mut instance,
+                    neighbors,
+                );
+                events::reapply_import_policy_all::<Ipv6Unicast>(
+                    &mut instance,
+                    neighbors,
+                );
+            }
         }
         IbusMsg::PolicyUpd(policy) => {
             // Update the local copy of the policy definition.
@@ -465,10 +486,32 @@ fn process_ibus_msg(
                 .shared
                 .policies
                 .insert(policy.name.clone(), policy.clone());
+
+            if let Some((mut instance, neighbors)) = instance.as_up() {
+                events::reapply_import_policy_all::<Ipv4Unicast>(
+                    &mut instance,
+                    neighbors,
+                );
+                events::reapply_import_policy_all::<Ipv6Unicast>(
+                    &mut instance,
+                    neighbors,
+                );
+            }
         }
         IbusMsg::PolicyDel(policy_name) => {
             // Remove the local copy of the policy definition.
             instance.shared.policies.remove(&policy_name);
+
+            if let Some((mut instance, neighbors)) = instance.as_up() {
+                events::reapply_import_policy_all::<Ipv4Unicast>(
+                    &mut instance,
+                    neighbors,
+                );
+                events::reapply_import_policy_all::<Ipv6Unicast>(
+                    &mut instance,
+                    neighbors,
+                );
+            }
         }
         IbusMsg::RouteRedistributeAdd(msg) => {
             // Route redistribute update notification.

--- a/holo-bgp/src/neighbor.rs
+++ b/holo-bgp/src/neighbor.rs
@@ -1033,6 +1033,17 @@ impl Neighbor {
                 }
             }
             ClearType::SoftInbound => {
+                events::reapply_nbr_import_policy_for_nbr::<Ipv4Unicast>(
+                    instance.state,
+                    instance.shared,
+                    self,
+                );
+                events::reapply_nbr_import_policy_for_nbr::<Ipv6Unicast>(
+                    instance.state,
+                    instance.shared,
+                    self,
+                );
+
                 // Request the Adj-RIB-In for this neighbor to be re-sent.
                 for (afi, safi) in self
                     .capabilities_nego

--- a/holo-bgp/src/northbound/configuration.rs
+++ b/holo-bgp/src/northbound/configuration.rs
@@ -23,11 +23,11 @@ use holo_yang::TryFromYang;
 use crate::af::{Ipv4Unicast, Ipv6Unicast};
 use crate::instance::{Instance, InstanceUpView};
 use crate::neighbor::{Neighbor, PeerType, fsm};
-use crate::network;
 use crate::northbound::yang_gen::bgp;
 use crate::packet::iana::{CeaseSubcode, ErrorCode};
 use crate::packet::message::{Message, NotificationMsg};
 use crate::rib::RouteOrigin;
+use crate::{events, network};
 
 #[derive(Debug, Default, EnumAsInner)]
 pub enum ListEntry {
@@ -51,6 +51,7 @@ pub enum Event {
     NeighborDelete(IpAddr),
     NeighborReset(IpAddr, NotificationMsg),
     NeighborUpdateAuth(IpAddr),
+    PolicyImportReapply(Option<IpAddr>, Option<AfiSafi>),
     RedistributeIbusSub(Protocol, AddressFamily),
     RedistributeDelete(Protocol, AddressFamily, AfiSafi),
     UpdateTraceOptions,
@@ -428,26 +429,35 @@ fn load_callbacks() -> Callbacks<Instance> {
         .path(bgp::global::afi_safis::afi_safi::apply_policy::import_policy::PATH)
         .create_apply(|instance, args| {
             let afi_safi = args.list_entry.into_afi_safi().unwrap();
-            let afi_safi = instance.config.afi_safi.get_mut(&afi_safi).unwrap();
+            let afi_safi_cfg = instance.config.afi_safi.get_mut(&afi_safi).unwrap();
 
             let policy = args.dnode.get_string();
-            afi_safi.apply_policy.import_policy.insert(policy);
+            afi_safi_cfg.apply_policy.import_policy.insert(policy);
+
+            let event_queue = args.event_queue;
+            event_queue.insert(Event::PolicyImportReapply(None, Some(afi_safi)));
         })
         .delete_apply(|instance, args| {
             let afi_safi = args.list_entry.into_afi_safi().unwrap();
-            let afi_safi = instance.config.afi_safi.get_mut(&afi_safi).unwrap();
+            let afi_safi_cfg = instance.config.afi_safi.get_mut(&afi_safi).unwrap();
 
             let policy = args.dnode.get_string();
-            afi_safi.apply_policy.import_policy.remove(&policy);
+            afi_safi_cfg.apply_policy.import_policy.remove(&policy);
+
+            let event_queue = args.event_queue;
+            event_queue.insert(Event::PolicyImportReapply(None, Some(afi_safi)));
         })
         .path(bgp::global::afi_safis::afi_safi::apply_policy::default_import_policy::PATH)
         .modify_apply(|instance, args| {
             let afi_safi = args.list_entry.into_afi_safi().unwrap();
-            let afi_safi = instance.config.afi_safi.get_mut(&afi_safi).unwrap();
+            let afi_safi_cfg = instance.config.afi_safi.get_mut(&afi_safi).unwrap();
 
             let default = args.dnode.get_string();
             let default = DefaultPolicyType::try_from_yang(&default).unwrap();
-            afi_safi.apply_policy.default_import_policy = default;
+            afi_safi_cfg.apply_policy.default_import_policy = default;
+
+            let event_queue = args.event_queue;
+            event_queue.insert(Event::PolicyImportReapply(None, Some(afi_safi)));
         })
         .path(bgp::global::afi_safis::afi_safi::apply_policy::export_policy::PATH)
         .create_apply(|instance, args| {
@@ -649,16 +659,25 @@ fn load_callbacks() -> Callbacks<Instance> {
         .create_apply(|instance, args| {
             let policy = args.dnode.get_string();
             instance.config.apply_policy.import_policy.insert(policy);
+
+            let event_queue = args.event_queue;
+            event_queue.insert(Event::PolicyImportReapply(None, None));
         })
         .delete_apply(|instance, args| {
             let policy = args.dnode.get_string();
             instance.config.apply_policy.import_policy.remove(&policy);
+
+            let event_queue = args.event_queue;
+            event_queue.insert(Event::PolicyImportReapply(None, None));
         })
         .path(bgp::global::apply_policy::default_import_policy::PATH)
         .modify_apply(|instance, args| {
             let default = args.dnode.get_string();
             let default = DefaultPolicyType::try_from_yang(&default).unwrap();
             instance.config.apply_policy.default_import_policy = default;
+
+            let event_queue = args.event_queue;
+            event_queue.insert(Event::PolicyImportReapply(None, None));
         })
         .path(bgp::global::apply_policy::export_policy::PATH)
         .create_apply(|instance, args| {
@@ -1082,6 +1101,9 @@ fn load_callbacks() -> Callbacks<Instance> {
 
             let policy = args.dnode.get_string();
             nbr.config.apply_policy.import_policy.insert(policy);
+
+            let event_queue = args.event_queue;
+            event_queue.insert(Event::PolicyImportReapply(Some(nbr_addr), None));
         })
         .delete_apply(|instance, args| {
             let nbr_addr = args.list_entry.into_neighbor().unwrap();
@@ -1089,6 +1111,9 @@ fn load_callbacks() -> Callbacks<Instance> {
 
             let policy = args.dnode.get_string();
             nbr.config.apply_policy.import_policy.remove(&policy);
+
+            let event_queue = args.event_queue;
+            event_queue.insert(Event::PolicyImportReapply(Some(nbr_addr), None));
         })
         .path(bgp::neighbors::neighbor::apply_policy::default_import_policy::PATH)
         .modify_apply(|instance, args| {
@@ -1098,6 +1123,9 @@ fn load_callbacks() -> Callbacks<Instance> {
             let default = args.dnode.get_string();
             let default = DefaultPolicyType::try_from_yang(&default).unwrap();
             nbr.config.apply_policy.default_import_policy = default;
+
+            let event_queue = args.event_queue;
+            event_queue.insert(Event::PolicyImportReapply(Some(nbr_addr), None));
         })
         .path(bgp::neighbors::neighbor::apply_policy::export_policy::PATH)
         .create_apply(|instance, args| {
@@ -1207,28 +1235,37 @@ fn load_callbacks() -> Callbacks<Instance> {
         .create_apply(|instance, args| {
             let (nbr_addr, afi_safi) = args.list_entry.into_neighbor_afi_safi().unwrap();
             let nbr = instance.neighbors.get_mut(&nbr_addr).unwrap();
-            let afi_safi = nbr.config.afi_safi.get_mut(&afi_safi).unwrap();
+            let afi_safi_cfg = nbr.config.afi_safi.get_mut(&afi_safi).unwrap();
 
             let policy = args.dnode.get_string();
-            afi_safi.apply_policy.import_policy.insert(policy);
+            afi_safi_cfg.apply_policy.import_policy.insert(policy);
+
+            let event_queue = args.event_queue;
+            event_queue.insert(Event::PolicyImportReapply(Some(nbr_addr), Some(afi_safi)));
         })
         .delete_apply(|instance, args| {
             let (nbr_addr, afi_safi) = args.list_entry.into_neighbor_afi_safi().unwrap();
             let nbr = instance.neighbors.get_mut(&nbr_addr).unwrap();
-            let afi_safi = nbr.config.afi_safi.get_mut(&afi_safi).unwrap();
+            let afi_safi_cfg = nbr.config.afi_safi.get_mut(&afi_safi).unwrap();
 
             let policy = args.dnode.get_string();
-            afi_safi.apply_policy.import_policy.remove(&policy);
+            afi_safi_cfg.apply_policy.import_policy.remove(&policy);
+
+            let event_queue = args.event_queue;
+            event_queue.insert(Event::PolicyImportReapply(Some(nbr_addr), Some(afi_safi)));
         })
         .path(bgp::neighbors::neighbor::afi_safis::afi_safi::apply_policy::default_import_policy::PATH)
         .modify_apply(|instance, args| {
             let (nbr_addr, afi_safi) = args.list_entry.into_neighbor_afi_safi().unwrap();
             let nbr = instance.neighbors.get_mut(&nbr_addr).unwrap();
-            let afi_safi = nbr.config.afi_safi.get_mut(&afi_safi).unwrap();
+            let afi_safi_cfg = nbr.config.afi_safi.get_mut(&afi_safi).unwrap();
 
             let default = args.dnode.get_string();
             let default = DefaultPolicyType::try_from_yang(&default).unwrap();
-            afi_safi.apply_policy.default_import_policy = default;
+            afi_safi_cfg.apply_policy.default_import_policy = default;
+
+            let event_queue = args.event_queue;
+            event_queue.insert(Event::PolicyImportReapply(Some(nbr_addr), Some(afi_safi)));
         })
         .path(bgp::neighbors::neighbor::afi_safis::afi_safi::apply_policy::export_policy::PATH)
         .create_apply(|instance, args| {
@@ -1574,6 +1611,62 @@ impl Provider for Instance {
                 // Set/unset password in the listening sockets.
                 for listener in instance.state.listening_sockets.iter().filter(|listener| listener.af == nbr_addr.address_family()) {
                     network::listen_socket_md5sig_update(&listener.socket, &nbr_addr, key.as_deref());
+                }
+            }
+            Event::PolicyImportReapply(nbr_addr, afi_safi) => {
+                let Some((mut instance, neighbors)) = self.as_up() else {
+                    return;
+                };
+
+                match (nbr_addr, afi_safi) {
+                    (Some(nbr_addr), Some(AfiSafi::Ipv4Unicast)) => {
+                        events::reapply_nbr_import_policy::<Ipv4Unicast>(
+                            &mut instance,
+                            neighbors,
+                            nbr_addr,
+                        );
+                    }
+                    (Some(nbr_addr), Some(AfiSafi::Ipv6Unicast)) => {
+                        events::reapply_nbr_import_policy::<Ipv6Unicast>(
+                            &mut instance,
+                            neighbors,
+                            nbr_addr,
+                        );
+                    }
+                    (Some(nbr_addr), None) => {
+                        events::reapply_nbr_import_policy::<Ipv4Unicast>(
+                            &mut instance,
+                            neighbors,
+                            nbr_addr,
+                        );
+                        events::reapply_nbr_import_policy::<Ipv6Unicast>(
+                            &mut instance,
+                            neighbors,
+                            nbr_addr,
+                        );
+                    }
+                    (None, Some(AfiSafi::Ipv4Unicast)) => {
+                        events::reapply_import_policy_all::<Ipv4Unicast>(
+                            &mut instance,
+                            neighbors,
+                        );
+                    }
+                    (None, Some(AfiSafi::Ipv6Unicast)) => {
+                        events::reapply_import_policy_all::<Ipv6Unicast>(
+                            &mut instance,
+                            neighbors,
+                        );
+                    }
+                    (None, None) => {
+                        events::reapply_import_policy_all::<Ipv4Unicast>(
+                            &mut instance,
+                            neighbors,
+                        );
+                        events::reapply_import_policy_all::<Ipv6Unicast>(
+                            &mut instance,
+                            neighbors,
+                        );
+                    }
                 }
             }
             Event::RedistributeIbusSub(protocol, af) => {

--- a/holo-bgp/src/northbound/configuration.rs
+++ b/holo-bgp/src/northbound/configuration.rs
@@ -1620,52 +1620,24 @@ impl Provider for Instance {
 
                 match (nbr_addr, afi_safi) {
                     (Some(nbr_addr), Some(AfiSafi::Ipv4Unicast)) => {
-                        events::reapply_nbr_import_policy::<Ipv4Unicast>(
-                            &mut instance,
-                            neighbors,
-                            nbr_addr,
-                        );
+                        events::reapply_nbr_import_policy::<Ipv4Unicast>(&mut instance, neighbors, nbr_addr);
                     }
                     (Some(nbr_addr), Some(AfiSafi::Ipv6Unicast)) => {
-                        events::reapply_nbr_import_policy::<Ipv6Unicast>(
-                            &mut instance,
-                            neighbors,
-                            nbr_addr,
-                        );
+                        events::reapply_nbr_import_policy::<Ipv6Unicast>(&mut instance, neighbors, nbr_addr);
                     }
                     (Some(nbr_addr), None) => {
-                        events::reapply_nbr_import_policy::<Ipv4Unicast>(
-                            &mut instance,
-                            neighbors,
-                            nbr_addr,
-                        );
-                        events::reapply_nbr_import_policy::<Ipv6Unicast>(
-                            &mut instance,
-                            neighbors,
-                            nbr_addr,
-                        );
+                        events::reapply_nbr_import_policy::<Ipv4Unicast>(&mut instance, neighbors, nbr_addr);
+                        events::reapply_nbr_import_policy::<Ipv6Unicast>(&mut instance, neighbors, nbr_addr);
                     }
                     (None, Some(AfiSafi::Ipv4Unicast)) => {
-                        events::reapply_import_policy_all::<Ipv4Unicast>(
-                            &mut instance,
-                            neighbors,
-                        );
+                        events::reapply_import_policy_all::<Ipv4Unicast>(&mut instance, neighbors);
                     }
                     (None, Some(AfiSafi::Ipv6Unicast)) => {
-                        events::reapply_import_policy_all::<Ipv6Unicast>(
-                            &mut instance,
-                            neighbors,
-                        );
+                        events::reapply_import_policy_all::<Ipv6Unicast>(&mut instance, neighbors);
                     }
                     (None, None) => {
-                        events::reapply_import_policy_all::<Ipv4Unicast>(
-                            &mut instance,
-                            neighbors,
-                        );
-                        events::reapply_import_policy_all::<Ipv6Unicast>(
-                            &mut instance,
-                            neighbors,
-                        );
+                        events::reapply_import_policy_all::<Ipv4Unicast>(&mut instance, neighbors);
+                        events::reapply_import_policy_all::<Ipv6Unicast>(&mut instance, neighbors);
                     }
                 }
             }

--- a/holo-bgp/src/policy.rs
+++ b/holo-bgp/src/policy.rs
@@ -13,9 +13,9 @@ use holo_utils::bgp::{AfiSafi, RouteType};
 use holo_utils::ip::IpNetworkKind;
 use holo_utils::policy::{
     BgpNexthop, BgpPolicyAction, BgpPolicyCondition, BgpSetCommMethod,
-    BgpSetCommOptions, BgpSetMed, DefaultPolicyType, MatchSets,
-    MatchSetRestrictedType, MatchSetType, MetricModification, Policy,
-    PolicyAction, PolicyCondition, PolicyResult, PolicyStmt, PolicyType,
+    BgpSetCommOptions, BgpSetMed, DefaultPolicyType, MatchSetRestrictedType,
+    MatchSetType, MatchSets, MetricModification, Policy, PolicyAction,
+    PolicyCondition, PolicyResult, PolicyStmt, PolicyType,
 };
 use holo_utils::southbound::RouteOpaqueAttrs;
 use ipnetwork::IpNetwork;
@@ -316,9 +316,9 @@ fn process_stmt_condition(
                 // "match-ext-community-set"
                 BgpPolicyCondition::MatchExtCommSet { value, match_type } => {
                     if let Some(ext_comm) = &attrs.ext_comm {
-                        match_sets.bgp.ext_comms.get(value).is_some_and(
-                            |set| match_comm_set(match_type, set, &ext_comm.0),
-                        )
+                        match_sets.bgp.ext_comms.get(value).is_some_and(|set| {
+                            match_comm_set(match_type, set, &ext_comm.0)
+                        })
                     } else {
                         false
                     }
@@ -327,7 +327,9 @@ fn process_stmt_condition(
                 BgpPolicyCondition::MatchExtv6CommSet { value, match_type } => {
                     if let Some(extv6_comm) = &attrs.extv6_comm {
                         match_sets.bgp.extv6_comms.get(value).is_some_and(
-                            |set| match_comm_set(match_type, set, &extv6_comm.0),
+                            |set| {
+                                match_comm_set(match_type, set, &extv6_comm.0)
+                            },
                         )
                     } else {
                         false
@@ -337,7 +339,9 @@ fn process_stmt_condition(
                 BgpPolicyCondition::MatchLargeCommSet { value, match_type } => {
                     if let Some(large_comm) = &attrs.large_comm {
                         match_sets.bgp.large_comms.get(value).is_some_and(
-                            |set| match_comm_set(match_type, set, &large_comm.0),
+                            |set| {
+                                match_comm_set(match_type, set, &large_comm.0)
+                            },
                         )
                     } else {
                         false
@@ -574,7 +578,9 @@ mod tests {
     };
 
     use super::*;
-    use crate::packet::attribute::{AsPath, AsPathSegment, AsPathSegmentType, CommList};
+    use crate::packet::attribute::{
+        AsPath, AsPathSegment, AsPathSegmentType, CommList,
+    };
 
     fn route_info() -> RoutePolicyInfo {
         RoutePolicyInfo::new(
@@ -687,17 +693,20 @@ mod tests {
     #[test]
     fn missing_bgp_set_reference_is_no_match() {
         let mut stmt = PolicyStmt::new("10".to_owned());
-        stmt.condition_add(PolicyCondition::Bgp(BgpPolicyCondition::MatchCommSet {
-            value: "MISSING".to_owned(),
-            match_type: MatchSetType::Any,
-        }));
+        stmt.condition_add(PolicyCondition::Bgp(
+            BgpPolicyCondition::MatchCommSet {
+                value: "MISSING".to_owned(),
+                match_type: MatchSetType::Any,
+            },
+        ));
         stmt.action_add(PolicyAction::Accept(true));
 
         let mut policy = Policy::new("POLICY".to_owned());
         policy.stmt_add(stmt);
 
         let mut route = route_info();
-        route.attrs.comm = Some(CommList(BTreeSet::from([holo_utils::bgp::Comm(100)])));
+        route.attrs.comm =
+            Some(CommList(BTreeSet::from([holo_utils::bgp::Comm(100)])));
 
         let result = process_policies(
             AfiSafi::Ipv4Unicast,
@@ -714,10 +723,12 @@ mod tests {
     #[test]
     fn community_match_all_requires_all_members_on_route() {
         let mut stmt = PolicyStmt::new("10".to_owned());
-        stmt.condition_add(PolicyCondition::Bgp(BgpPolicyCondition::MatchCommSet {
-            value: "COMM".to_owned(),
-            match_type: MatchSetType::All,
-        }));
+        stmt.condition_add(PolicyCondition::Bgp(
+            BgpPolicyCondition::MatchCommSet {
+                value: "COMM".to_owned(),
+                match_type: MatchSetType::All,
+            },
+        ));
         stmt.action_add(PolicyAction::Accept(true));
 
         let mut policy = Policy::new("POLICY".to_owned());
@@ -726,11 +737,15 @@ mod tests {
         let mut match_sets = MatchSets::default();
         match_sets.bgp.comms.insert(
             "COMM".to_owned(),
-            BTreeSet::from([holo_utils::bgp::Comm(100), holo_utils::bgp::Comm(200)]),
+            BTreeSet::from([
+                holo_utils::bgp::Comm(100),
+                holo_utils::bgp::Comm(200),
+            ]),
         );
 
         let mut route = route_info();
-        route.attrs.comm = Some(CommList(BTreeSet::from([holo_utils::bgp::Comm(100)])));
+        route.attrs.comm =
+            Some(CommList(BTreeSet::from([holo_utils::bgp::Comm(100)])));
         let result = process_policies(
             AfiSafi::Ipv4Unicast,
             "198.51.100.0/24".parse().unwrap(),
@@ -772,7 +787,10 @@ mod tests {
         policy.stmt_add(stmt);
 
         let mut match_sets = MatchSets::default();
-        match_sets.bgp.as_paths.insert("ASNS".to_owned(), BTreeSet::from([65001]));
+        match_sets
+            .bgp
+            .as_paths
+            .insert("ASNS".to_owned(), BTreeSet::from([65001]));
 
         let mut route = route_info();
         route.attrs.base.as_path = AsPath {
@@ -823,7 +841,9 @@ mod tests {
         let mut stmt = PolicyStmt::new("10".to_owned());
         stmt.action_add(PolicyAction::Bgp(BgpPolicyAction::SetComm {
             options: BgpSetCommOptions::Remove,
-            method: BgpSetCommMethod::Inline(BTreeSet::from([holo_utils::bgp::Comm(100)])),
+            method: BgpSetCommMethod::Inline(BTreeSet::from([
+                holo_utils::bgp::Comm(100),
+            ])),
         }));
         stmt.action_add(PolicyAction::Accept(true));
 
@@ -831,7 +851,8 @@ mod tests {
         policy.stmt_add(stmt);
 
         let mut route = route_info();
-        route.attrs.comm = Some(CommList(BTreeSet::from([holo_utils::bgp::Comm(200)])));
+        route.attrs.comm =
+            Some(CommList(BTreeSet::from([holo_utils::bgp::Comm(200)])));
         let result = process_policies(
             AfiSafi::Ipv4Unicast,
             "198.51.100.0/24".parse().unwrap(),
@@ -855,7 +876,9 @@ mod tests {
         let mut stmt = PolicyStmt::new("10".to_owned());
         stmt.action_add(PolicyAction::Bgp(BgpPolicyAction::SetComm {
             options: BgpSetCommOptions::Add,
-            method: BgpSetCommMethod::Inline(BTreeSet::from([holo_utils::bgp::Comm(200)])),
+            method: BgpSetCommMethod::Inline(BTreeSet::from([
+                holo_utils::bgp::Comm(200),
+            ])),
         }));
 
         let mut policy = Policy::new("POLICY".to_owned());
@@ -863,7 +886,8 @@ mod tests {
         policy.stmt_add(accept_stmt("20"));
 
         let mut route = route_info();
-        route.attrs.comm = Some(CommList(BTreeSet::from([holo_utils::bgp::Comm(100)])));
+        route.attrs.comm =
+            Some(CommList(BTreeSet::from([holo_utils::bgp::Comm(100)])));
         let result = process_policies(
             AfiSafi::Ipv4Unicast,
             "198.51.100.0/24".parse().unwrap(),
@@ -878,13 +902,18 @@ mod tests {
         };
         assert_eq!(
             route.attrs.comm.unwrap().0,
-            BTreeSet::from([holo_utils::bgp::Comm(100), holo_utils::bgp::Comm(200)])
+            BTreeSet::from([
+                holo_utils::bgp::Comm(100),
+                holo_utils::bgp::Comm(200)
+            ])
         );
 
         let mut stmt = PolicyStmt::new("10".to_owned());
         stmt.action_add(PolicyAction::Bgp(BgpPolicyAction::SetComm {
             options: BgpSetCommOptions::Replace,
-            method: BgpSetCommMethod::Inline(BTreeSet::from([holo_utils::bgp::Comm(300)])),
+            method: BgpSetCommMethod::Inline(BTreeSet::from([
+                holo_utils::bgp::Comm(300),
+            ])),
         }));
 
         let mut policy = Policy::new("POLICY".to_owned());
@@ -892,7 +921,8 @@ mod tests {
         policy.stmt_add(accept_stmt("20"));
 
         let mut route = route_info();
-        route.attrs.comm = Some(CommList(BTreeSet::from([holo_utils::bgp::Comm(100)])));
+        route.attrs.comm =
+            Some(CommList(BTreeSet::from([holo_utils::bgp::Comm(100)])));
         let result = process_policies(
             AfiSafi::Ipv4Unicast,
             "198.51.100.0/24".parse().unwrap(),

--- a/holo-bgp/src/policy.rs
+++ b/holo-bgp/src/policy.rs
@@ -307,7 +307,7 @@ fn process_stmt_condition(
                 BgpPolicyCondition::MatchCommSet { value, match_type } => {
                     if let Some(comm) = &attrs.comm {
                         match_sets.bgp.comms.get(value).is_some_and(|set| {
-                            match_type.compare(set, &comm.0)
+                            match_comm_set(match_type, set, &comm.0)
                         })
                     } else {
                         false
@@ -317,7 +317,7 @@ fn process_stmt_condition(
                 BgpPolicyCondition::MatchExtCommSet { value, match_type } => {
                     if let Some(ext_comm) = &attrs.ext_comm {
                         match_sets.bgp.ext_comms.get(value).is_some_and(
-                            |set| match_type.compare(set, &ext_comm.0),
+                            |set| match_comm_set(match_type, set, &ext_comm.0),
                         )
                     } else {
                         false
@@ -327,7 +327,7 @@ fn process_stmt_condition(
                 BgpPolicyCondition::MatchExtv6CommSet { value, match_type } => {
                     if let Some(extv6_comm) = &attrs.extv6_comm {
                         match_sets.bgp.extv6_comms.get(value).is_some_and(
-                            |set| match_type.compare(set, &extv6_comm.0),
+                            |set| match_comm_set(match_type, set, &extv6_comm.0),
                         )
                     } else {
                         false
@@ -337,7 +337,7 @@ fn process_stmt_condition(
                 BgpPolicyCondition::MatchLargeCommSet { value, match_type } => {
                     if let Some(large_comm) = &attrs.large_comm {
                         match_sets.bgp.large_comms.get(value).is_some_and(
-                            |set| match_type.compare(set, &large_comm.0),
+                            |set| match_comm_set(match_type, set, &large_comm.0),
                         )
                     } else {
                         false
@@ -347,7 +347,7 @@ fn process_stmt_condition(
                 BgpPolicyCondition::MatchAsPathSet { value, match_type } => {
                     match_sets.bgp.as_paths.get(value).is_some_and(|set| {
                         let asns = attrs.base.as_path.iter().collect();
-                        match_type.compare(set, &asns)
+                        match_comm_set(match_type, set, &asns)
                     })
                 }
                 // "match-next-hop-set"
@@ -366,6 +366,21 @@ fn process_stmt_condition(
         }
         // Ignore unsupported conditions.
         _ => true,
+    }
+}
+
+fn match_comm_set<T>(
+    match_type: &MatchSetType,
+    policy_set: &BTreeSet<T>,
+    route_values: &BTreeSet<T>,
+) -> bool
+where
+    T: Eq + Ord + PartialEq + PartialOrd,
+{
+    match match_type {
+        MatchSetType::Any => !policy_set.is_disjoint(route_values),
+        MatchSetType::All => route_values.is_superset(policy_set),
+        MatchSetType::Invert => policy_set.is_disjoint(route_values),
     }
 }
 
@@ -551,7 +566,7 @@ where
 
 #[cfg(test)]
 mod tests {
-    use std::collections::BTreeSet;
+    use std::collections::{BTreeSet, VecDeque};
 
     use holo_utils::ip::AddressFamily;
     use holo_utils::policy::{
@@ -559,7 +574,7 @@ mod tests {
     };
 
     use super::*;
-    use crate::packet::attribute::CommList;
+    use crate::packet::attribute::{AsPath, AsPathSegment, AsPathSegmentType, CommList};
 
     fn route_info() -> RoutePolicyInfo {
         RoutePolicyInfo::new(
@@ -694,6 +709,206 @@ mod tests {
         );
 
         assert!(matches!(result, PolicyResult::Reject));
+    }
+
+    #[test]
+    fn community_match_all_requires_all_members_on_route() {
+        let mut stmt = PolicyStmt::new("10".to_owned());
+        stmt.condition_add(PolicyCondition::Bgp(BgpPolicyCondition::MatchCommSet {
+            value: "COMM".to_owned(),
+            match_type: MatchSetType::All,
+        }));
+        stmt.action_add(PolicyAction::Accept(true));
+
+        let mut policy = Policy::new("POLICY".to_owned());
+        policy.stmt_add(stmt);
+
+        let mut match_sets = MatchSets::default();
+        match_sets.bgp.comms.insert(
+            "COMM".to_owned(),
+            BTreeSet::from([holo_utils::bgp::Comm(100), holo_utils::bgp::Comm(200)]),
+        );
+
+        let mut route = route_info();
+        route.attrs.comm = Some(CommList(BTreeSet::from([holo_utils::bgp::Comm(100)])));
+        let result = process_policies(
+            AfiSafi::Ipv4Unicast,
+            "198.51.100.0/24".parse().unwrap(),
+            route,
+            &[Arc::new(policy.clone())],
+            &match_sets,
+            DefaultPolicyType::RejectRoute,
+        );
+        assert!(matches!(result, PolicyResult::Reject));
+
+        let mut route = route_info();
+        route.attrs.comm = Some(CommList(BTreeSet::from([
+            holo_utils::bgp::Comm(100),
+            holo_utils::bgp::Comm(200),
+        ])));
+        let result = process_policies(
+            AfiSafi::Ipv4Unicast,
+            "198.51.100.0/24".parse().unwrap(),
+            route,
+            &[Arc::new(policy)],
+            &match_sets,
+            DefaultPolicyType::RejectRoute,
+        );
+        assert!(matches!(result, PolicyResult::Accept(_)));
+    }
+
+    #[test]
+    fn as_path_set_matches_literal_as_membership() {
+        let mut stmt = PolicyStmt::new("10".to_owned());
+        stmt.condition_add(PolicyCondition::Bgp(
+            BgpPolicyCondition::MatchAsPathSet {
+                value: "ASNS".to_owned(),
+                match_type: MatchSetType::Any,
+            },
+        ));
+        stmt.action_add(PolicyAction::Accept(true));
+
+        let mut policy = Policy::new("POLICY".to_owned());
+        policy.stmt_add(stmt);
+
+        let mut match_sets = MatchSets::default();
+        match_sets.bgp.as_paths.insert("ASNS".to_owned(), BTreeSet::from([65001]));
+
+        let mut route = route_info();
+        route.attrs.base.as_path = AsPath {
+            segments: VecDeque::from([AsPathSegment {
+                seg_type: AsPathSegmentType::Sequence,
+                members: VecDeque::from([65000, 65001]),
+            }]),
+        };
+
+        let result = process_policies(
+            AfiSafi::Ipv4Unicast,
+            "198.51.100.0/24".parse().unwrap(),
+            route,
+            &[Arc::new(policy)],
+            &match_sets,
+            DefaultPolicyType::RejectRoute,
+        );
+
+        assert!(matches!(result, PolicyResult::Accept(_)));
+    }
+
+    #[test]
+    fn set_action_missing_reference_rejects_route() {
+        let mut stmt = PolicyStmt::new("10".to_owned());
+        stmt.action_add(PolicyAction::Bgp(BgpPolicyAction::SetComm {
+            options: BgpSetCommOptions::Add,
+            method: BgpSetCommMethod::Reference("MISSING".to_owned()),
+        }));
+        stmt.action_add(PolicyAction::Accept(true));
+
+        let mut policy = Policy::new("POLICY".to_owned());
+        policy.stmt_add(stmt);
+
+        let result = process_policies(
+            AfiSafi::Ipv4Unicast,
+            "198.51.100.0/24".parse().unwrap(),
+            route_info(),
+            &[Arc::new(policy)],
+            &MatchSets::default(),
+            DefaultPolicyType::RejectRoute,
+        );
+
+        assert!(matches!(result, PolicyResult::Reject));
+    }
+
+    #[test]
+    fn remove_absent_community_is_noop() {
+        let mut stmt = PolicyStmt::new("10".to_owned());
+        stmt.action_add(PolicyAction::Bgp(BgpPolicyAction::SetComm {
+            options: BgpSetCommOptions::Remove,
+            method: BgpSetCommMethod::Inline(BTreeSet::from([holo_utils::bgp::Comm(100)])),
+        }));
+        stmt.action_add(PolicyAction::Accept(true));
+
+        let mut policy = Policy::new("POLICY".to_owned());
+        policy.stmt_add(stmt);
+
+        let mut route = route_info();
+        route.attrs.comm = Some(CommList(BTreeSet::from([holo_utils::bgp::Comm(200)])));
+        let result = process_policies(
+            AfiSafi::Ipv4Unicast,
+            "198.51.100.0/24".parse().unwrap(),
+            route,
+            &[Arc::new(policy)],
+            &MatchSets::default(),
+            DefaultPolicyType::RejectRoute,
+        );
+
+        let PolicyResult::Accept(route) = result else {
+            panic!("route should be accepted");
+        };
+        assert_eq!(
+            route.attrs.comm.unwrap().0,
+            BTreeSet::from([holo_utils::bgp::Comm(200)])
+        );
+    }
+
+    #[test]
+    fn community_actions_add_and_replace_values() {
+        let mut stmt = PolicyStmt::new("10".to_owned());
+        stmt.action_add(PolicyAction::Bgp(BgpPolicyAction::SetComm {
+            options: BgpSetCommOptions::Add,
+            method: BgpSetCommMethod::Inline(BTreeSet::from([holo_utils::bgp::Comm(200)])),
+        }));
+
+        let mut policy = Policy::new("POLICY".to_owned());
+        policy.stmt_add(stmt);
+        policy.stmt_add(accept_stmt("20"));
+
+        let mut route = route_info();
+        route.attrs.comm = Some(CommList(BTreeSet::from([holo_utils::bgp::Comm(100)])));
+        let result = process_policies(
+            AfiSafi::Ipv4Unicast,
+            "198.51.100.0/24".parse().unwrap(),
+            route,
+            &[Arc::new(policy)],
+            &MatchSets::default(),
+            DefaultPolicyType::RejectRoute,
+        );
+
+        let PolicyResult::Accept(route) = result else {
+            panic!("route should be accepted");
+        };
+        assert_eq!(
+            route.attrs.comm.unwrap().0,
+            BTreeSet::from([holo_utils::bgp::Comm(100), holo_utils::bgp::Comm(200)])
+        );
+
+        let mut stmt = PolicyStmt::new("10".to_owned());
+        stmt.action_add(PolicyAction::Bgp(BgpPolicyAction::SetComm {
+            options: BgpSetCommOptions::Replace,
+            method: BgpSetCommMethod::Inline(BTreeSet::from([holo_utils::bgp::Comm(300)])),
+        }));
+
+        let mut policy = Policy::new("POLICY".to_owned());
+        policy.stmt_add(stmt);
+        policy.stmt_add(accept_stmt("20"));
+
+        let mut route = route_info();
+        route.attrs.comm = Some(CommList(BTreeSet::from([holo_utils::bgp::Comm(100)])));
+        let result = process_policies(
+            AfiSafi::Ipv4Unicast,
+            "198.51.100.0/24".parse().unwrap(),
+            route,
+            &[Arc::new(policy)],
+            &MatchSets::default(),
+            DefaultPolicyType::RejectRoute,
+        );
+
+        let PolicyResult::Accept(route) = result else {
+            panic!("route should be accepted");
+        };
+        assert_eq!(
+            route.attrs.comm.unwrap().0,
+            BTreeSet::from([holo_utils::bgp::Comm(300)])
+        );
     }
 
     #[test]

--- a/holo-bgp/src/policy.rs
+++ b/holo-bgp/src/policy.rs
@@ -14,8 +14,8 @@ use holo_utils::ip::IpNetworkKind;
 use holo_utils::policy::{
     BgpNexthop, BgpPolicyAction, BgpPolicyCondition, BgpSetCommMethod,
     BgpSetCommOptions, BgpSetMed, DefaultPolicyType, MatchSets,
-    MetricModification, Policy, PolicyAction, PolicyCondition, PolicyResult,
-    PolicyType,
+    MatchSetRestrictedType, MatchSetType, MetricModification, Policy,
+    PolicyAction, PolicyCondition, PolicyResult, PolicyStmt, PolicyType,
 };
 use holo_utils::southbound::RouteOpaqueAttrs;
 use ipnetwork::IpNetwork;
@@ -26,6 +26,12 @@ use tokio::sync::mpsc::UnboundedSender;
 use crate::packet::attribute::{Attrs, CommList, CommType};
 use crate::rib::RouteOrigin;
 use crate::tasks::messages::input::PolicyResultMsg;
+
+enum PolicyActionResult {
+    Continue,
+    Accept,
+    Reject,
+}
 
 // Represents a simplified version of `Route`, containing only information
 // relevant for the application of routing policies.
@@ -124,11 +130,11 @@ fn process_policies(
 ) -> PolicyResult<RoutePolicyInfo> {
     let mut matches = false;
 
-    for stmt in policies.iter().flat_map(|policy| policy.stmts.values()) {
+    for stmt in policies.iter().flat_map(|policy| policy.stmts_ordered()) {
         // Check if all conditions in the policy statement are satisfied.
         if !stmt.conditions.values().all(|condition| {
             process_stmt_condition(
-                afi_safi, &prefix, &rpinfo, condition, match_sets,
+                afi_safi, &prefix, &rpinfo, stmt, condition, match_sets,
             )
         }) {
             continue;
@@ -136,10 +142,30 @@ fn process_policies(
 
         matches = true;
 
-        // Process actions defined in the policy statement.
+        // Process route mutations before terminal accept/reject actions. The
+        // action map is keyed for replacement, not semantic evaluation order.
         for action in stmt.actions.values() {
-            if !process_stmt_action(&mut rpinfo.attrs, action, match_sets) {
-                return PolicyResult::Reject;
+            if matches!(action, PolicyAction::Accept(_)) {
+                continue;
+            }
+            match process_stmt_action(&mut rpinfo.attrs, action, match_sets) {
+                PolicyActionResult::Continue => {}
+                PolicyActionResult::Accept => {
+                    return PolicyResult::Accept(rpinfo);
+                }
+                PolicyActionResult::Reject => return PolicyResult::Reject,
+            }
+        }
+        for action in stmt.actions.values() {
+            if !matches!(action, PolicyAction::Accept(_)) {
+                continue;
+            }
+            match process_stmt_action(&mut rpinfo.attrs, action, match_sets) {
+                PolicyActionResult::Continue => {}
+                PolicyActionResult::Accept => {
+                    return PolicyResult::Accept(rpinfo);
+                }
+                PolicyActionResult::Reject => return PolicyResult::Reject,
             }
         }
     }
@@ -160,6 +186,7 @@ fn process_stmt_condition(
     afi_safi: AfiSafi,
     prefix: &IpNetwork,
     rpinfo: &RoutePolicyInfo,
+    stmt: &PolicyStmt,
     condition: &PolicyCondition,
     match_sets: &MatchSets,
 ) -> bool {
@@ -168,7 +195,7 @@ fn process_stmt_condition(
         // "source-protocol"
         PolicyCondition::SrcProtocol(value) => {
             let RouteOrigin::Protocol(protocol) = &rpinfo.origin else {
-                return true;
+                return false;
             };
 
             protocol == value
@@ -181,20 +208,24 @@ fn process_stmt_condition(
         // "match-prefix-set"
         PolicyCondition::MatchPrefixSet(value) => {
             let af = prefix.address_family();
-            match match_sets.prefixes.get(&(value.clone(), af)) {
+            let matches = match match_sets.prefixes.get(&(value.clone(), af)) {
                 Some(set) => set.prefixes.iter().any(|range| {
                     prefix.ip() == range.prefix.ip()
                         && prefix.prefix() >= range.masklen_lower
                         && prefix.prefix() <= range.masklen_upper
                 }),
                 None => false,
+            };
+            match stmt.prefix_set_match_type {
+                MatchSetRestrictedType::Any => matches,
+                MatchSetRestrictedType::Invert => !matches,
             }
         }
         // "match-neighbor-set"
         PolicyCondition::MatchNeighborSet(value) => {
             let RouteOrigin::Neighbor { remote_addr, .. } = &rpinfo.origin
             else {
-                return true;
+                return false;
             };
 
             match match_sets.neighbors.get(value) {
@@ -204,12 +235,16 @@ fn process_stmt_condition(
         }
         // "match-tag-set"
         PolicyCondition::MatchTagSet(value) => {
-            if let Some(tag) = &rpinfo.tag
+            let matches = if let Some(tag) = &rpinfo.tag
                 && let Some(set) = match_sets.tags.get(value)
             {
                 set.tags.contains(tag)
             } else {
                 false
+            };
+            match stmt.tag_set_match_type {
+                MatchSetType::Any | MatchSetType::All => matches,
+                MatchSetType::Invert => !matches,
             }
         }
         // "match-route-type"
@@ -223,11 +258,6 @@ fn process_stmt_condition(
         }
         // "bgp-conditions"
         PolicyCondition::Bgp(condition) => {
-            let RouteOrigin::Neighbor { remote_addr, .. } = &rpinfo.origin
-            else {
-                return true;
-            };
-
             match condition {
                 // "local-pref"
                 BgpPolicyCondition::LocalPref { value, op } => {
@@ -251,6 +281,11 @@ fn process_stmt_condition(
                 }
                 // "match-neighbor"
                 BgpPolicyCondition::MatchNeighbor { value, match_type } => {
+                    let RouteOrigin::Neighbor { remote_addr, .. } =
+                        &rpinfo.origin
+                    else {
+                        return false;
+                    };
                     match_type.compare(value, remote_addr)
                 }
                 // "route-type"
@@ -271,8 +306,9 @@ fn process_stmt_condition(
                 // "match-community-set"
                 BgpPolicyCondition::MatchCommSet { value, match_type } => {
                     if let Some(comm) = &attrs.comm {
-                        let set = match_sets.bgp.comms.get(value).unwrap();
-                        match_type.compare(set, &comm.0)
+                        match_sets.bgp.comms.get(value).is_some_and(|set| {
+                            match_type.compare(set, &comm.0)
+                        })
                     } else {
                         false
                     }
@@ -280,8 +316,9 @@ fn process_stmt_condition(
                 // "match-ext-community-set"
                 BgpPolicyCondition::MatchExtCommSet { value, match_type } => {
                     if let Some(ext_comm) = &attrs.ext_comm {
-                        let set = match_sets.bgp.ext_comms.get(value).unwrap();
-                        match_type.compare(set, &ext_comm.0)
+                        match_sets.bgp.ext_comms.get(value).is_some_and(
+                            |set| match_type.compare(set, &ext_comm.0),
+                        )
                     } else {
                         false
                     }
@@ -289,9 +326,9 @@ fn process_stmt_condition(
                 // "match-ipv6-ext-community-set"
                 BgpPolicyCondition::MatchExtv6CommSet { value, match_type } => {
                     if let Some(extv6_comm) = &attrs.extv6_comm {
-                        let set =
-                            match_sets.bgp.extv6_comms.get(value).unwrap();
-                        match_type.compare(set, &extv6_comm.0)
+                        match_sets.bgp.extv6_comms.get(value).is_some_and(
+                            |set| match_type.compare(set, &extv6_comm.0),
+                        )
                     } else {
                         false
                     }
@@ -299,18 +336,19 @@ fn process_stmt_condition(
                 // "match-large-community-set"
                 BgpPolicyCondition::MatchLargeCommSet { value, match_type } => {
                     if let Some(large_comm) = &attrs.large_comm {
-                        let set =
-                            match_sets.bgp.large_comms.get(value).unwrap();
-                        match_type.compare(set, &large_comm.0)
+                        match_sets.bgp.large_comms.get(value).is_some_and(
+                            |set| match_type.compare(set, &large_comm.0),
+                        )
                     } else {
                         false
                     }
                 }
                 // "match-as-path-set"
                 BgpPolicyCondition::MatchAsPathSet { value, match_type } => {
-                    let set = match_sets.bgp.as_paths.get(value).unwrap();
-                    let asns = attrs.base.as_path.iter().collect();
-                    match_type.compare(set, &asns)
+                    match_sets.bgp.as_paths.get(value).is_some_and(|set| {
+                        let asns = attrs.base.as_path.iter().collect();
+                        match_type.compare(set, &asns)
+                    })
                 }
                 // "match-next-hop-set"
                 BgpPolicyCondition::MatchNexthopSet { value, match_type } => {
@@ -318,8 +356,11 @@ fn process_stmt_condition(
                         Some(nexthop) => BgpNexthop::Addr(nexthop),
                         None => BgpNexthop::NexthopSelf,
                     };
-                    let set = match_sets.bgp.nexthops.get(value).unwrap();
-                    match_type.compare(set, &nexthop)
+                    match_sets
+                        .bgp
+                        .nexthops
+                        .get(value)
+                        .is_some_and(|set| match_type.compare(set, &nexthop))
                 }
             }
         }
@@ -330,17 +371,20 @@ fn process_stmt_condition(
 
 // Processes a single action statement within a routing policy.
 //
-// Returns a boolean value indicating whether the route should be accepted or
-// not.
+// Returns the policy flow-control result for this action.
 fn process_stmt_action(
     attrs: &mut Attrs,
     action: &PolicyAction,
     match_sets: &MatchSets,
-) -> bool {
+) -> PolicyActionResult {
     match action {
         // "policy-result"
         PolicyAction::Accept(accept) => {
-            return *accept;
+            return if *accept {
+                PolicyActionResult::Accept
+            } else {
+                PolicyActionResult::Reject
+            };
         }
         // "set-metric"
         PolicyAction::SetMetric { value, mod_type } => match mod_type {
@@ -405,46 +449,54 @@ fn process_stmt_action(
             }
             // "set-community"
             BgpPolicyAction::SetComm { options, method } => {
-                action_set_comm(
+                if !action_set_comm(
                     options,
                     method,
                     &match_sets.bgp.comms,
                     &mut attrs.comm,
-                );
+                ) {
+                    return PolicyActionResult::Reject;
+                }
             }
             // "set-ext-community"
             BgpPolicyAction::SetExtComm { options, method } => {
-                action_set_comm(
+                if !action_set_comm(
                     options,
                     method,
                     &match_sets.bgp.ext_comms,
                     &mut attrs.ext_comm,
-                );
+                ) {
+                    return PolicyActionResult::Reject;
+                }
             }
             // "set-ipv6-ext-community"
             BgpPolicyAction::SetExtv6Comm { options, method } => {
-                action_set_comm(
+                if !action_set_comm(
                     options,
                     method,
                     &match_sets.bgp.extv6_comms,
                     &mut attrs.extv6_comm,
-                );
+                ) {
+                    return PolicyActionResult::Reject;
+                }
             }
             // "set-large-community"
             BgpPolicyAction::SetLargeComm { options, method } => {
-                action_set_comm(
+                if !action_set_comm(
                     options,
                     method,
                     &match_sets.bgp.large_comms,
                     &mut attrs.large_comm,
-                );
+                ) {
+                    return PolicyActionResult::Reject;
+                }
             }
         },
         // Ignore unsupported actions.
         _ => {}
     }
 
-    true
+    PolicyActionResult::Continue
 }
 
 // Modifies the list of communities based on the specified method and options.
@@ -453,13 +505,19 @@ fn action_set_comm<T>(
     method: &BgpSetCommMethod<T>,
     comm_sets: &BTreeMap<String, BTreeSet<T>>,
     comm_list: &mut Option<CommList<T>>,
-) where
+) -> bool
+where
     T: CommType,
 {
     // Get list of communities.
     let comms = match method {
         BgpSetCommMethod::Inline(comms) => comms,
-        BgpSetCommMethod::Reference(set) => comm_sets.get(set).unwrap(),
+        BgpSetCommMethod::Reference(set) => {
+            let Some(comms) = comm_sets.get(set) else {
+                return false;
+            };
+            comms
+        }
     };
 
     // Add, remove or replace communities.
@@ -486,5 +544,181 @@ fn action_set_comm<T>(
         && list.0.is_empty()
     {
         *comm_list = None;
+    }
+
+    true
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeSet;
+
+    use holo_utils::ip::AddressFamily;
+    use holo_utils::policy::{
+        IpPrefixRange, Policy, PolicyAction, PolicyCondition, PolicyStmt,
+    };
+
+    use super::*;
+    use crate::packet::attribute::CommList;
+
+    fn route_info() -> RoutePolicyInfo {
+        RoutePolicyInfo::new(
+            RouteOrigin::Neighbor {
+                identifier: "192.0.2.2".parse().unwrap(),
+                remote_addr: "192.0.2.2".parse().unwrap(),
+            },
+            RouteType::External,
+            None,
+            None,
+            Attrs::default(),
+        )
+    }
+
+    fn accept_stmt(name: &str) -> PolicyStmt {
+        let mut stmt = PolicyStmt::new(name.to_owned());
+        stmt.action_add(PolicyAction::Accept(true));
+        stmt
+    }
+
+    fn reject_stmt(name: &str) -> PolicyStmt {
+        let mut stmt = PolicyStmt::new(name.to_owned());
+        stmt.action_add(PolicyAction::Accept(false));
+        stmt
+    }
+
+    #[test]
+    fn ordered_statements_are_not_key_sorted() {
+        let mut policy = Policy::new("POLICY".to_owned());
+        policy.stmt_add(accept_stmt("2"));
+        policy.stmt_add(reject_stmt("1"));
+
+        let result = process_policies(
+            AfiSafi::Ipv4Unicast,
+            "198.51.100.0/24".parse().unwrap(),
+            route_info(),
+            &[Arc::new(policy)],
+            &MatchSets::default(),
+            DefaultPolicyType::RejectRoute,
+        );
+
+        assert!(matches!(result, PolicyResult::Accept(_)));
+    }
+
+    #[test]
+    fn prefix_policy_can_mutate_then_accept() {
+        let mut stmt1 = PolicyStmt::new("10".to_owned());
+        stmt1.condition_add(PolicyCondition::MatchPrefixSet("PL".to_owned()));
+        stmt1.action_add(PolicyAction::Bgp(BgpPolicyAction::SetLocalPref(200)));
+
+        let mut policy = Policy::new("POLICY".to_owned());
+        policy.stmt_add(stmt1);
+        policy.stmt_add(accept_stmt("20"));
+
+        let mut match_sets = MatchSets::default();
+        let mut prefixes = BTreeSet::new();
+        prefixes.insert(IpPrefixRange {
+            prefix: "198.51.100.0/24".parse().unwrap(),
+            masklen_lower: 24,
+            masklen_upper: 32,
+        });
+        match_sets.prefixes.insert(
+            ("PL".to_owned(), AddressFamily::Ipv4),
+            holo_utils::policy::PrefixSet {
+                name: "PL".to_owned(),
+                mode: AddressFamily::Ipv4,
+                prefixes,
+            },
+        );
+
+        let result = process_policies(
+            AfiSafi::Ipv4Unicast,
+            "198.51.100.0/24".parse().unwrap(),
+            route_info(),
+            &[Arc::new(policy)],
+            &match_sets,
+            DefaultPolicyType::RejectRoute,
+        );
+
+        let PolicyResult::Accept(route) = result else {
+            panic!("route should be accepted");
+        };
+        assert_eq!(route.attrs.base.local_pref, Some(200));
+    }
+
+    #[test]
+    fn statement_actions_mutate_before_accepting() {
+        let mut stmt = PolicyStmt::new("10".to_owned());
+        stmt.action_add(PolicyAction::Accept(true));
+        stmt.action_add(PolicyAction::Bgp(BgpPolicyAction::SetLocalPref(300)));
+
+        let mut policy = Policy::new("POLICY".to_owned());
+        policy.stmt_add(stmt);
+
+        let result = process_policies(
+            AfiSafi::Ipv4Unicast,
+            "198.51.100.0/24".parse().unwrap(),
+            route_info(),
+            &[Arc::new(policy)],
+            &MatchSets::default(),
+            DefaultPolicyType::RejectRoute,
+        );
+
+        let PolicyResult::Accept(route) = result else {
+            panic!("route should be accepted");
+        };
+        assert_eq!(route.attrs.base.local_pref, Some(300));
+    }
+
+    #[test]
+    fn missing_bgp_set_reference_is_no_match() {
+        let mut stmt = PolicyStmt::new("10".to_owned());
+        stmt.condition_add(PolicyCondition::Bgp(BgpPolicyCondition::MatchCommSet {
+            value: "MISSING".to_owned(),
+            match_type: MatchSetType::Any,
+        }));
+        stmt.action_add(PolicyAction::Accept(true));
+
+        let mut policy = Policy::new("POLICY".to_owned());
+        policy.stmt_add(stmt);
+
+        let mut route = route_info();
+        route.attrs.comm = Some(CommList(BTreeSet::from([holo_utils::bgp::Comm(100)])));
+
+        let result = process_policies(
+            AfiSafi::Ipv4Unicast,
+            "198.51.100.0/24".parse().unwrap(),
+            route,
+            &[Arc::new(policy)],
+            &MatchSets::default(),
+            DefaultPolicyType::RejectRoute,
+        );
+
+        assert!(matches!(result, PolicyResult::Reject));
+    }
+
+    #[test]
+    fn afi_safi_condition_filters_routes() {
+        let mut stmt = PolicyStmt::new("10".to_owned());
+        stmt.condition_add(PolicyCondition::Bgp(
+            BgpPolicyCondition::MatchAfiSafi {
+                values: BTreeSet::from([AfiSafi::Ipv6Unicast]),
+                match_type: MatchSetRestrictedType::Any,
+            },
+        ));
+        stmt.action_add(PolicyAction::Accept(true));
+
+        let mut policy = Policy::new("POLICY".to_owned());
+        policy.stmt_add(stmt);
+
+        let result = process_policies(
+            AfiSafi::Ipv4Unicast,
+            "198.51.100.0/24".parse().unwrap(),
+            route_info(),
+            &[Arc::new(policy)],
+            &MatchSets::default(),
+            DefaultPolicyType::RejectRoute,
+        );
+
+        assert!(matches!(result, PolicyResult::Reject));
     }
 }

--- a/holo-bgp/src/tasks.rs
+++ b/holo-bgp/src/tasks.rs
@@ -181,6 +181,7 @@ pub mod messages {
                 nbr_addr: IpAddr,
                 afi_safi: AfiSafi,
                 routes: Vec<(IpNetwork, RoutePolicyInfo)>,
+                missing_policy: bool,
                 #[serde(skip)]
                 policies: Vec<Arc<Policy>>,
                 #[serde(skip)]
@@ -192,6 +193,7 @@ pub mod messages {
                 afi_safi: AfiSafi,
                 prefix: IpNetwork,
                 route: RoutePolicyInfo,
+                missing_policy: bool,
                 #[serde(skip)]
                 policies: Vec<Arc<Policy>>,
                 #[serde(skip)]
@@ -474,38 +476,67 @@ pub(crate) fn policy_apply(
                         nbr_addr,
                         afi_safi,
                         routes,
+                        missing_policy,
                         policies,
                         match_sets,
                         default_policy,
                     } => {
-                        policy::neighbor_apply(
-                            policy_type,
-                            nbr_addr,
-                            afi_safi,
-                            routes,
-                            &policies,
-                            &match_sets,
-                            default_policy,
-                            &policy_resultp,
-                        );
+                        if missing_policy {
+                            let routes = routes
+                                .into_iter()
+                                .map(|(prefix, _)| {
+                                    (prefix, holo_utils::policy::PolicyResult::Reject)
+                                })
+                                .collect();
+                            let _ = policy_resultp.send(
+                                messages::input::PolicyResultMsg::Neighbor {
+                                    policy_type,
+                                    nbr_addr,
+                                    afi_safi,
+                                    routes,
+                                },
+                            );
+                        } else {
+                            policy::neighbor_apply(
+                                policy_type,
+                                nbr_addr,
+                                afi_safi,
+                                routes,
+                                &policies,
+                                &match_sets,
+                                default_policy,
+                                &policy_resultp,
+                            );
+                        }
                     }
                     messages::output::PolicyApplyMsg::Redistribute {
                         afi_safi,
                         prefix,
                         route,
+                        missing_policy,
                         policies,
                         match_sets,
                         default_policy,
                     } => {
-                        policy::redistribute_apply(
-                            afi_safi,
-                            prefix,
-                            route,
-                            &policies,
-                            &match_sets,
-                            default_policy,
-                            &policy_resultp,
-                        );
+                        if missing_policy {
+                            let _ = policy_resultp.send(
+                                messages::input::PolicyResultMsg::Redistribute {
+                                    afi_safi,
+                                    prefix,
+                                    result: holo_utils::policy::PolicyResult::Reject,
+                                },
+                            );
+                        } else {
+                            policy::redistribute_apply(
+                                afi_safi,
+                                prefix,
+                                route,
+                                &policies,
+                                &match_sets,
+                                default_policy,
+                                &policy_resultp,
+                            );
+                        }
                     }
                 }
             }

--- a/holo-bgp/tests/conformance/soft-reconfig-in-1/01-input-ibus.jsonl
+++ b/holo-bgp/tests/conformance/soft-reconfig-in-1/01-input-ibus.jsonl
@@ -1,0 +1,2 @@
+{"PolicyMatchSetsUpd":{"prefixes":[[["ACCEPTED","Ipv4"],{"name":"ACCEPTED","mode":"Ipv4","prefixes":[{"prefix":"198.51.100.2/32","masklen_lower":32,"masklen_upper":32}]}]],"neighbors":{},"tags":{},"bgp":{"as_paths":{},"comms":{},"ext_comms":{},"extv6_comms":{},"large_comms":{},"nexthops":{}}}}
+{"PolicyUpd":{"name":"SOFT-IN","stmt_order":["10"],"stmts":{"10":{"name":"10","prefix_set_match_type":"Any","tag_set_match_type":"Any","conditions":[["MatchPrefixSet",{"MatchPrefixSet":"ACCEPTED"}]],"actions":[["Accept",{"Accept":true}]]}}}}

--- a/holo-bgp/tests/conformance/soft-reconfig-in-1/02-input-protocol.jsonl
+++ b/holo-bgp/tests/conformance/soft-reconfig-in-1/02-input-protocol.jsonl
@@ -1,0 +1,2 @@
+{"PolicyResult":{"Neighbor":{"policy_type":"Import","nbr_addr":"192.0.2.2","afi_safi":"Ipv4Unicast","routes":[["198.51.100.1/32","Reject"],["198.51.100.2/32",{"Accept":{"origin":{"Neighbor":{"identifier":"192.0.2.2","remote_addr":"192.0.2.2"}},"route_type":"External","attrs":{"base":{"origin":"Incomplete","as_path":{"segments":[{"seg_type":"Sequence","members":[65001]}]},"nexthop":"192.0.2.2"}}}}]]}}}
+{"TriggerDecisionProcess":null}

--- a/holo-bgp/tests/conformance/soft-reconfig-in-1/02-output-ibus.jsonl
+++ b/holo-bgp/tests/conformance/soft-reconfig-in-1/02-output-ibus.jsonl
@@ -1,0 +1,3 @@
+{"NexthopUntrack":{"addr":"192.0.2.2"}}
+{"NexthopTrack":{"addr":"192.0.2.2"}}
+{"RouteIpDel":{"protocol":"bgp","prefix":"198.51.100.1/32"}}

--- a/holo-bgp/tests/conformance/soft-reconfig-in-1/03-input-ibus.jsonl
+++ b/holo-bgp/tests/conformance/soft-reconfig-in-1/03-input-ibus.jsonl
@@ -1,0 +1,1 @@
+{"NexthopUpd":{"addr":"192.0.2.2","metric":0}}

--- a/holo-bgp/tests/conformance/soft-reconfig-in-1/04-input-protocol.jsonl
+++ b/holo-bgp/tests/conformance/soft-reconfig-in-1/04-input-protocol.jsonl
@@ -1,0 +1,1 @@
+{"TriggerDecisionProcess":null}

--- a/holo-bgp/tests/conformance/soft-reconfig-in-1/04-output-ibus.jsonl
+++ b/holo-bgp/tests/conformance/soft-reconfig-in-1/04-output-ibus.jsonl
@@ -1,0 +1,1 @@
+{"RouteIpAdd":{"protocol":"bgp","prefix":"198.51.100.2/32","distance":20,"metric":0,"tag":null,"nexthops":[{"Recursive":{"addr":"192.0.2.2","labels":[],"resolved":[]}}]}}

--- a/holo-bgp/tests/conformance/topologies/mod.rs
+++ b/holo-bgp/tests/conformance/topologies/mod.rs
@@ -27,3 +27,8 @@ async fn topology2_1() {
 async fn policy_core_1() {
     run_test_topology::<Instance>("policy-core-1", "rt1").await;
 }
+
+#[tokio::test]
+async fn policy_community_1() {
+    run_test_topology::<Instance>("policy-community-1", "rt1").await;
+}

--- a/holo-bgp/tests/conformance/topologies/mod.rs
+++ b/holo-bgp/tests/conformance/topologies/mod.rs
@@ -22,3 +22,8 @@ async fn topology2_1() {
         run_test_topology::<Instance>("topo2-1", &rt_name).await;
     }
 }
+
+#[tokio::test]
+async fn policy_core_1() {
+    run_test_topology::<Instance>("policy-core-1", "rt1").await;
+}

--- a/holo-bgp/tests/conformance/topologies/mod.rs
+++ b/holo-bgp/tests/conformance/topologies/mod.rs
@@ -5,7 +5,7 @@
 //
 
 use holo_bgp::instance::Instance;
-use holo_protocol::test::stub::run_test_topology;
+use holo_protocol::test::stub::{run_test, run_test_topology};
 
 #[tokio::test]
 async fn topology1_1() {
@@ -31,4 +31,10 @@ async fn policy_core_1() {
 #[tokio::test]
 async fn policy_community_1() {
     run_test_topology::<Instance>("policy-community-1", "rt1").await;
+}
+
+#[tokio::test]
+async fn soft_reconfig_in_1() {
+    run_test::<Instance>("soft-reconfig-in-1", "soft-reconfig-in-1", "rt1")
+        .await;
 }

--- a/holo-bgp/tests/conformance/topologies/policy-community-1/description.txt
+++ b/holo-bgp/tests/conformance/topologies/policy-community-1/description.txt
@@ -1,0 +1,1 @@
+BGP community and AS-path policy condition/action translation.

--- a/holo-bgp/tests/conformance/topologies/policy-community-1/rt1/config.json
+++ b/holo-bgp/tests/conformance/topologies/policy-community-1/rt1/config.json
@@ -1,0 +1,154 @@
+{
+  "ietf-routing:routing": {
+    "control-plane-protocols": {
+      "control-plane-protocol": [
+        {
+          "type": "ietf-bgp:bgp",
+          "name": "test",
+          "ietf-bgp:bgp": {
+            "global": {
+              "as": 65000,
+              "identifier": "192.0.2.1",
+              "afi-safis": {
+                "afi-safi": [
+                  {
+                    "name": "iana-bgp-types:ipv4-unicast",
+                    "apply-policy": {
+                      "import-policy": [
+                        "COMMUNITY"
+                      ],
+                      "default-import-policy": "reject-route"
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        }
+      ]
+    }
+  },
+  "ietf-routing-policy:routing-policy": {
+    "defined-sets": {
+      "ietf-bgp-policy:bgp-defined-sets": {
+        "as-path-sets": {
+          "as-path-set": [
+            {
+              "name": "ASNS",
+              "member": [
+                "65001"
+              ]
+            }
+          ]
+        },
+        "community-sets": {
+          "community-set": [
+            {
+              "name": "COMM-IN",
+              "member": [
+                "65000:100"
+              ]
+            },
+            {
+              "name": "COMM-OUT",
+              "member": [
+                "65000:200"
+              ]
+            }
+          ]
+        },
+        "ext-community-sets": {
+          "ext-community-set": [
+            {
+              "name": "EXT-IN",
+              "member": [
+                "raw:00:02:FD:E8:00:00:00:01"
+              ]
+            }
+          ]
+        },
+        "large-community-sets": {
+          "large-community-set": [
+            {
+              "name": "LARGE-REMOVE",
+              "member": [
+                "65000:300:1"
+              ]
+            }
+          ]
+        }
+      }
+    },
+    "policy-definitions": {
+      "policy-definition": [
+        {
+          "name": "COMMUNITY",
+          "statements": {
+            "statement": [
+              {
+                "name": "10",
+                "conditions": {
+                  "ietf-bgp-policy:bgp-conditions": {
+                    "match-community-set": {
+                      "community-set": "COMM-IN",
+                      "match-set-options": "any"
+                    }
+                  }
+                },
+                "actions": {
+                  "policy-result": "accept-route"
+                }
+              },
+              {
+                "name": "20",
+                "conditions": {
+                  "ietf-bgp-policy:bgp-conditions": {
+                    "match-as-path-set": {
+                      "as-path-set": "ASNS",
+                      "match-set-options": "any"
+                    }
+                  }
+                },
+                "actions": {
+                  "ietf-bgp-policy:bgp-actions": {
+                    "set-community": {
+                      "options": "add",
+                      "community-set-ref": "COMM-OUT"
+                    },
+                    "set-ext-community": {
+                      "options": "replace",
+                      "communities": [
+                        "raw:00:02:FD:E8:00:00:00:01"
+                      ]
+                    },
+                    "set-large-community": {
+                      "options": "remove",
+                      "communities": [
+                        "65000:300:1"
+                      ]
+                    }
+                  },
+                  "policy-result": "accept-route"
+                }
+              },
+              {
+                "name": "30",
+                "conditions": {
+                  "ietf-bgp-policy:bgp-conditions": {
+                    "match-ext-community-set": {
+                      "ext-community-set": "EXT-IN",
+                      "match-set-options": "any"
+                    }
+                  }
+                },
+                "actions": {
+                  "policy-result": "accept-route"
+                }
+              }
+            ]
+          }
+        }
+      ]
+    }
+  }
+}

--- a/holo-bgp/tests/conformance/topologies/policy-community-1/rt1/events.jsonl
+++ b/holo-bgp/tests/conformance/topologies/policy-community-1/rt1/events.jsonl
@@ -1,0 +1,1 @@
+{"Protocol":{"TriggerDecisionProcess":null}}

--- a/holo-bgp/tests/conformance/topologies/policy-community-1/rt1/output/ibus.jsonl
+++ b/holo-bgp/tests/conformance/topologies/policy-community-1/rt1/output/ibus.jsonl
@@ -1,0 +1,1 @@
+{"RouterIdSub":{}}

--- a/holo-bgp/tests/conformance/topologies/policy-community-1/rt1/output/northbound-state.json
+++ b/holo-bgp/tests/conformance/topologies/policy-community-1/rt1/output/northbound-state.json
@@ -1,0 +1,38 @@
+{
+  "ietf-routing:routing": {
+    "control-plane-protocols": {
+      "control-plane-protocol": [
+        {
+          "type": "ietf-bgp:bgp",
+          "name": "test",
+          "ietf-bgp:bgp": {
+            "global": {
+              "afi-safis": {
+                "afi-safi": [
+                  {
+                    "name": "iana-bgp-types:ipv4-unicast",
+                    "statistics": {
+                      "total-prefixes": 0
+                    }
+                  }
+                ]
+              },
+              "statistics": {
+                "total-prefixes": 0
+              }
+            },
+            "rib": {
+              "afi-safis": {
+                "afi-safi": [
+                  {
+                    "name": "iana-bgp-types:ipv4-unicast"
+                  }
+                ]
+              }
+            }
+          }
+        }
+      ]
+    }
+  }
+}

--- a/holo-bgp/tests/conformance/topologies/policy-core-1/description.txt
+++ b/holo-bgp/tests/conformance/topologies/policy-core-1/description.txt
@@ -1,0 +1,1 @@
+BGP policy core statement ordering and basic policy translation.

--- a/holo-bgp/tests/conformance/topologies/policy-core-1/rt1/config.json
+++ b/holo-bgp/tests/conformance/topologies/policy-core-1/rt1/config.json
@@ -1,0 +1,86 @@
+{
+  "ietf-routing:routing": {
+    "control-plane-protocols": {
+      "control-plane-protocol": [
+        {
+          "type": "ietf-bgp:bgp",
+          "name": "test",
+          "ietf-bgp:bgp": {
+            "global": {
+              "as": 65000,
+              "identifier": "192.0.2.1",
+              "afi-safis": {
+                "afi-safi": [
+                  {
+                    "name": "iana-bgp-types:ipv4-unicast",
+                    "apply-policy": {
+                      "import-policy": [
+                        "ORDERED"
+                      ]
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        }
+      ]
+    }
+  },
+  "ietf-routing-policy:routing-policy": {
+    "defined-sets": {
+      "prefix-sets": {
+        "prefix-set": [
+          {
+            "name": "DOC",
+            "mode": "ipv4",
+            "prefixes": {
+              "prefix-list": [
+                {
+                  "ip-prefix": "192.0.2.0/24",
+                  "mask-length-lower": 24,
+                  "mask-length-upper": 32
+                }
+              ]
+            }
+          }
+        ]
+      }
+    },
+    "policy-definitions": {
+      "policy-definition": [
+        {
+          "name": "ORDERED",
+          "statements": {
+            "statement": [
+              {
+                "name": "20",
+                "conditions": {
+                  "match-prefix-set": {
+                    "prefix-set": "DOC"
+                  },
+                  "ietf-bgp-policy:bgp-conditions": {
+                    "match-afi-safi": {
+                      "afi-safi-in": [
+                        "iana-bgp-types:ipv4-unicast"
+                      ]
+                    }
+                  }
+                },
+                "actions": {
+                  "policy-result": "accept-route"
+                }
+              },
+              {
+                "name": "10",
+                "actions": {
+                  "policy-result": "reject-route"
+                }
+              }
+            ]
+          }
+        }
+      ]
+    }
+  }
+}

--- a/holo-bgp/tests/conformance/topologies/policy-core-1/rt1/events.jsonl
+++ b/holo-bgp/tests/conformance/topologies/policy-core-1/rt1/events.jsonl
@@ -1,0 +1,4 @@
+{"Ibus":{"RouterIdUpdate":"192.0.2.1"}}
+{"Ibus":{"PolicyMatchSetsUpd":{"prefixes":[[["DOC","Ipv4"],{"name":"DOC","mode":"Ipv4","prefixes":[{"prefix":"192.0.2.0/24","masklen_lower":24,"masklen_upper":32}]}]],"neighbors":{},"tags":{},"bgp":{"as_paths":{},"comms":{},"ext_comms":{},"extv6_comms":{},"large_comms":{},"nexthops":{}}}}}
+{"Ibus":{"PolicyUpd":{"name":"ORDERED","stmt_order":["20","10"],"stmts":{"10":{"name":"10","prefix_set_match_type":"Any","tag_set_match_type":"Any","conditions":[],"actions":[["Accept",{"Accept":false}]]},"20":{"name":"20","prefix_set_match_type":"Any","tag_set_match_type":"Any","conditions":[["MatchPrefixSet",{"MatchPrefixSet":"DOC"}],[{"Bgp":"MatchAfiSafi"},{"Bgp":{"MatchAfiSafi":{"values":["Ipv4Unicast"],"match_type":"Any"}}}]],"actions":[["Accept",{"Accept":true}]]}}}}}
+{"Protocol":{"TriggerDecisionProcess":null}}

--- a/holo-bgp/tests/conformance/topologies/policy-core-1/rt1/output/ibus.jsonl
+++ b/holo-bgp/tests/conformance/topologies/policy-core-1/rt1/output/ibus.jsonl
@@ -1,0 +1,1 @@
+{"RouterIdSub":{}}

--- a/holo-bgp/tests/conformance/topologies/policy-core-1/rt1/output/northbound-state.json
+++ b/holo-bgp/tests/conformance/topologies/policy-core-1/rt1/output/northbound-state.json
@@ -1,0 +1,38 @@
+{
+  "ietf-routing:routing": {
+    "control-plane-protocols": {
+      "control-plane-protocol": [
+        {
+          "type": "ietf-bgp:bgp",
+          "name": "test",
+          "ietf-bgp:bgp": {
+            "global": {
+              "afi-safis": {
+                "afi-safi": [
+                  {
+                    "name": "iana-bgp-types:ipv4-unicast",
+                    "statistics": {
+                      "total-prefixes": 0
+                    }
+                  }
+                ]
+              },
+              "statistics": {
+                "total-prefixes": 0
+              }
+            },
+            "rib": {
+              "afi-safis": {
+                "afi-safi": [
+                  {
+                    "name": "iana-bgp-types:ipv4-unicast"
+                  }
+                ]
+              }
+            }
+          }
+        }
+      ]
+    }
+  }
+}

--- a/holo-bgp/tests/conformance/topologies/soft-reconfig-in-1/description.txt
+++ b/holo-bgp/tests/conformance/topologies/soft-reconfig-in-1/description.txt
@@ -1,0 +1,1 @@
+BGP inbound soft reconfiguration re-applies import policy to retained Adj-RIB-In.

--- a/holo-bgp/tests/conformance/topologies/soft-reconfig-in-1/rt1/config.json
+++ b/holo-bgp/tests/conformance/topologies/soft-reconfig-in-1/rt1/config.json
@@ -1,0 +1,84 @@
+{
+  "ietf-routing:routing": {
+    "control-plane-protocols": {
+      "control-plane-protocol": [
+        {
+          "type": "ietf-bgp:bgp",
+          "name": "test",
+          "ietf-bgp:bgp": {
+            "global": {
+              "as": 65000,
+              "identifier": "192.0.2.1"
+            },
+            "neighbors": {
+              "neighbor": [
+                {
+                  "remote-address": "192.0.2.2",
+                  "peer-as": 65001,
+                  "afi-safis": {
+                    "afi-safi": [
+                      {
+                        "name": "iana-bgp-types:ipv4-unicast",
+                        "enabled": true,
+                        "apply-policy": {
+                          "import-policy": [
+                            "SOFT-IN"
+                          ],
+                          "default-import-policy": "reject-route",
+                          "default-export-policy": "accept-route"
+                        }
+                      }
+                    ]
+                  }
+                }
+              ]
+            }
+          }
+        }
+      ]
+    }
+  },
+  "ietf-routing-policy:routing-policy": {
+    "defined-sets": {
+      "prefix-sets": {
+        "prefix-set": [
+          {
+            "name": "ACCEPTED",
+            "mode": "ipv4",
+            "prefixes": {
+              "prefix-list": [
+                {
+                  "ip-prefix": "198.51.100.1/32",
+                  "mask-length-lower": 32,
+                  "mask-length-upper": 32
+                }
+              ]
+            }
+          }
+        ]
+      }
+    },
+    "policy-definitions": {
+      "policy-definition": [
+        {
+          "name": "SOFT-IN",
+          "statements": {
+            "statement": [
+              {
+                "name": "10",
+                "conditions": {
+                  "match-prefix-set": {
+                    "prefix-set": "ACCEPTED"
+                  }
+                },
+                "actions": {
+                  "policy-result": "accept-route"
+                }
+              }
+            ]
+          }
+        }
+      ]
+    }
+  }
+}

--- a/holo-bgp/tests/conformance/topologies/soft-reconfig-in-1/rt1/events.jsonl
+++ b/holo-bgp/tests/conformance/topologies/soft-reconfig-in-1/rt1/events.jsonl
@@ -1,0 +1,16 @@
+{"Ibus":{"RouterIdUpdate":"192.0.2.1"}}
+{"Ibus":{"PolicyMatchSetsUpd":{"prefixes":[[["ACCEPTED","Ipv4"],{"name":"ACCEPTED","mode":"Ipv4","prefixes":[{"prefix":"198.51.100.1/32","masklen_lower":32,"masklen_upper":32}]}]],"neighbors":{},"tags":{},"bgp":{"as_paths":{},"comms":{},"ext_comms":{},"extv6_comms":{},"large_comms":{},"nexthops":{}}}}}
+{"Ibus":{"PolicyUpd":{"name":"SOFT-IN","stmt_order":["10"],"stmts":{"10":{"name":"10","prefix_set_match_type":"Any","tag_set_match_type":"Any","conditions":[["MatchPrefixSet",{"MatchPrefixSet":"ACCEPTED"}]],"actions":[["Accept",{"Accept":true}]]}}}}}
+{"Protocol":{"TriggerDecisionProcess":null}}
+{"Protocol":{"TcpAccept":{"conn_info":{"local_addr":"192.0.2.1","local_port":179,"remote_addr":"192.0.2.2","remote_port":50179}}}}
+{"Protocol":{"NbrTimer":{"nbr_addr":"192.0.2.2","timer":"AutoStart"}}}
+{"Protocol":{"TcpConnect":{"conn_info":{"local_addr":"192.0.2.1","local_port":50180,"remote_addr":"192.0.2.2","remote_port":179}}}}
+{"Protocol":{"NbrRx":{"nbr_addr":"192.0.2.2","msg":{"Err":{"TcpConnClosed":null}}}}}
+{"Protocol":{"TriggerDecisionProcess":null}}
+{"Protocol":{"TcpAccept":{"conn_info":{"local_addr":"192.0.2.1","local_port":179,"remote_addr":"192.0.2.2","remote_port":50181}}}}
+{"Protocol":{"NbrRx":{"nbr_addr":"192.0.2.2","msg":{"Ok":{"Open":{"version":4,"my_as":65001,"holdtime":90,"identifier":"192.0.2.2","capabilities":[{"MultiProtocol":{"afi":"Ipv4","safi":"Unicast"}},{"FourOctetAsNumber":{"asn":65001}},"RouteRefresh"]}}}}}}
+{"Protocol":{"NbrRx":{"nbr_addr":"192.0.2.2","msg":{"Ok":{"Keepalive":{}}}}}}
+{"Protocol":{"NbrRx":{"nbr_addr":"192.0.2.2","msg":{"Ok":{"Update":{"reach":{"prefixes":["198.51.100.1/32","198.51.100.2/32"],"nexthop":"192.0.2.2"},"attrs":{"base":{"origin":"Incomplete","as_path":{"segments":[{"seg_type":"Sequence","members":[65001]}]}}}}}}}}}
+{"Protocol":{"PolicyResult":{"Neighbor":{"policy_type":"Import","nbr_addr":"192.0.2.2","afi_safi":"Ipv4Unicast","routes":[["198.51.100.1/32",{"Accept":{"origin":{"Neighbor":{"identifier":"192.0.2.2","remote_addr":"192.0.2.2"}},"route_type":"External","attrs":{"base":{"origin":"Incomplete","as_path":{"segments":[{"seg_type":"Sequence","members":[65001]}]},"nexthop":"192.0.2.2"}}}}],["198.51.100.2/32","Reject"]]}}}}
+{"Ibus":{"NexthopUpd":{"addr":"192.0.2.2","metric":0}}}
+{"Protocol":{"TriggerDecisionProcess":null}}

--- a/holo-policy/src/northbound/configuration.rs
+++ b/holo-policy/src/northbound/configuration.rs
@@ -314,11 +314,7 @@ fn load_callbacks() -> Callbacks<Master> {
         .path(routing_policy::policy_definitions::policy_definition::PATH)
         .create_apply(|master, args| {
             let name = args.dnode.get_string_relative("./name").unwrap();
-            let policy = Policy {
-                name: name.clone(),
-                stmts: Default::default(),
-            };
-            master.policies.insert(name, policy);
+            master.policies.insert(name.clone(), Policy::new(name));
         })
         .delete_apply(|master, args| {
             let name = args.list_entry.into_policy().unwrap();
@@ -338,7 +334,7 @@ fn load_callbacks() -> Callbacks<Master> {
 
             let stmt_name = args.dnode.get_string_relative("./name").unwrap();
             let stmt = PolicyStmt::new(stmt_name.clone());
-            policy.stmts.insert(stmt_name, stmt);
+            policy.stmt_add(stmt);
 
             let event_queue = args.event_queue;
             event_queue.insert(Event::PolicyChange(policy.name.clone()));
@@ -347,7 +343,7 @@ fn load_callbacks() -> Callbacks<Master> {
             let (policy_name, stmt_name) = args.list_entry.into_policy_stmt().unwrap();
             let policy = master.policies.get_mut(&policy_name).unwrap();
 
-            policy.stmts.remove(&stmt_name);
+            policy.stmt_remove(&stmt_name);
 
             let event_queue = args.event_queue;
             event_queue.insert(Event::PolicyChange(policy.name.clone()));
@@ -661,20 +657,76 @@ fn load_callbacks() -> Callbacks<Master> {
             let event_queue = args.event_queue;
             event_queue.insert(Event::PolicyChange(policy.name.clone()));
         })
-        // BGP condition: match-afi-safi (TODO: multi-value set, deferred)
+        // BGP condition: match-afi-safi
         .path(routing_policy::policy_definitions::policy_definition::statements::statement::conditions::bgp_conditions::match_afi_safi::afi_safi_in::PATH)
-        .create_apply(|_master, _args| {
-            // TODO: implement me!
+        .create_apply(|master, args| {
+            let (policy_name, stmt_name) = args.list_entry.into_policy_stmt().unwrap();
+            let policy = master.policies.get_mut(&policy_name).unwrap();
+            let stmt = policy.stmts.get_mut(&stmt_name).unwrap();
+
+            let afi_safi = args.dnode.get_string();
+            let afi_safi = bgp::AfiSafi::try_from_yang(&afi_safi).unwrap();
+            let key = PolicyConditionType::Bgp(BgpPolicyConditionType::MatchAfiSafi);
+            match stmt.conditions.get_mut(&key) {
+                Some(PolicyCondition::Bgp(BgpPolicyCondition::MatchAfiSafi {
+                    values, ..
+                })) => {
+                    values.insert(afi_safi);
+                }
+                _ => {
+                    let mut values = BTreeSet::new();
+                    values.insert(afi_safi);
+                    stmt.condition_add(PolicyCondition::Bgp(BgpPolicyCondition::MatchAfiSafi {
+                        values,
+                        match_type: MatchSetRestrictedType::Any,
+                    }));
+                }
+            }
+
+            let event_queue = args.event_queue;
+            event_queue.insert(Event::PolicyChange(policy.name.clone()));
         })
-        .delete_apply(|_master, _args| {
-            // TODO: implement me!
+        .delete_apply(|master, args| {
+            let (policy_name, stmt_name) = args.list_entry.into_policy_stmt().unwrap();
+            let policy = master.policies.get_mut(&policy_name).unwrap();
+            let stmt = policy.stmts.get_mut(&stmt_name).unwrap();
+
+            let afi_safi = args.dnode.get_string();
+            let afi_safi = bgp::AfiSafi::try_from_yang(&afi_safi).unwrap();
+            let key = PolicyConditionType::Bgp(BgpPolicyConditionType::MatchAfiSafi);
+            if let Some(PolicyCondition::Bgp(BgpPolicyCondition::MatchAfiSafi {
+                values, ..
+            })) = stmt.conditions.get_mut(&key)
+            {
+                values.remove(&afi_safi);
+                if values.is_empty() {
+                    stmt.condition_remove(key);
+                }
+            }
+
+            let event_queue = args.event_queue;
+            event_queue.insert(Event::PolicyChange(policy.name.clone()));
         })
         .path(routing_policy::policy_definitions::policy_definition::statements::statement::conditions::bgp_conditions::match_afi_safi::match_set_options::PATH)
-        .modify_apply(|_master, _args| {
-            // TODO: implement me!
+        .modify_apply(|master, args| {
+            let (policy_name, stmt_name) = args.list_entry.into_policy_stmt().unwrap();
+            let policy = master.policies.get_mut(&policy_name).unwrap();
+            let stmt = policy.stmts.get_mut(&stmt_name).unwrap();
+
+            let match_type = args.dnode.get_string();
+            let match_type = MatchSetRestrictedType::try_from_yang(&match_type).unwrap();
+            let key = PolicyConditionType::Bgp(BgpPolicyConditionType::MatchAfiSafi);
+            if let Some(PolicyCondition::Bgp(BgpPolicyCondition::MatchAfiSafi {
+                match_type: existing, ..
+            })) = stmt.conditions.get_mut(&key)
+            {
+                *existing = match_type;
+            }
+
+            let event_queue = args.event_queue;
+            event_queue.insert(Event::PolicyChange(policy.name.clone()));
         })
         .delete_apply(|_master, _args| {
-            // TODO: implement me!
         })
         // BGP condition: match-neighbor
         .path(routing_policy::policy_definitions::policy_definition::statements::statement::conditions::bgp_conditions::match_neighbor::neighbor_eq::PATH)

--- a/holo-policy/src/northbound/configuration.rs
+++ b/holo-policy/src/northbound/configuration.rs
@@ -13,8 +13,8 @@ use holo_northbound::configuration::{self, Callbacks, CallbacksBuilder, Provider
 use holo_utils::bgp::{self, Comm, ExtComm, Extv6Comm, LargeComm, Origin};
 use holo_utils::ip::AddressFamily;
 use holo_utils::policy::{
-    BgpEqOperator, BgpNexthop, BgpPolicyAction, BgpPolicyActionType, BgpPolicyCondition, BgpPolicyConditionType, BgpSetCommMethod, BgpSetCommOptions, BgpSetMed, IpPrefixRange, MatchSetRestrictedType, MatchSetType, MetricType, NeighborSet, Policy, PolicyAction,
-    PolicyActionType, PolicyCondition, PolicyConditionType, PolicyStmt, PrefixSet, RouteLevel, RouteType, TagSet,
+    BgpEqOperator, BgpNexthop, BgpPolicyAction, BgpPolicyActionType, BgpPolicyCondition, BgpPolicyConditionType, BgpSetCommMethod, BgpSetCommOptions, BgpSetMed, IpPrefixRange, MatchSetRestrictedType, MatchSetType, MetricType, NeighborSet,
+    Policy, PolicyAction, PolicyActionType, PolicyCondition, PolicyConditionType, PolicyStmt, PrefixSet, RouteLevel, RouteType, TagSet,
 };
 use holo_utils::protocol::Protocol;
 use holo_utils::yang::DataNodeRefExt;
@@ -826,8 +826,7 @@ fn load_callbacks() -> Callbacks<Master> {
             let event_queue = args.event_queue;
             event_queue.insert(Event::PolicyChange(policy.name.clone()));
         })
-        .delete_apply(|_master, _args| {
-        })
+        .delete_apply(|_master, _args| {})
         // BGP condition: match-neighbor
         .path(routing_policy::policy_definitions::policy_definition::statements::statement::conditions::bgp_conditions::match_neighbor::neighbor_eq::PATH)
         .create_apply(|master, args| {
@@ -1026,8 +1025,7 @@ fn load_callbacks() -> Callbacks<Master> {
         .modify_apply(|master, args| {
             bgp_match_set_options(master, args, BgpPolicyConditionType::MatchCommSet);
         })
-        .delete_apply(|_master, _args| {
-        })
+        .delete_apply(|_master, _args| {})
         .path(routing_policy::policy_definitions::policy_definition::statements::statement::conditions::bgp_conditions::match_ext_community_set::ext_community_set::PATH)
         .modify_apply(|master, args| {
             bgp_match_set_ref(
@@ -1051,8 +1049,7 @@ fn load_callbacks() -> Callbacks<Master> {
         .modify_apply(|master, args| {
             bgp_match_set_options(master, args, BgpPolicyConditionType::MatchExtCommSet);
         })
-        .delete_apply(|_master, _args| {
-        })
+        .delete_apply(|_master, _args| {})
         .path(routing_policy::policy_definitions::policy_definition::statements::statement::conditions::bgp_conditions::match_ipv6_ext_community_set::ipv6_ext_community_set::PATH)
         .modify_apply(|master, args| {
             bgp_match_set_ref(
@@ -1076,8 +1073,7 @@ fn load_callbacks() -> Callbacks<Master> {
         .modify_apply(|master, args| {
             bgp_match_set_options(master, args, BgpPolicyConditionType::MatchExtv6CommSet);
         })
-        .delete_apply(|_master, _args| {
-        })
+        .delete_apply(|_master, _args| {})
         .path(routing_policy::policy_definitions::policy_definition::statements::statement::conditions::bgp_conditions::match_large_community_set::large_community_set::PATH)
         .modify_apply(|master, args| {
             bgp_match_set_ref(
@@ -1097,8 +1093,7 @@ fn load_callbacks() -> Callbacks<Master> {
         .modify_apply(|master, args| {
             bgp_match_set_options(master, args, BgpPolicyConditionType::MatchLargeCommSet);
         })
-        .delete_apply(|_master, _args| {
-        })
+        .delete_apply(|_master, _args| {})
         .path(routing_policy::policy_definitions::policy_definition::statements::statement::conditions::bgp_conditions::match_as_path_set::as_path_set::PATH)
         .modify_apply(|master, args| {
             bgp_match_set_ref(
@@ -1118,8 +1113,7 @@ fn load_callbacks() -> Callbacks<Master> {
         .modify_apply(|master, args| {
             bgp_match_set_options(master, args, BgpPolicyConditionType::MatchAsPathSet);
         })
-        .delete_apply(|_master, _args| {
-        })
+        .delete_apply(|_master, _args| {})
         .path(routing_policy::policy_definitions::policy_definition::statements::statement::conditions::bgp_conditions::match_next_hop_set::next_hop_set::PATH)
         .modify_apply(|_master, _args| {
             // TODO: implement me!
@@ -1451,8 +1445,7 @@ fn load_callbacks() -> Callbacks<Master> {
         .modify_apply(|master, args| {
             bgp_set_comm_options(master, args, BgpPolicyActionType::SetComm);
         })
-        .delete_apply(|_master, _args| {
-        })
+        .delete_apply(|_master, _args| {})
         .path(routing_policy::policy_definitions::policy_definition::statements::statement::actions::bgp_actions::set_community::communities::PATH)
         .create_apply(|master, args| {
             let comm = Comm::try_from_yang(&args.dnode.get_string()).unwrap();
@@ -1473,8 +1466,7 @@ fn load_callbacks() -> Callbacks<Master> {
         .modify_apply(|master, args| {
             bgp_set_comm_options(master, args, BgpPolicyActionType::SetExtComm);
         })
-        .delete_apply(|_master, _args| {
-        })
+        .delete_apply(|_master, _args| {})
         .path(routing_policy::policy_definitions::policy_definition::statements::statement::actions::bgp_actions::set_ext_community::communities::PATH)
         .create_apply(|master, args| {
             let comm = ExtComm::try_from_yang(&args.dnode.get_string()).unwrap();
@@ -1495,8 +1487,7 @@ fn load_callbacks() -> Callbacks<Master> {
         .modify_apply(|master, args| {
             bgp_set_comm_options(master, args, BgpPolicyActionType::SetExtv6Comm);
         })
-        .delete_apply(|_master, _args| {
-        })
+        .delete_apply(|_master, _args| {})
         .path(routing_policy::policy_definitions::policy_definition::statements::statement::actions::bgp_actions::set_ipv6_ext_community::communities::PATH)
         .create_apply(|master, args| {
             let comm = Extv6Comm::try_from_yang(&args.dnode.get_string()).unwrap();
@@ -1517,8 +1508,7 @@ fn load_callbacks() -> Callbacks<Master> {
         .modify_apply(|master, args| {
             bgp_set_comm_options(master, args, BgpPolicyActionType::SetLargeComm);
         })
-        .delete_apply(|_master, _args| {
-        })
+        .delete_apply(|_master, _args| {})
         .path(routing_policy::policy_definitions::policy_definition::statements::statement::actions::bgp_actions::set_large_community::communities::PATH)
         .create_apply(|master, args| {
             let comm = LargeComm::try_from_yang(&args.dnode.get_string()).unwrap();
@@ -1629,10 +1619,7 @@ fn bgp_cond_set_op(master: &mut Master, args: configuration::CallbackArgs<'_, Ma
     event_queue.insert(Event::PolicyChange(policy.name.clone()));
 }
 
-fn bgp_match_set_type_get(
-    stmt: &PolicyStmt,
-    cond_type: BgpPolicyConditionType,
-) -> MatchSetType {
+fn bgp_match_set_type_get(stmt: &PolicyStmt, cond_type: BgpPolicyConditionType) -> MatchSetType {
     let key = PolicyConditionType::Bgp(cond_type);
     match stmt.conditions.get(&key) {
         Some(PolicyCondition::Bgp(
@@ -1656,12 +1643,7 @@ fn bgp_match_set_type_get(
     }
 }
 
-fn bgp_match_set_ref(
-    master: &mut Master,
-    args: configuration::CallbackArgs<'_, Master>,
-    cond_type: BgpPolicyConditionType,
-    mut condition: BgpPolicyCondition,
-) {
+fn bgp_match_set_ref(master: &mut Master, args: configuration::CallbackArgs<'_, Master>, cond_type: BgpPolicyConditionType, mut condition: BgpPolicyCondition) {
     let (policy_name, stmt_name) = args.list_entry.into_policy_stmt().unwrap();
     let policy = master.policies.get_mut(&policy_name).unwrap();
     let stmt = policy.stmts.get_mut(&stmt_name).unwrap();
@@ -1700,11 +1682,7 @@ fn bgp_match_set_ref(
     event_queue.insert(Event::PolicyChange(policy.name.clone()));
 }
 
-fn bgp_match_set_options(
-    master: &mut Master,
-    args: configuration::CallbackArgs<'_, Master>,
-    cond_type: BgpPolicyConditionType,
-) {
+fn bgp_match_set_options(master: &mut Master, args: configuration::CallbackArgs<'_, Master>, cond_type: BgpPolicyConditionType) {
     let (policy_name, stmt_name) = args.list_entry.into_policy_stmt().unwrap();
     let policy = master.policies.get_mut(&policy_name).unwrap();
     let stmt = policy.stmts.get_mut(&stmt_name).unwrap();
@@ -1737,11 +1715,7 @@ fn bgp_match_set_options(
     event_queue.insert(Event::PolicyChange(policy.name.clone()));
 }
 
-fn bgp_match_set_delete(
-    master: &mut Master,
-    args: configuration::CallbackArgs<'_, Master>,
-    cond_type: BgpPolicyConditionType,
-) {
+fn bgp_match_set_delete(master: &mut Master, args: configuration::CallbackArgs<'_, Master>, cond_type: BgpPolicyConditionType) {
     let (policy_name, stmt_name) = args.list_entry.into_policy_stmt().unwrap();
     let policy = master.policies.get_mut(&policy_name).unwrap();
     let stmt = policy.stmts.get_mut(&stmt_name).unwrap();
@@ -1752,38 +1726,30 @@ fn bgp_match_set_delete(
     event_queue.insert(Event::PolicyChange(policy.name.clone()));
 }
 
-trait BgpCommValue:
-    Clone + Eq + Ord + PartialEq + PartialOrd
-{
+trait BgpCommValue: Clone + Eq + Ord + PartialEq + PartialOrd {
     const ACTION_TYPE: BgpPolicyActionType;
 
-    fn make_action(
-        options: BgpSetCommOptions,
-        method: BgpSetCommMethod<Self>,
-    ) -> PolicyAction;
+    fn make_action(options: BgpSetCommOptions, method: BgpSetCommMethod<Self>) -> PolicyAction;
 
-    fn action_mut(
-        action: &mut PolicyAction,
-    ) -> Option<(&mut BgpSetCommOptions, &mut BgpSetCommMethod<Self>)>;
+    fn action_mut(action: &mut PolicyAction) -> Option<(&mut BgpSetCommOptions, &mut BgpSetCommMethod<Self>)>;
 }
 
 impl BgpCommValue for Comm {
     const ACTION_TYPE: BgpPolicyActionType = BgpPolicyActionType::SetComm;
 
-    fn make_action(
-        options: BgpSetCommOptions,
-        method: BgpSetCommMethod<Self>,
-    ) -> PolicyAction {
-        PolicyAction::Bgp(BgpPolicyAction::SetComm { options, method })
+    fn make_action(options: BgpSetCommOptions, method: BgpSetCommMethod<Self>) -> PolicyAction {
+        PolicyAction::Bgp(BgpPolicyAction::SetComm {
+            options,
+            method,
+        })
     }
 
-    fn action_mut(
-        action: &mut PolicyAction,
-    ) -> Option<(&mut BgpSetCommOptions, &mut BgpSetCommMethod<Self>)> {
+    fn action_mut(action: &mut PolicyAction) -> Option<(&mut BgpSetCommOptions, &mut BgpSetCommMethod<Self>)> {
         match action {
-            PolicyAction::Bgp(BgpPolicyAction::SetComm { options, method }) => {
-                Some((options, method))
-            }
+            PolicyAction::Bgp(BgpPolicyAction::SetComm {
+                options,
+                method,
+            }) => Some((options, method)),
             _ => None,
         }
     }
@@ -1792,20 +1758,19 @@ impl BgpCommValue for Comm {
 impl BgpCommValue for ExtComm {
     const ACTION_TYPE: BgpPolicyActionType = BgpPolicyActionType::SetExtComm;
 
-    fn make_action(
-        options: BgpSetCommOptions,
-        method: BgpSetCommMethod<Self>,
-    ) -> PolicyAction {
-        PolicyAction::Bgp(BgpPolicyAction::SetExtComm { options, method })
+    fn make_action(options: BgpSetCommOptions, method: BgpSetCommMethod<Self>) -> PolicyAction {
+        PolicyAction::Bgp(BgpPolicyAction::SetExtComm {
+            options,
+            method,
+        })
     }
 
-    fn action_mut(
-        action: &mut PolicyAction,
-    ) -> Option<(&mut BgpSetCommOptions, &mut BgpSetCommMethod<Self>)> {
+    fn action_mut(action: &mut PolicyAction) -> Option<(&mut BgpSetCommOptions, &mut BgpSetCommMethod<Self>)> {
         match action {
-            PolicyAction::Bgp(BgpPolicyAction::SetExtComm { options, method }) => {
-                Some((options, method))
-            }
+            PolicyAction::Bgp(BgpPolicyAction::SetExtComm {
+                options,
+                method,
+            }) => Some((options, method)),
             _ => None,
         }
     }
@@ -1814,20 +1779,19 @@ impl BgpCommValue for ExtComm {
 impl BgpCommValue for Extv6Comm {
     const ACTION_TYPE: BgpPolicyActionType = BgpPolicyActionType::SetExtv6Comm;
 
-    fn make_action(
-        options: BgpSetCommOptions,
-        method: BgpSetCommMethod<Self>,
-    ) -> PolicyAction {
-        PolicyAction::Bgp(BgpPolicyAction::SetExtv6Comm { options, method })
+    fn make_action(options: BgpSetCommOptions, method: BgpSetCommMethod<Self>) -> PolicyAction {
+        PolicyAction::Bgp(BgpPolicyAction::SetExtv6Comm {
+            options,
+            method,
+        })
     }
 
-    fn action_mut(
-        action: &mut PolicyAction,
-    ) -> Option<(&mut BgpSetCommOptions, &mut BgpSetCommMethod<Self>)> {
+    fn action_mut(action: &mut PolicyAction) -> Option<(&mut BgpSetCommOptions, &mut BgpSetCommMethod<Self>)> {
         match action {
-            PolicyAction::Bgp(BgpPolicyAction::SetExtv6Comm { options, method }) => {
-                Some((options, method))
-            }
+            PolicyAction::Bgp(BgpPolicyAction::SetExtv6Comm {
+                options,
+                method,
+            }) => Some((options, method)),
             _ => None,
         }
     }
@@ -1836,49 +1800,36 @@ impl BgpCommValue for Extv6Comm {
 impl BgpCommValue for LargeComm {
     const ACTION_TYPE: BgpPolicyActionType = BgpPolicyActionType::SetLargeComm;
 
-    fn make_action(
-        options: BgpSetCommOptions,
-        method: BgpSetCommMethod<Self>,
-    ) -> PolicyAction {
-        PolicyAction::Bgp(BgpPolicyAction::SetLargeComm { options, method })
+    fn make_action(options: BgpSetCommOptions, method: BgpSetCommMethod<Self>) -> PolicyAction {
+        PolicyAction::Bgp(BgpPolicyAction::SetLargeComm {
+            options,
+            method,
+        })
     }
 
-    fn action_mut(
-        action: &mut PolicyAction,
-    ) -> Option<(&mut BgpSetCommOptions, &mut BgpSetCommMethod<Self>)> {
+    fn action_mut(action: &mut PolicyAction) -> Option<(&mut BgpSetCommOptions, &mut BgpSetCommMethod<Self>)> {
         match action {
-            PolicyAction::Bgp(BgpPolicyAction::SetLargeComm { options, method }) => {
-                Some((options, method))
-            }
+            PolicyAction::Bgp(BgpPolicyAction::SetLargeComm {
+                options,
+                method,
+            }) => Some((options, method)),
             _ => None,
         }
     }
 }
 
-fn bgp_set_comm_options(
-    master: &mut Master,
-    args: configuration::CallbackArgs<'_, Master>,
-    action_type: BgpPolicyActionType,
-) {
+fn bgp_set_comm_options(master: &mut Master, args: configuration::CallbackArgs<'_, Master>, action_type: BgpPolicyActionType) {
     match action_type {
         BgpPolicyActionType::SetComm => bgp_set_comm_options_t::<Comm>(master, args),
-        BgpPolicyActionType::SetExtComm => {
-            bgp_set_comm_options_t::<ExtComm>(master, args)
-        }
-        BgpPolicyActionType::SetExtv6Comm => {
-            bgp_set_comm_options_t::<Extv6Comm>(master, args)
-        }
-        BgpPolicyActionType::SetLargeComm => {
-            bgp_set_comm_options_t::<LargeComm>(master, args)
-        }
+        BgpPolicyActionType::SetExtComm => bgp_set_comm_options_t::<ExtComm>(master, args),
+        BgpPolicyActionType::SetExtv6Comm => bgp_set_comm_options_t::<Extv6Comm>(master, args),
+        BgpPolicyActionType::SetLargeComm => bgp_set_comm_options_t::<LargeComm>(master, args),
         _ => unreachable!(),
     }
 }
 
-fn bgp_set_comm_options_t<T>(
-    master: &mut Master,
-    args: configuration::CallbackArgs<'_, Master>,
-) where
+fn bgp_set_comm_options_t<T>(master: &mut Master, args: configuration::CallbackArgs<'_, Master>)
+where
     T: BgpCommValue,
 {
     let (policy_name, stmt_name) = args.list_entry.into_policy_stmt().unwrap();
@@ -1889,22 +1840,15 @@ fn bgp_set_comm_options_t<T>(
     let key = PolicyActionType::Bgp(T::ACTION_TYPE);
     match stmt.actions.get_mut(&key).and_then(T::action_mut) {
         Some((existing, _)) => *existing = options,
-        None => stmt.action_add(T::make_action(
-            options,
-            BgpSetCommMethod::Inline(Default::default()),
-        )),
+        None => stmt.action_add(T::make_action(options, BgpSetCommMethod::Inline(Default::default()))),
     }
 
     let event_queue = args.event_queue;
     event_queue.insert(Event::PolicyChange(policy.name.clone()));
 }
 
-fn bgp_set_comm_inline_add<T>(
-    master: &mut Master,
-    args: configuration::CallbackArgs<'_, Master>,
-    comm: T,
-    _action_type: BgpPolicyActionType,
-) where
+fn bgp_set_comm_inline_add<T>(master: &mut Master, args: configuration::CallbackArgs<'_, Master>, comm: T, _action_type: BgpPolicyActionType)
+where
     T: BgpCommValue,
 {
     let (policy_name, stmt_name) = args.list_entry.into_policy_stmt().unwrap();
@@ -1919,22 +1863,15 @@ fn bgp_set_comm_inline_add<T>(
         Some((_, method)) => {
             *method = BgpSetCommMethod::Inline(BTreeSet::from([comm]));
         }
-        None => stmt.action_add(T::make_action(
-            BgpSetCommOptions::Add,
-            BgpSetCommMethod::Inline(BTreeSet::from([comm])),
-        )),
+        None => stmt.action_add(T::make_action(BgpSetCommOptions::Add, BgpSetCommMethod::Inline(BTreeSet::from([comm])))),
     }
 
     let event_queue = args.event_queue;
     event_queue.insert(Event::PolicyChange(policy.name.clone()));
 }
 
-fn bgp_set_comm_inline_remove<T>(
-    master: &mut Master,
-    args: configuration::CallbackArgs<'_, Master>,
-    comm: T,
-    _action_type: BgpPolicyActionType,
-) where
+fn bgp_set_comm_inline_remove<T>(master: &mut Master, args: configuration::CallbackArgs<'_, Master>, comm: T, _action_type: BgpPolicyActionType)
+where
     T: BgpCommValue,
 {
     let (policy_name, stmt_name) = args.list_entry.into_policy_stmt().unwrap();
@@ -1942,9 +1879,7 @@ fn bgp_set_comm_inline_remove<T>(
     let stmt = policy.stmts.get_mut(&stmt_name).unwrap();
     let key = PolicyActionType::Bgp(T::ACTION_TYPE);
 
-    if let Some((_, BgpSetCommMethod::Inline(comms))) =
-        stmt.actions.get_mut(&key).and_then(T::action_mut)
-    {
+    if let Some((_, BgpSetCommMethod::Inline(comms))) = stmt.actions.get_mut(&key).and_then(T::action_mut) {
         comms.remove(&comm);
     }
 
@@ -1952,30 +1887,18 @@ fn bgp_set_comm_inline_remove<T>(
     event_queue.insert(Event::PolicyChange(policy.name.clone()));
 }
 
-fn bgp_set_comm_reference(
-    master: &mut Master,
-    args: configuration::CallbackArgs<'_, Master>,
-    action_type: BgpPolicyActionType,
-) {
+fn bgp_set_comm_reference(master: &mut Master, args: configuration::CallbackArgs<'_, Master>, action_type: BgpPolicyActionType) {
     match action_type {
         BgpPolicyActionType::SetComm => bgp_set_comm_reference_t::<Comm>(master, args),
-        BgpPolicyActionType::SetExtComm => {
-            bgp_set_comm_reference_t::<ExtComm>(master, args)
-        }
-        BgpPolicyActionType::SetExtv6Comm => {
-            bgp_set_comm_reference_t::<Extv6Comm>(master, args)
-        }
-        BgpPolicyActionType::SetLargeComm => {
-            bgp_set_comm_reference_t::<LargeComm>(master, args)
-        }
+        BgpPolicyActionType::SetExtComm => bgp_set_comm_reference_t::<ExtComm>(master, args),
+        BgpPolicyActionType::SetExtv6Comm => bgp_set_comm_reference_t::<Extv6Comm>(master, args),
+        BgpPolicyActionType::SetLargeComm => bgp_set_comm_reference_t::<LargeComm>(master, args),
         _ => unreachable!(),
     }
 }
 
-fn bgp_set_comm_reference_t<T>(
-    master: &mut Master,
-    args: configuration::CallbackArgs<'_, Master>,
-) where
+fn bgp_set_comm_reference_t<T>(master: &mut Master, args: configuration::CallbackArgs<'_, Master>)
+where
     T: BgpCommValue,
 {
     let (policy_name, stmt_name) = args.list_entry.into_policy_stmt().unwrap();
@@ -1984,26 +1907,14 @@ fn bgp_set_comm_reference_t<T>(
 
     let set_name = args.dnode.get_string();
     let key = PolicyActionType::Bgp(T::ACTION_TYPE);
-    let options = stmt
-        .actions
-        .get_mut(&key)
-        .and_then(T::action_mut)
-        .map(|(options, _)| *options)
-        .unwrap_or(BgpSetCommOptions::Add);
-    stmt.action_add(T::make_action(
-        options,
-        BgpSetCommMethod::Reference(set_name),
-    ));
+    let options = stmt.actions.get_mut(&key).and_then(T::action_mut).map(|(options, _)| *options).unwrap_or(BgpSetCommOptions::Add);
+    stmt.action_add(T::make_action(options, BgpSetCommMethod::Reference(set_name)));
 
     let event_queue = args.event_queue;
     event_queue.insert(Event::PolicyChange(policy.name.clone()));
 }
 
-fn bgp_set_comm_delete(
-    master: &mut Master,
-    args: configuration::CallbackArgs<'_, Master>,
-    action_type: BgpPolicyActionType,
-) {
+fn bgp_set_comm_delete(master: &mut Master, args: configuration::CallbackArgs<'_, Master>, action_type: BgpPolicyActionType) {
     let (policy_name, stmt_name) = args.list_entry.into_policy_stmt().unwrap();
     let policy = master.policies.get_mut(&policy_name).unwrap();
     let stmt = policy.stmts.get_mut(&stmt_name).unwrap();

--- a/holo-policy/src/northbound/configuration.rs
+++ b/holo-policy/src/northbound/configuration.rs
@@ -10,10 +10,10 @@ use std::sync::{Arc, LazyLock as Lazy};
 
 use enum_as_inner::EnumAsInner;
 use holo_northbound::configuration::{self, Callbacks, CallbacksBuilder, Provider};
-use holo_utils::bgp::{self, Origin};
+use holo_utils::bgp::{self, Comm, ExtComm, Extv6Comm, LargeComm, Origin};
 use holo_utils::ip::AddressFamily;
 use holo_utils::policy::{
-    BgpEqOperator, BgpNexthop, BgpPolicyAction, BgpPolicyActionType, BgpPolicyCondition, BgpPolicyConditionType, BgpSetMed, IpPrefixRange, MatchSetRestrictedType, MatchSetType, MetricType, NeighborSet, Policy, PolicyAction,
+    BgpEqOperator, BgpNexthop, BgpPolicyAction, BgpPolicyActionType, BgpPolicyCondition, BgpPolicyConditionType, BgpSetCommMethod, BgpSetCommOptions, BgpSetMed, IpPrefixRange, MatchSetRestrictedType, MatchSetType, MetricType, NeighborSet, Policy, PolicyAction,
     PolicyActionType, PolicyCondition, PolicyConditionType, PolicyStmt, PrefixSet, RouteLevel, RouteType, TagSet,
 };
 use holo_utils::protocol::Protocol;
@@ -32,6 +32,11 @@ pub enum ListEntry {
     PrefixSet(String, AddressFamily),
     NeighborSet(String),
     TagSet(String),
+    AsPathSet(String),
+    CommSet(String),
+    ExtCommSet(String),
+    Extv6CommSet(String),
+    LargeCommSet(String),
     Policy(String),
     PolicyStmt(String, String),
 }
@@ -204,94 +209,189 @@ fn load_callbacks() -> Callbacks<Master> {
             event_queue.insert(Event::MatchSetsUpdate);
         })
         .path(routing_policy::defined_sets::bgp_defined_sets::as_path_sets::as_path_set::PATH)
-        .create_apply(|_master, _args| {
-            // TODO: implement me!
+        .create_apply(|master, args| {
+            let name = args.dnode.get_string_relative("./name").unwrap();
+            master.match_sets.bgp.as_paths.insert(name, Default::default());
         })
-        .delete_apply(|_master, _args| {
-            // TODO: implement me!
+        .delete_apply(|master, args| {
+            let name = args.list_entry.into_as_path_set().unwrap();
+            master.match_sets.bgp.as_paths.remove(&name);
+
+            let event_queue = args.event_queue;
+            event_queue.insert(Event::MatchSetsUpdate);
         })
-        .lookup(|_master, _list_entry, _dnode| {
-            // TODO: implement me!
-            todo!();
+        .lookup(|_master, _list_entry, dnode| {
+            let name = dnode.get_string_relative("./name").unwrap();
+            ListEntry::AsPathSet(name)
         })
         .path(routing_policy::defined_sets::bgp_defined_sets::as_path_sets::as_path_set::member::PATH)
-        .create_apply(|_master, _args| {
-            // TODO: implement me!
+        .create_apply(|master, args| {
+            let name = args.list_entry.into_as_path_set().unwrap();
+            let set = master.match_sets.bgp.as_paths.get_mut(&name).unwrap();
+            if let Ok(asn) = args.dnode.get_string().parse::<u32>() {
+                set.insert(asn);
+            }
+
+            let event_queue = args.event_queue;
+            event_queue.insert(Event::MatchSetsUpdate);
         })
-        .delete_apply(|_master, _args| {
-            // TODO: implement me!
+        .delete_apply(|master, args| {
+            let name = args.list_entry.into_as_path_set().unwrap();
+            let set = master.match_sets.bgp.as_paths.get_mut(&name).unwrap();
+            if let Ok(asn) = args.dnode.get_string().parse::<u32>() {
+                set.remove(&asn);
+            }
+
+            let event_queue = args.event_queue;
+            event_queue.insert(Event::MatchSetsUpdate);
         })
         .path(routing_policy::defined_sets::bgp_defined_sets::community_sets::community_set::PATH)
-        .create_apply(|_master, _args| {
-            // TODO: implement me!
+        .create_apply(|master, args| {
+            let name = args.dnode.get_string_relative("./name").unwrap();
+            master.match_sets.bgp.comms.insert(name, Default::default());
         })
-        .delete_apply(|_master, _args| {
-            // TODO: implement me!
+        .delete_apply(|master, args| {
+            let name = args.list_entry.into_comm_set().unwrap();
+            master.match_sets.bgp.comms.remove(&name);
+
+            let event_queue = args.event_queue;
+            event_queue.insert(Event::MatchSetsUpdate);
         })
-        .lookup(|_master, _list_entry, _dnode| {
-            // TODO: implement me!
-            todo!();
+        .lookup(|_master, _list_entry, dnode| {
+            let name = dnode.get_string_relative("./name").unwrap();
+            ListEntry::CommSet(name)
         })
         .path(routing_policy::defined_sets::bgp_defined_sets::community_sets::community_set::member::PATH)
-        .create_apply(|_master, _args| {
-            // TODO: implement me!
+        .create_apply(|master, args| {
+            let name = args.list_entry.into_comm_set().unwrap();
+            let set = master.match_sets.bgp.comms.get_mut(&name).unwrap();
+            if let Some(comm) = Comm::try_from_yang(&args.dnode.get_string()) {
+                set.insert(comm);
+            }
+
+            let event_queue = args.event_queue;
+            event_queue.insert(Event::MatchSetsUpdate);
         })
-        .delete_apply(|_master, _args| {
-            // TODO: implement me!
+        .delete_apply(|master, args| {
+            let name = args.list_entry.into_comm_set().unwrap();
+            let set = master.match_sets.bgp.comms.get_mut(&name).unwrap();
+            if let Some(comm) = Comm::try_from_yang(&args.dnode.get_string()) {
+                set.remove(&comm);
+            }
+
+            let event_queue = args.event_queue;
+            event_queue.insert(Event::MatchSetsUpdate);
         })
         .path(routing_policy::defined_sets::bgp_defined_sets::ext_community_sets::ext_community_set::PATH)
-        .create_apply(|_master, _args| {
-            // TODO: implement me!
+        .create_apply(|master, args| {
+            let name = args.dnode.get_string_relative("./name").unwrap();
+            master.match_sets.bgp.ext_comms.insert(name, Default::default());
         })
-        .delete_apply(|_master, _args| {
-            // TODO: implement me!
+        .delete_apply(|master, args| {
+            let name = args.list_entry.into_ext_comm_set().unwrap();
+            master.match_sets.bgp.ext_comms.remove(&name);
+
+            let event_queue = args.event_queue;
+            event_queue.insert(Event::MatchSetsUpdate);
         })
-        .lookup(|_master, _list_entry, _dnode| {
-            // TODO: implement me!
-            todo!();
+        .lookup(|_master, _list_entry, dnode| {
+            let name = dnode.get_string_relative("./name").unwrap();
+            ListEntry::ExtCommSet(name)
         })
         .path(routing_policy::defined_sets::bgp_defined_sets::ext_community_sets::ext_community_set::member::PATH)
-        .create_apply(|_master, _args| {
-            // TODO: implement me!
+        .create_apply(|master, args| {
+            let name = args.list_entry.into_ext_comm_set().unwrap();
+            let set = master.match_sets.bgp.ext_comms.get_mut(&name).unwrap();
+            if let Some(comm) = ExtComm::try_from_yang(&args.dnode.get_string()) {
+                set.insert(comm);
+            }
+
+            let event_queue = args.event_queue;
+            event_queue.insert(Event::MatchSetsUpdate);
         })
-        .delete_apply(|_master, _args| {
-            // TODO: implement me!
+        .delete_apply(|master, args| {
+            let name = args.list_entry.into_ext_comm_set().unwrap();
+            let set = master.match_sets.bgp.ext_comms.get_mut(&name).unwrap();
+            if let Some(comm) = ExtComm::try_from_yang(&args.dnode.get_string()) {
+                set.remove(&comm);
+            }
+
+            let event_queue = args.event_queue;
+            event_queue.insert(Event::MatchSetsUpdate);
         })
         .path(routing_policy::defined_sets::bgp_defined_sets::ipv6_ext_community_sets::ipv6_ext_community_set::PATH)
-        .create_apply(|_master, _args| {
-            // TODO: implement me!
+        .create_apply(|master, args| {
+            let name = args.dnode.get_string_relative("./name").unwrap();
+            master.match_sets.bgp.extv6_comms.insert(name, Default::default());
         })
-        .delete_apply(|_master, _args| {
-            // TODO: implement me!
+        .delete_apply(|master, args| {
+            let name = args.list_entry.into_extv6_comm_set().unwrap();
+            master.match_sets.bgp.extv6_comms.remove(&name);
+
+            let event_queue = args.event_queue;
+            event_queue.insert(Event::MatchSetsUpdate);
         })
-        .lookup(|_master, _list_entry, _dnode| {
-            // TODO: implement me!
-            todo!();
+        .lookup(|_master, _list_entry, dnode| {
+            let name = dnode.get_string_relative("./name").unwrap();
+            ListEntry::Extv6CommSet(name)
         })
         .path(routing_policy::defined_sets::bgp_defined_sets::ipv6_ext_community_sets::ipv6_ext_community_set::member::PATH)
-        .create_apply(|_master, _args| {
-            // TODO: implement me!
+        .create_apply(|master, args| {
+            let name = args.list_entry.into_extv6_comm_set().unwrap();
+            let set = master.match_sets.bgp.extv6_comms.get_mut(&name).unwrap();
+            if let Some(comm) = Extv6Comm::try_from_yang(&args.dnode.get_string()) {
+                set.insert(comm);
+            }
+
+            let event_queue = args.event_queue;
+            event_queue.insert(Event::MatchSetsUpdate);
         })
-        .delete_apply(|_master, _args| {
-            // TODO: implement me!
+        .delete_apply(|master, args| {
+            let name = args.list_entry.into_extv6_comm_set().unwrap();
+            let set = master.match_sets.bgp.extv6_comms.get_mut(&name).unwrap();
+            if let Some(comm) = Extv6Comm::try_from_yang(&args.dnode.get_string()) {
+                set.remove(&comm);
+            }
+
+            let event_queue = args.event_queue;
+            event_queue.insert(Event::MatchSetsUpdate);
         })
         .path(routing_policy::defined_sets::bgp_defined_sets::large_community_sets::large_community_set::PATH)
-        .create_apply(|_master, _args| {
-            // TODO: implement me!
+        .create_apply(|master, args| {
+            let name = args.dnode.get_string_relative("./name").unwrap();
+            master.match_sets.bgp.large_comms.insert(name, Default::default());
         })
-        .delete_apply(|_master, _args| {
-            // TODO: implement me!
+        .delete_apply(|master, args| {
+            let name = args.list_entry.into_large_comm_set().unwrap();
+            master.match_sets.bgp.large_comms.remove(&name);
+
+            let event_queue = args.event_queue;
+            event_queue.insert(Event::MatchSetsUpdate);
         })
-        .lookup(|_master, _list_entry, _dnode| {
-            // TODO: implement me!
-            todo!();
+        .lookup(|_master, _list_entry, dnode| {
+            let name = dnode.get_string_relative("./name").unwrap();
+            ListEntry::LargeCommSet(name)
         })
         .path(routing_policy::defined_sets::bgp_defined_sets::large_community_sets::large_community_set::member::PATH)
-        .create_apply(|_master, _args| {
-            // TODO: implement me!
+        .create_apply(|master, args| {
+            let name = args.list_entry.into_large_comm_set().unwrap();
+            let set = master.match_sets.bgp.large_comms.get_mut(&name).unwrap();
+            if let Some(comm) = LargeComm::try_from_yang(&args.dnode.get_string()) {
+                set.insert(comm);
+            }
+
+            let event_queue = args.event_queue;
+            event_queue.insert(Event::MatchSetsUpdate);
         })
-        .delete_apply(|_master, _args| {
-            // TODO: implement me!
+        .delete_apply(|master, args| {
+            let name = args.list_entry.into_large_comm_set().unwrap();
+            let set = master.match_sets.bgp.large_comms.get_mut(&name).unwrap();
+            if let Some(comm) = LargeComm::try_from_yang(&args.dnode.get_string()) {
+                set.remove(&comm);
+            }
+
+            let event_queue = args.event_queue;
+            event_queue.insert(Event::MatchSetsUpdate);
         })
         .path(routing_policy::defined_sets::bgp_defined_sets::next_hop_sets::next_hop_set::PATH)
         .create_apply(|_master, _args| {
@@ -908,82 +1008,117 @@ fn load_callbacks() -> Callbacks<Master> {
         })
         .delete_apply(|_master, _args| {})
         .path(routing_policy::policy_definitions::policy_definition::statements::statement::conditions::bgp_conditions::match_community_set::community_set::PATH)
-        .modify_apply(|_master, _args| {
-            // TODO: implement me!
+        .modify_apply(|master, args| {
+            bgp_match_set_ref(
+                master,
+                args,
+                BgpPolicyConditionType::MatchCommSet,
+                BgpPolicyCondition::MatchCommSet {
+                    value: String::new(),
+                    match_type: MatchSetType::Any,
+                },
+            );
         })
-        .delete_apply(|_master, _args| {
-            // TODO: implement me!
+        .delete_apply(|master, args| {
+            bgp_match_set_delete(master, args, BgpPolicyConditionType::MatchCommSet);
         })
         .path(routing_policy::policy_definitions::policy_definition::statements::statement::conditions::bgp_conditions::match_community_set::match_set_options::PATH)
-        .modify_apply(|_master, _args| {
-            // TODO: implement me!
+        .modify_apply(|master, args| {
+            bgp_match_set_options(master, args, BgpPolicyConditionType::MatchCommSet);
         })
         .delete_apply(|_master, _args| {
-            // TODO: implement me!
         })
         .path(routing_policy::policy_definitions::policy_definition::statements::statement::conditions::bgp_conditions::match_ext_community_set::ext_community_set::PATH)
-        .modify_apply(|_master, _args| {
-            // TODO: implement me!
+        .modify_apply(|master, args| {
+            bgp_match_set_ref(
+                master,
+                args,
+                BgpPolicyConditionType::MatchExtCommSet,
+                BgpPolicyCondition::MatchExtCommSet {
+                    value: String::new(),
+                    match_type: MatchSetType::Any,
+                },
+            );
         })
-        .delete_apply(|_master, _args| {
-            // TODO: implement me!
+        .delete_apply(|master, args| {
+            bgp_match_set_delete(master, args, BgpPolicyConditionType::MatchExtCommSet);
         })
         .path(routing_policy::policy_definitions::policy_definition::statements::statement::conditions::bgp_conditions::match_ext_community_set::ext_community_match_kind::PATH)
         .modify_apply(|_master, _args| {
             // TODO: implement me!
         })
         .path(routing_policy::policy_definitions::policy_definition::statements::statement::conditions::bgp_conditions::match_ext_community_set::match_set_options::PATH)
-        .modify_apply(|_master, _args| {
-            // TODO: implement me!
+        .modify_apply(|master, args| {
+            bgp_match_set_options(master, args, BgpPolicyConditionType::MatchExtCommSet);
         })
         .delete_apply(|_master, _args| {
-            // TODO: implement me!
         })
         .path(routing_policy::policy_definitions::policy_definition::statements::statement::conditions::bgp_conditions::match_ipv6_ext_community_set::ipv6_ext_community_set::PATH)
-        .modify_apply(|_master, _args| {
-            // TODO: implement me!
+        .modify_apply(|master, args| {
+            bgp_match_set_ref(
+                master,
+                args,
+                BgpPolicyConditionType::MatchExtv6CommSet,
+                BgpPolicyCondition::MatchExtv6CommSet {
+                    value: String::new(),
+                    match_type: MatchSetType::Any,
+                },
+            );
         })
-        .delete_apply(|_master, _args| {
-            // TODO: implement me!
+        .delete_apply(|master, args| {
+            bgp_match_set_delete(master, args, BgpPolicyConditionType::MatchExtv6CommSet);
         })
         .path(routing_policy::policy_definitions::policy_definition::statements::statement::conditions::bgp_conditions::match_ipv6_ext_community_set::ipv6_ext_community_match_kind::PATH)
         .modify_apply(|_master, _args| {
             // TODO: implement me!
         })
         .path(routing_policy::policy_definitions::policy_definition::statements::statement::conditions::bgp_conditions::match_ipv6_ext_community_set::match_set_options::PATH)
-        .modify_apply(|_master, _args| {
-            // TODO: implement me!
+        .modify_apply(|master, args| {
+            bgp_match_set_options(master, args, BgpPolicyConditionType::MatchExtv6CommSet);
         })
         .delete_apply(|_master, _args| {
-            // TODO: implement me!
         })
         .path(routing_policy::policy_definitions::policy_definition::statements::statement::conditions::bgp_conditions::match_large_community_set::large_community_set::PATH)
-        .modify_apply(|_master, _args| {
-            // TODO: implement me!
+        .modify_apply(|master, args| {
+            bgp_match_set_ref(
+                master,
+                args,
+                BgpPolicyConditionType::MatchLargeCommSet,
+                BgpPolicyCondition::MatchLargeCommSet {
+                    value: String::new(),
+                    match_type: MatchSetType::Any,
+                },
+            );
         })
-        .delete_apply(|_master, _args| {
-            // TODO: implement me!
+        .delete_apply(|master, args| {
+            bgp_match_set_delete(master, args, BgpPolicyConditionType::MatchLargeCommSet);
         })
         .path(routing_policy::policy_definitions::policy_definition::statements::statement::conditions::bgp_conditions::match_large_community_set::match_set_options::PATH)
-        .modify_apply(|_master, _args| {
-            // TODO: implement me!
+        .modify_apply(|master, args| {
+            bgp_match_set_options(master, args, BgpPolicyConditionType::MatchLargeCommSet);
         })
         .delete_apply(|_master, _args| {
-            // TODO: implement me!
         })
         .path(routing_policy::policy_definitions::policy_definition::statements::statement::conditions::bgp_conditions::match_as_path_set::as_path_set::PATH)
-        .modify_apply(|_master, _args| {
-            // TODO: implement me!
+        .modify_apply(|master, args| {
+            bgp_match_set_ref(
+                master,
+                args,
+                BgpPolicyConditionType::MatchAsPathSet,
+                BgpPolicyCondition::MatchAsPathSet {
+                    value: String::new(),
+                    match_type: MatchSetType::Any,
+                },
+            );
         })
-        .delete_apply(|_master, _args| {
-            // TODO: implement me!
+        .delete_apply(|master, args| {
+            bgp_match_set_delete(master, args, BgpPolicyConditionType::MatchAsPathSet);
         })
         .path(routing_policy::policy_definitions::policy_definition::statements::statement::conditions::bgp_conditions::match_as_path_set::match_set_options::PATH)
-        .modify_apply(|_master, _args| {
-            // TODO: implement me!
+        .modify_apply(|master, args| {
+            bgp_match_set_options(master, args, BgpPolicyConditionType::MatchAsPathSet);
         })
         .delete_apply(|_master, _args| {
-            // TODO: implement me!
         })
         .path(routing_policy::policy_definitions::policy_definition::statements::statement::conditions::bgp_conditions::match_next_hop_set::next_hop_set::PATH)
         .modify_apply(|_master, _args| {
@@ -1313,88 +1448,92 @@ fn load_callbacks() -> Callbacks<Master> {
             event_queue.insert(Event::PolicyChange(policy.name.clone()));
         })
         .path(routing_policy::policy_definitions::policy_definition::statements::statement::actions::bgp_actions::set_community::options::PATH)
-        .modify_apply(|_master, _args| {
-            // TODO: implement me!
+        .modify_apply(|master, args| {
+            bgp_set_comm_options(master, args, BgpPolicyActionType::SetComm);
         })
         .delete_apply(|_master, _args| {
-            // TODO: implement me!
         })
         .path(routing_policy::policy_definitions::policy_definition::statements::statement::actions::bgp_actions::set_community::communities::PATH)
-        .create_apply(|_master, _args| {
-            // TODO: implement me!
+        .create_apply(|master, args| {
+            let comm = Comm::try_from_yang(&args.dnode.get_string()).unwrap();
+            bgp_set_comm_inline_add(master, args, comm, BgpPolicyActionType::SetComm);
         })
-        .delete_apply(|_master, _args| {
-            // TODO: implement me!
+        .delete_apply(|master, args| {
+            let comm = Comm::try_from_yang(&args.dnode.get_string()).unwrap();
+            bgp_set_comm_inline_remove(master, args, comm, BgpPolicyActionType::SetComm);
         })
         .path(routing_policy::policy_definitions::policy_definition::statements::statement::actions::bgp_actions::set_community::community_set_ref::PATH)
-        .modify_apply(|_master, _args| {
-            // TODO: implement me!
+        .modify_apply(|master, args| {
+            bgp_set_comm_reference(master, args, BgpPolicyActionType::SetComm);
         })
-        .delete_apply(|_master, _args| {
-            // TODO: implement me!
+        .delete_apply(|master, args| {
+            bgp_set_comm_delete(master, args, BgpPolicyActionType::SetComm);
         })
         .path(routing_policy::policy_definitions::policy_definition::statements::statement::actions::bgp_actions::set_ext_community::options::PATH)
-        .modify_apply(|_master, _args| {
-            // TODO: implement me!
+        .modify_apply(|master, args| {
+            bgp_set_comm_options(master, args, BgpPolicyActionType::SetExtComm);
         })
         .delete_apply(|_master, _args| {
-            // TODO: implement me!
         })
         .path(routing_policy::policy_definitions::policy_definition::statements::statement::actions::bgp_actions::set_ext_community::communities::PATH)
-        .create_apply(|_master, _args| {
-            // TODO: implement me!
+        .create_apply(|master, args| {
+            let comm = ExtComm::try_from_yang(&args.dnode.get_string()).unwrap();
+            bgp_set_comm_inline_add(master, args, comm, BgpPolicyActionType::SetExtComm);
         })
-        .delete_apply(|_master, _args| {
-            // TODO: implement me!
+        .delete_apply(|master, args| {
+            let comm = ExtComm::try_from_yang(&args.dnode.get_string()).unwrap();
+            bgp_set_comm_inline_remove(master, args, comm, BgpPolicyActionType::SetExtComm);
         })
         .path(routing_policy::policy_definitions::policy_definition::statements::statement::actions::bgp_actions::set_ext_community::ext_community_set_ref::PATH)
-        .modify_apply(|_master, _args| {
-            // TODO: implement me!
+        .modify_apply(|master, args| {
+            bgp_set_comm_reference(master, args, BgpPolicyActionType::SetExtComm);
         })
-        .delete_apply(|_master, _args| {
-            // TODO: implement me!
+        .delete_apply(|master, args| {
+            bgp_set_comm_delete(master, args, BgpPolicyActionType::SetExtComm);
         })
         .path(routing_policy::policy_definitions::policy_definition::statements::statement::actions::bgp_actions::set_ipv6_ext_community::options::PATH)
-        .modify_apply(|_master, _args| {
-            // TODO: implement me!
+        .modify_apply(|master, args| {
+            bgp_set_comm_options(master, args, BgpPolicyActionType::SetExtv6Comm);
         })
         .delete_apply(|_master, _args| {
-            // TODO: implement me!
         })
         .path(routing_policy::policy_definitions::policy_definition::statements::statement::actions::bgp_actions::set_ipv6_ext_community::communities::PATH)
-        .create_apply(|_master, _args| {
-            // TODO: implement me!
+        .create_apply(|master, args| {
+            let comm = Extv6Comm::try_from_yang(&args.dnode.get_string()).unwrap();
+            bgp_set_comm_inline_add(master, args, comm, BgpPolicyActionType::SetExtv6Comm);
         })
-        .delete_apply(|_master, _args| {
-            // TODO: implement me!
+        .delete_apply(|master, args| {
+            let comm = Extv6Comm::try_from_yang(&args.dnode.get_string()).unwrap();
+            bgp_set_comm_inline_remove(master, args, comm, BgpPolicyActionType::SetExtv6Comm);
         })
         .path(routing_policy::policy_definitions::policy_definition::statements::statement::actions::bgp_actions::set_ipv6_ext_community::ipv6_ext_community_set_ref::PATH)
-        .modify_apply(|_master, _args| {
-            // TODO: implement me!
+        .modify_apply(|master, args| {
+            bgp_set_comm_reference(master, args, BgpPolicyActionType::SetExtv6Comm);
         })
-        .delete_apply(|_master, _args| {
-            // TODO: implement me!
+        .delete_apply(|master, args| {
+            bgp_set_comm_delete(master, args, BgpPolicyActionType::SetExtv6Comm);
         })
         .path(routing_policy::policy_definitions::policy_definition::statements::statement::actions::bgp_actions::set_large_community::options::PATH)
-        .modify_apply(|_master, _args| {
-            // TODO: implement me!
+        .modify_apply(|master, args| {
+            bgp_set_comm_options(master, args, BgpPolicyActionType::SetLargeComm);
         })
         .delete_apply(|_master, _args| {
-            // TODO: implement me!
         })
         .path(routing_policy::policy_definitions::policy_definition::statements::statement::actions::bgp_actions::set_large_community::communities::PATH)
-        .create_apply(|_master, _args| {
-            // TODO: implement me!
+        .create_apply(|master, args| {
+            let comm = LargeComm::try_from_yang(&args.dnode.get_string()).unwrap();
+            bgp_set_comm_inline_add(master, args, comm, BgpPolicyActionType::SetLargeComm);
         })
-        .delete_apply(|_master, _args| {
-            // TODO: implement me!
+        .delete_apply(|master, args| {
+            let comm = LargeComm::try_from_yang(&args.dnode.get_string()).unwrap();
+            bgp_set_comm_inline_remove(master, args, comm, BgpPolicyActionType::SetLargeComm);
         })
         .path(routing_policy::policy_definitions::policy_definition::statements::statement::actions::bgp_actions::set_large_community::large_community_set_ref::PATH)
-        .modify_apply(|_master, _args| {
-            // TODO: implement me!
+        .modify_apply(|master, args| {
+            bgp_set_comm_reference(master, args, BgpPolicyActionType::SetLargeComm);
         })
-        .delete_apply(|_master, _args| {
-            // TODO: implement me!
+        .delete_apply(|master, args| {
+            bgp_set_comm_delete(master, args, BgpPolicyActionType::SetLargeComm);
         })
         .build()
 }
@@ -1488,6 +1627,400 @@ fn bgp_cond_set_op(master: &mut Master, args: configuration::CallbackArgs<'_, Ma
 
     let event_queue = args.event_queue;
     event_queue.insert(Event::PolicyChange(policy.name.clone()));
+}
+
+fn bgp_match_set_type_get(
+    stmt: &PolicyStmt,
+    cond_type: BgpPolicyConditionType,
+) -> MatchSetType {
+    let key = PolicyConditionType::Bgp(cond_type);
+    match stmt.conditions.get(&key) {
+        Some(PolicyCondition::Bgp(
+            BgpPolicyCondition::MatchCommSet {
+                match_type, ..
+            }
+            | BgpPolicyCondition::MatchExtCommSet {
+                match_type, ..
+            }
+            | BgpPolicyCondition::MatchExtv6CommSet {
+                match_type, ..
+            }
+            | BgpPolicyCondition::MatchLargeCommSet {
+                match_type, ..
+            }
+            | BgpPolicyCondition::MatchAsPathSet {
+                match_type, ..
+            },
+        )) => *match_type,
+        _ => MatchSetType::Any,
+    }
+}
+
+fn bgp_match_set_ref(
+    master: &mut Master,
+    args: configuration::CallbackArgs<'_, Master>,
+    cond_type: BgpPolicyConditionType,
+    mut condition: BgpPolicyCondition,
+) {
+    let (policy_name, stmt_name) = args.list_entry.into_policy_stmt().unwrap();
+    let policy = master.policies.get_mut(&policy_name).unwrap();
+    let stmt = policy.stmts.get_mut(&stmt_name).unwrap();
+
+    let set_name = args.dnode.get_string();
+    let match_type = bgp_match_set_type_get(stmt, cond_type);
+    match &mut condition {
+        BgpPolicyCondition::MatchCommSet {
+            value,
+            match_type: existing,
+        }
+        | BgpPolicyCondition::MatchExtCommSet {
+            value,
+            match_type: existing,
+        }
+        | BgpPolicyCondition::MatchExtv6CommSet {
+            value,
+            match_type: existing,
+        }
+        | BgpPolicyCondition::MatchLargeCommSet {
+            value,
+            match_type: existing,
+        }
+        | BgpPolicyCondition::MatchAsPathSet {
+            value,
+            match_type: existing,
+        } => {
+            *value = set_name;
+            *existing = match_type;
+        }
+        _ => unreachable!(),
+    }
+    stmt.condition_add(PolicyCondition::Bgp(condition));
+
+    let event_queue = args.event_queue;
+    event_queue.insert(Event::PolicyChange(policy.name.clone()));
+}
+
+fn bgp_match_set_options(
+    master: &mut Master,
+    args: configuration::CallbackArgs<'_, Master>,
+    cond_type: BgpPolicyConditionType,
+) {
+    let (policy_name, stmt_name) = args.list_entry.into_policy_stmt().unwrap();
+    let policy = master.policies.get_mut(&policy_name).unwrap();
+    let stmt = policy.stmts.get_mut(&stmt_name).unwrap();
+
+    let match_type = args.dnode.get_string();
+    let match_type = MatchSetType::try_from_yang(&match_type).unwrap();
+    let key = PolicyConditionType::Bgp(cond_type);
+    if let Some(PolicyCondition::Bgp(
+        BgpPolicyCondition::MatchCommSet {
+            match_type: existing, ..
+        }
+        | BgpPolicyCondition::MatchExtCommSet {
+            match_type: existing, ..
+        }
+        | BgpPolicyCondition::MatchExtv6CommSet {
+            match_type: existing, ..
+        }
+        | BgpPolicyCondition::MatchLargeCommSet {
+            match_type: existing, ..
+        }
+        | BgpPolicyCondition::MatchAsPathSet {
+            match_type: existing, ..
+        },
+    )) = stmt.conditions.get_mut(&key)
+    {
+        *existing = match_type;
+    }
+
+    let event_queue = args.event_queue;
+    event_queue.insert(Event::PolicyChange(policy.name.clone()));
+}
+
+fn bgp_match_set_delete(
+    master: &mut Master,
+    args: configuration::CallbackArgs<'_, Master>,
+    cond_type: BgpPolicyConditionType,
+) {
+    let (policy_name, stmt_name) = args.list_entry.into_policy_stmt().unwrap();
+    let policy = master.policies.get_mut(&policy_name).unwrap();
+    let stmt = policy.stmts.get_mut(&stmt_name).unwrap();
+
+    stmt.condition_remove(PolicyConditionType::Bgp(cond_type));
+
+    let event_queue = args.event_queue;
+    event_queue.insert(Event::PolicyChange(policy.name.clone()));
+}
+
+trait BgpCommValue:
+    Clone + Eq + Ord + PartialEq + PartialOrd
+{
+    const ACTION_TYPE: BgpPolicyActionType;
+
+    fn make_action(
+        options: BgpSetCommOptions,
+        method: BgpSetCommMethod<Self>,
+    ) -> PolicyAction;
+
+    fn action_mut(
+        action: &mut PolicyAction,
+    ) -> Option<(&mut BgpSetCommOptions, &mut BgpSetCommMethod<Self>)>;
+}
+
+impl BgpCommValue for Comm {
+    const ACTION_TYPE: BgpPolicyActionType = BgpPolicyActionType::SetComm;
+
+    fn make_action(
+        options: BgpSetCommOptions,
+        method: BgpSetCommMethod<Self>,
+    ) -> PolicyAction {
+        PolicyAction::Bgp(BgpPolicyAction::SetComm { options, method })
+    }
+
+    fn action_mut(
+        action: &mut PolicyAction,
+    ) -> Option<(&mut BgpSetCommOptions, &mut BgpSetCommMethod<Self>)> {
+        match action {
+            PolicyAction::Bgp(BgpPolicyAction::SetComm { options, method }) => {
+                Some((options, method))
+            }
+            _ => None,
+        }
+    }
+}
+
+impl BgpCommValue for ExtComm {
+    const ACTION_TYPE: BgpPolicyActionType = BgpPolicyActionType::SetExtComm;
+
+    fn make_action(
+        options: BgpSetCommOptions,
+        method: BgpSetCommMethod<Self>,
+    ) -> PolicyAction {
+        PolicyAction::Bgp(BgpPolicyAction::SetExtComm { options, method })
+    }
+
+    fn action_mut(
+        action: &mut PolicyAction,
+    ) -> Option<(&mut BgpSetCommOptions, &mut BgpSetCommMethod<Self>)> {
+        match action {
+            PolicyAction::Bgp(BgpPolicyAction::SetExtComm { options, method }) => {
+                Some((options, method))
+            }
+            _ => None,
+        }
+    }
+}
+
+impl BgpCommValue for Extv6Comm {
+    const ACTION_TYPE: BgpPolicyActionType = BgpPolicyActionType::SetExtv6Comm;
+
+    fn make_action(
+        options: BgpSetCommOptions,
+        method: BgpSetCommMethod<Self>,
+    ) -> PolicyAction {
+        PolicyAction::Bgp(BgpPolicyAction::SetExtv6Comm { options, method })
+    }
+
+    fn action_mut(
+        action: &mut PolicyAction,
+    ) -> Option<(&mut BgpSetCommOptions, &mut BgpSetCommMethod<Self>)> {
+        match action {
+            PolicyAction::Bgp(BgpPolicyAction::SetExtv6Comm { options, method }) => {
+                Some((options, method))
+            }
+            _ => None,
+        }
+    }
+}
+
+impl BgpCommValue for LargeComm {
+    const ACTION_TYPE: BgpPolicyActionType = BgpPolicyActionType::SetLargeComm;
+
+    fn make_action(
+        options: BgpSetCommOptions,
+        method: BgpSetCommMethod<Self>,
+    ) -> PolicyAction {
+        PolicyAction::Bgp(BgpPolicyAction::SetLargeComm { options, method })
+    }
+
+    fn action_mut(
+        action: &mut PolicyAction,
+    ) -> Option<(&mut BgpSetCommOptions, &mut BgpSetCommMethod<Self>)> {
+        match action {
+            PolicyAction::Bgp(BgpPolicyAction::SetLargeComm { options, method }) => {
+                Some((options, method))
+            }
+            _ => None,
+        }
+    }
+}
+
+fn bgp_set_comm_options(
+    master: &mut Master,
+    args: configuration::CallbackArgs<'_, Master>,
+    action_type: BgpPolicyActionType,
+) {
+    match action_type {
+        BgpPolicyActionType::SetComm => bgp_set_comm_options_t::<Comm>(master, args),
+        BgpPolicyActionType::SetExtComm => {
+            bgp_set_comm_options_t::<ExtComm>(master, args)
+        }
+        BgpPolicyActionType::SetExtv6Comm => {
+            bgp_set_comm_options_t::<Extv6Comm>(master, args)
+        }
+        BgpPolicyActionType::SetLargeComm => {
+            bgp_set_comm_options_t::<LargeComm>(master, args)
+        }
+        _ => unreachable!(),
+    }
+}
+
+fn bgp_set_comm_options_t<T>(
+    master: &mut Master,
+    args: configuration::CallbackArgs<'_, Master>,
+) where
+    T: BgpCommValue,
+{
+    let (policy_name, stmt_name) = args.list_entry.into_policy_stmt().unwrap();
+    let policy = master.policies.get_mut(&policy_name).unwrap();
+    let stmt = policy.stmts.get_mut(&stmt_name).unwrap();
+
+    let options = bgp_set_comm_options_from_yang(&args.dnode.get_string());
+    let key = PolicyActionType::Bgp(T::ACTION_TYPE);
+    match stmt.actions.get_mut(&key).and_then(T::action_mut) {
+        Some((existing, _)) => *existing = options,
+        None => stmt.action_add(T::make_action(
+            options,
+            BgpSetCommMethod::Inline(Default::default()),
+        )),
+    }
+
+    let event_queue = args.event_queue;
+    event_queue.insert(Event::PolicyChange(policy.name.clone()));
+}
+
+fn bgp_set_comm_inline_add<T>(
+    master: &mut Master,
+    args: configuration::CallbackArgs<'_, Master>,
+    comm: T,
+    _action_type: BgpPolicyActionType,
+) where
+    T: BgpCommValue,
+{
+    let (policy_name, stmt_name) = args.list_entry.into_policy_stmt().unwrap();
+    let policy = master.policies.get_mut(&policy_name).unwrap();
+    let stmt = policy.stmts.get_mut(&stmt_name).unwrap();
+    let key = PolicyActionType::Bgp(T::ACTION_TYPE);
+
+    match stmt.actions.get_mut(&key).and_then(T::action_mut) {
+        Some((_, BgpSetCommMethod::Inline(comms))) => {
+            comms.insert(comm);
+        }
+        Some((_, method)) => {
+            *method = BgpSetCommMethod::Inline(BTreeSet::from([comm]));
+        }
+        None => stmt.action_add(T::make_action(
+            BgpSetCommOptions::Add,
+            BgpSetCommMethod::Inline(BTreeSet::from([comm])),
+        )),
+    }
+
+    let event_queue = args.event_queue;
+    event_queue.insert(Event::PolicyChange(policy.name.clone()));
+}
+
+fn bgp_set_comm_inline_remove<T>(
+    master: &mut Master,
+    args: configuration::CallbackArgs<'_, Master>,
+    comm: T,
+    _action_type: BgpPolicyActionType,
+) where
+    T: BgpCommValue,
+{
+    let (policy_name, stmt_name) = args.list_entry.into_policy_stmt().unwrap();
+    let policy = master.policies.get_mut(&policy_name).unwrap();
+    let stmt = policy.stmts.get_mut(&stmt_name).unwrap();
+    let key = PolicyActionType::Bgp(T::ACTION_TYPE);
+
+    if let Some((_, BgpSetCommMethod::Inline(comms))) =
+        stmt.actions.get_mut(&key).and_then(T::action_mut)
+    {
+        comms.remove(&comm);
+    }
+
+    let event_queue = args.event_queue;
+    event_queue.insert(Event::PolicyChange(policy.name.clone()));
+}
+
+fn bgp_set_comm_reference(
+    master: &mut Master,
+    args: configuration::CallbackArgs<'_, Master>,
+    action_type: BgpPolicyActionType,
+) {
+    match action_type {
+        BgpPolicyActionType::SetComm => bgp_set_comm_reference_t::<Comm>(master, args),
+        BgpPolicyActionType::SetExtComm => {
+            bgp_set_comm_reference_t::<ExtComm>(master, args)
+        }
+        BgpPolicyActionType::SetExtv6Comm => {
+            bgp_set_comm_reference_t::<Extv6Comm>(master, args)
+        }
+        BgpPolicyActionType::SetLargeComm => {
+            bgp_set_comm_reference_t::<LargeComm>(master, args)
+        }
+        _ => unreachable!(),
+    }
+}
+
+fn bgp_set_comm_reference_t<T>(
+    master: &mut Master,
+    args: configuration::CallbackArgs<'_, Master>,
+) where
+    T: BgpCommValue,
+{
+    let (policy_name, stmt_name) = args.list_entry.into_policy_stmt().unwrap();
+    let policy = master.policies.get_mut(&policy_name).unwrap();
+    let stmt = policy.stmts.get_mut(&stmt_name).unwrap();
+
+    let set_name = args.dnode.get_string();
+    let key = PolicyActionType::Bgp(T::ACTION_TYPE);
+    let options = stmt
+        .actions
+        .get_mut(&key)
+        .and_then(T::action_mut)
+        .map(|(options, _)| *options)
+        .unwrap_or(BgpSetCommOptions::Add);
+    stmt.action_add(T::make_action(
+        options,
+        BgpSetCommMethod::Reference(set_name),
+    ));
+
+    let event_queue = args.event_queue;
+    event_queue.insert(Event::PolicyChange(policy.name.clone()));
+}
+
+fn bgp_set_comm_delete(
+    master: &mut Master,
+    args: configuration::CallbackArgs<'_, Master>,
+    action_type: BgpPolicyActionType,
+) {
+    let (policy_name, stmt_name) = args.list_entry.into_policy_stmt().unwrap();
+    let policy = master.policies.get_mut(&policy_name).unwrap();
+    let stmt = policy.stmts.get_mut(&stmt_name).unwrap();
+
+    stmt.action_remove(PolicyActionType::Bgp(action_type));
+
+    let event_queue = args.event_queue;
+    event_queue.insert(Event::PolicyChange(policy.name.clone()));
+}
+
+fn bgp_set_comm_options_from_yang(value: &str) -> BgpSetCommOptions {
+    match value {
+        "add" => BgpSetCommOptions::Add,
+        "remove" => BgpSetCommOptions::Remove,
+        "replace" => BgpSetCommOptions::Replace,
+        _ => unreachable!(),
+    }
 }
 
 fn bgp_as_path_prepend_get_asn(stmt: &PolicyStmt) -> u32 {

--- a/holo-protocol/src/lib.rs
+++ b/holo-protocol/src/lib.rs
@@ -387,6 +387,34 @@ pub fn spawn_protocol_task<P>(
     ibus_instance_tx: IbusSender,
     ibus_instance_rx: IbusReceiver,
     agg_channels: InstanceAggChannels<P>,
+    shared: InstanceShared,
+) -> NbDaemonSender
+where
+    P: ProtocolInstance,
+{
+    #[cfg(feature = "testing")]
+    let (_test_tx, test_rx) = mpsc::channel(4);
+
+    spawn_protocol_task_inner::<P>(
+        name,
+        nb_provider_tx,
+        ibus_tx,
+        ibus_instance_tx,
+        ibus_instance_rx,
+        agg_channels,
+        #[cfg(feature = "testing")]
+        test_rx,
+        shared,
+    )
+}
+
+pub(crate) fn spawn_protocol_task_inner<P>(
+    name: String,
+    nb_provider_tx: &NbProviderSender,
+    ibus_tx: &IbusChannelsTx,
+    ibus_instance_tx: IbusSender,
+    ibus_instance_rx: IbusReceiver,
+    agg_channels: InstanceAggChannels<P>,
     #[cfg(feature = "testing")] test_rx: Receiver<
         TestMsg<P::ProtocolOutputMsg>,
     >,

--- a/holo-protocol/src/test/stub/mod.rs
+++ b/holo-protocol/src/test/stub/mod.rs
@@ -23,7 +23,6 @@ use crate::test::stub::northbound::NorthboundStub;
 use crate::test::{OutputChannelsRx, setup};
 use crate::{
     InstanceAggChannels, InstanceMsg, InstanceShared, ProtocolInstance,
-    spawn_protocol_task,
 };
 
 // Environment variable that controls if the test data needs to be updated or
@@ -277,7 +276,7 @@ where
     let channels = InstanceAggChannels::default();
     let instance_tx = channels.tx.clone();
     let (test_tx, test_rx) = mpsc::channel(4);
-    let nb_daemon_tx = spawn_protocol_task::<P>(
+    let nb_daemon_tx = crate::spawn_protocol_task_inner::<P>(
         name.to_owned(),
         &nb_provider_tx,
         &ibus_tx,

--- a/holo-utils/src/bgp.rs
+++ b/holo-utils/src/bgp.rs
@@ -12,7 +12,7 @@
 //! eliminating the need for shared definitions.
 
 use std::borrow::Cow;
-use std::net::Ipv6Addr;
+use std::net::{IpAddr, Ipv6Addr};
 
 use holo_yang::{ToYang, TryFromYang};
 use itertools::Itertools;
@@ -222,6 +222,25 @@ impl ToYang for ExtComm {
     }
 }
 
+impl TryFromYang for ExtComm {
+    fn try_from_yang(value: &str) -> Option<ExtComm> {
+        if let Some(raw) = value.strip_prefix("raw:") {
+            let bytes = parse_hex_bytes::<8>(raw)?;
+            return Some(ExtComm(bytes));
+        }
+
+        if let Some(value) = value.strip_prefix("route-target:") {
+            return parse_ext_comm_route(0x02, value);
+        }
+
+        if let Some(value) = value.strip_prefix("route-origin:") {
+            return parse_ext_comm_route(0x03, value);
+        }
+
+        None
+    }
+}
+
 // ===== impl Extv6Comm =====
 
 impl ToYang for Extv6Comm {
@@ -243,6 +262,16 @@ impl ToYang for Extv6Comm {
     }
 }
 
+impl TryFromYang for Extv6Comm {
+    fn try_from_yang(value: &str) -> Option<Extv6Comm> {
+        let raw = value.strip_prefix("ipv6-raw:")?;
+        let bytes = parse_hex_bytes::<20>(raw)?;
+        let addr = Ipv6Addr::from(<[u8; 16]>::try_from(&bytes[..16]).ok()?);
+        let local = u32::from_be_bytes(bytes[16..].try_into().ok()?);
+        Some(Extv6Comm(addr, local))
+    }
+}
+
 // ===== impl LargeComm =====
 
 impl ToYang for LargeComm {
@@ -259,23 +288,72 @@ impl ToYang for LargeComm {
 
 impl TryFromYang for LargeComm {
     fn try_from_yang(value: &str) -> Option<LargeComm> {
-        // Parse large community in the "global:local:local" format.
-        let re = Regex::new(r#"^(?:(?:4[0-2][0-9][0-4][0-9][0-6][0-7][0-2][0-9][0-6])|(?:[1-3][0-9]{9}|[1-9]([0-9]{1,7})?[0-9]|[0-9])):(?:(?:4[0-2][0-9][0-4][0-9][0-6][0-7][0-2][0-9][0-6])|(?:[1-3][0-9]{9}|[1-9]([0-9]{1,7})?[0-9]|[0-9])):(?:(?:4[0-2][0-9][0-4][0-9][0-6][0-7][0-2][0-9][0-6])|(?:[1-3][0-9]{9}|[1-9]([0-9]{1,7})?[0-9]|[0-9]))$"#).unwrap();
-        if let Some(captures) = re.captures(value) {
-            let global =
-                captures.get(1).unwrap().as_str().parse::<u32>().unwrap();
-            let local1 =
-                captures.get(2).unwrap().as_str().parse::<u32>().unwrap();
-            let local2 =
-                captures.get(3).unwrap().as_str().parse::<u32>().unwrap();
-
-            let mut comm = [0u8; 12];
-            comm[..4].copy_from_slice(&global.to_be_bytes());
-            comm[4..8].copy_from_slice(&local1.to_be_bytes());
-            comm[8..].copy_from_slice(&local2.to_be_bytes());
-            return Some(LargeComm(comm));
+        let mut parts = value.split(':');
+        let global = parts.next()?.parse::<u32>().ok()?;
+        let local1 = parts.next()?.parse::<u32>().ok()?;
+        let local2 = parts.next()?.parse::<u32>().ok()?;
+        if parts.next().is_some() {
+            return None;
         }
 
-        None
+        let mut comm = [0u8; 12];
+        comm[..4].copy_from_slice(&global.to_be_bytes());
+        comm[4..8].copy_from_slice(&local1.to_be_bytes());
+        comm[8..].copy_from_slice(&local2.to_be_bytes());
+        Some(LargeComm(comm))
     }
+}
+
+// ===== helper functions =====
+
+fn parse_hex_bytes<const N: usize>(value: &str) -> Option<[u8; N]> {
+    let mut bytes = [0u8; N];
+    let mut count = 0;
+
+    for (idx, byte) in value.split(':').enumerate() {
+        if idx >= N || byte.len() != 2 {
+            return None;
+        }
+        bytes[idx] = u8::from_str_radix(byte, 16).ok()?;
+        count += 1;
+    }
+
+    (count == N).then_some(bytes)
+}
+
+fn parse_ext_comm_route(subtype: u8, value: &str) -> Option<ExtComm> {
+    let (global, local) = value.rsplit_once(':')?;
+    let local = local.parse::<u32>().ok()?;
+    let mut bytes = [0u8; 8];
+
+    match global.parse::<IpAddr>() {
+        Ok(IpAddr::V4(addr)) => {
+            if local > u16::MAX.into() {
+                return None;
+            }
+            bytes[0] = 0x01;
+            bytes[1] = subtype;
+            bytes[2..6].copy_from_slice(&addr.octets());
+            bytes[6..8].copy_from_slice(&(local as u16).to_be_bytes());
+        }
+        Ok(IpAddr::V6(_)) => return None,
+        Err(_) => {
+            let global = global.parse::<u32>().ok()?;
+            if global <= u16::MAX.into() {
+                bytes[0] = 0x00;
+                bytes[1] = subtype;
+                bytes[2..4].copy_from_slice(&(global as u16).to_be_bytes());
+                bytes[4..8].copy_from_slice(&local.to_be_bytes());
+            } else if local <= u16::MAX.into() {
+                bytes[0] = 0x02;
+                bytes[1] = subtype;
+                bytes[2..6].copy_from_slice(&global.to_be_bytes());
+                bytes[6..8].copy_from_slice(&(local as u16).to_be_bytes());
+            } else {
+                return None;
+            }
+        }
+    }
+
+    Some(ExtComm(bytes))
 }

--- a/holo-utils/src/policy.rs
+++ b/holo-utils/src/policy.rs
@@ -187,8 +187,10 @@ pub struct BgpMatchSets {
 pub struct Policy {
     // Name of the policy.
     pub name: String,
-    // List of statements.
-    // TODO: "ordered-by user"
+    // Statement names in YANG "ordered-by user" order.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub stmt_order: Vec<String>,
+    // Statements keyed by name for configuration callbacks.
     pub stmts: BTreeMap<String, PolicyStmt>,
 }
 
@@ -578,6 +580,39 @@ impl TryFromYang for MatchSetRestrictedType {
             "invert" => Some(MatchSetRestrictedType::Invert),
             _ => None,
         }
+    }
+}
+
+// ===== impl Policy =====
+
+impl Policy {
+    pub fn new(name: String) -> Self {
+        Self {
+            name,
+            stmt_order: Default::default(),
+            stmts: Default::default(),
+        }
+    }
+
+    pub fn stmt_add(&mut self, stmt: PolicyStmt) {
+        if !self.stmts.contains_key(&stmt.name) {
+            self.stmt_order.push(stmt.name.clone());
+        }
+        self.stmts.insert(stmt.name.clone(), stmt);
+    }
+
+    pub fn stmt_remove(&mut self, name: &str) {
+        self.stmts.remove(name);
+        self.stmt_order.retain(|stmt_name| stmt_name != name);
+    }
+
+    pub fn stmts_ordered(&self) -> impl Iterator<Item = &PolicyStmt> {
+        self.stmt_order
+            .iter()
+            .filter_map(|name| self.stmts.get(name))
+            .chain(self.stmts.iter().filter_map(|(name, stmt)| {
+                (!self.stmt_order.contains(name)).then_some(stmt)
+            }))
     }
 }
 

--- a/holo-utils/src/task.rs
+++ b/holo-utils/src/task.rs
@@ -221,6 +221,17 @@ impl TimeoutTask {
         }
     }
 
+    /// Returns an inert timeout handle in deterministic test builds.
+    #[cfg(feature = "testing")]
+    pub fn new<F, Fut>(timeout: Duration, cb: F) -> TimeoutTask
+    where
+        F: FnOnce() -> Fut + Send + 'static,
+        Fut: Future<Output = ()> + Send,
+    {
+        let _ = (timeout, cb);
+        TimeoutTask {}
+    }
+
     /// Resets the timeout, regardless if it has already expired or not.
     ///
     /// If a new timeout value isn't specified, the last value will be reused.


### PR DESCRIPTION
Inbound soft-reconfiguration (stacked on #140): re-apply import policy to already-received routes without asking the peer to re-send, using the retained pre-policy Adj-RIB-In.

- Any import-policy change (per-AF or per-neighbor import-policy add/remove, and default-import-policy) queues a re-apply that re-evaluates the retained Adj-RIB-In for the affected neighbor(s)/AF(s) through the new policy, then re-runs the decision process.
- Re-evaluation reads the **unmodified pre-policy** Adj-RIB-In (never a previously policy-mutated copy), so mutations don't compound — unit test `import_reapply_uses_retained_adj_rib_in_pre`.
- Correct deltas: a route that now fails policy is **withdrawn** from the Loc-RIB; a route that now passes is added. The `soft-reconfig-in-1` conformance test flips the policy and asserts both — `RouteIpDel` for the newly-failing prefix and `RouteIpAdd` for the newly-passing one.
- Fail-safe evaluation is unchanged from the policy engine (no panic on missing refs).

Wired for the IPv4/IPv6 unicast address families. Deferred: outbound soft-reconfiguration (export re-run over Adj-RIB-Out); precise per-policy affected-neighbor mapping (currently re-evaluates the affected AF conservatively); VPN/EVPN AF re-apply.

Stacked on #140.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
