### PR TITLE
bgp: register neighbors as BFD clients

### DIFF
--- a/holo-bgp/src/ibus/rx.rs
+++ b/holo-bgp/src/ibus/rx.rs
@@ -41,10 +41,9 @@ pub(crate) fn process_bfd_state_update(
         return;
     };
 
-    let Some(nbr) = neighbors
-        .values_mut()
-        .find(|nbr| nbr.bfd.as_ref().is_some_and(|bfd| bfd.sess_key == sess_key))
-    else {
+    let Some(nbr) = neighbors.values_mut().find(|nbr| {
+        nbr.bfd.as_ref().is_some_and(|bfd| bfd.sess_key == sess_key)
+    }) else {
         return;
     };
 
@@ -59,11 +58,7 @@ pub(crate) fn process_iface_update(
         return;
     };
 
-    instance
-        .state
-        .interfaces
-        .entry(msg.ifname)
-        .or_default();
+    instance.state.interfaces.entry(msg.ifname).or_default();
     update_bfd_sessions(&instance, neighbors);
 }
 

--- a/holo-bgp/src/ibus/rx.rs
+++ b/holo-bgp/src/ibus/rx.rs
@@ -6,10 +6,13 @@
 
 use std::net::{IpAddr, Ipv4Addr};
 
+use holo_utils::bfd;
 use holo_utils::bgp::RouteType;
 use holo_utils::ip::IpNetworkExt;
 use holo_utils::protocol::Protocol;
-use holo_utils::southbound::{RouteKeyMsg, RouteMsg};
+use holo_utils::southbound::{
+    AddressMsg, InterfaceUpdateMsg, RouteKeyMsg, RouteMsg,
+};
 use ipnetwork::IpNetwork;
 
 use crate::af::{AddressFamily, Ipv4Unicast, Ipv6Unicast};
@@ -27,6 +30,71 @@ pub(crate) fn process_router_id_update(
 ) {
     instance.system.router_id = router_id;
     instance.update();
+}
+
+pub(crate) fn process_bfd_state_update(
+    instance: &mut Instance,
+    sess_key: bfd::SessionKey,
+    state: bfd::State,
+) {
+    let Some((mut instance, neighbors)) = instance.as_up() else {
+        return;
+    };
+
+    let Some(nbr) = neighbors
+        .values_mut()
+        .find(|nbr| nbr.bfd.as_ref().is_some_and(|bfd| bfd.sess_key == sess_key))
+    else {
+        return;
+    };
+
+    nbr.bfd_state_update(&mut instance, state);
+}
+
+pub(crate) fn process_iface_update(
+    instance: &mut Instance,
+    msg: InterfaceUpdateMsg,
+) {
+    let Some((instance, neighbors)) = instance.as_up() else {
+        return;
+    };
+
+    instance
+        .state
+        .interfaces
+        .entry(msg.ifname)
+        .or_default();
+    update_bfd_sessions(&instance, neighbors);
+}
+
+pub(crate) fn process_addr_add(instance: &mut Instance, msg: AddressMsg) {
+    if msg.addr.ip().is_loopback() {
+        return;
+    }
+
+    let Some((instance, neighbors)) = instance.as_up() else {
+        return;
+    };
+
+    instance
+        .state
+        .interfaces
+        .entry(msg.ifname)
+        .or_default()
+        .addrs
+        .insert(msg.addr);
+    update_bfd_sessions(&instance, neighbors);
+}
+
+pub(crate) fn process_addr_del(instance: &mut Instance, msg: AddressMsg) {
+    let Some((instance, neighbors)) = instance.as_up() else {
+        return;
+    };
+
+    if let Some(iface) = instance.state.interfaces.get_mut(&msg.ifname) {
+        iface.addrs.remove(&msg.addr);
+    }
+    update_bfd_sessions(&instance, neighbors);
 }
 
 pub(crate) fn process_nht_update(
@@ -86,6 +154,17 @@ pub(crate) fn process_route_del(instance: &mut Instance, msg: RouteKeyMsg) {
 }
 
 // ===== helper functions =====
+
+fn update_bfd_sessions(
+    instance: &InstanceUpView<'_>,
+    neighbors: &mut crate::neighbor::Neighbors,
+) {
+    for nbr in neighbors.values_mut() {
+        if nbr.config.bfd.enabled {
+            nbr.bfd_update_session(instance);
+        }
+    }
+}
 
 fn process_nht_update_af<A>(
     instance: &mut InstanceUpView<'_>,

--- a/holo-bgp/src/ibus/tx.rs
+++ b/holo-bgp/src/ibus/tx.rs
@@ -22,6 +22,10 @@ pub(crate) fn router_id_sub(ibus_tx: &IbusChannelsTx) {
     ibus_tx.router_id_sub();
 }
 
+pub(crate) fn interface_sub(ibus_tx: &IbusChannelsTx) {
+    ibus_tx.interface_sub(None, None);
+}
+
 pub(crate) fn route_install(
     ibus_tx: &IbusChannelsTx,
     prefix: impl Into<IpNetwork>,

--- a/holo-bgp/src/instance.rs
+++ b/holo-bgp/src/instance.rs
@@ -4,6 +4,7 @@
 // SPDX-License-Identifier: MIT
 //
 
+use std::collections::{BTreeMap, BTreeSet};
 use std::net::Ipv4Addr;
 use std::sync::Arc;
 
@@ -71,6 +72,13 @@ pub struct InstanceState {
     pub decision_process_task: Option<TimeoutTask>,
     // BGP RIB.
     pub rib: Rib,
+    // Interface addresses learned from the interface provider.
+    pub interfaces: BTreeMap<String, InterfaceState>,
+}
+
+#[derive(Debug, Default)]
+pub struct InterfaceState {
+    pub addrs: BTreeSet<ipnetwork::IpNetwork>,
 }
 
 #[derive(Debug)]
@@ -375,6 +383,7 @@ impl InstanceState {
             policy_apply_tasks,
             decision_process_task: None,
             rib: Default::default(),
+            interfaces: Default::default(),
         })
     }
 
@@ -447,6 +456,22 @@ fn process_ibus_msg(
     }
 
     match msg {
+        IbusMsg::BfdStateUpd { sess_key, state } => {
+            // BFD peer state update notification.
+            ibus::rx::process_bfd_state_update(instance, sess_key, state);
+        }
+        IbusMsg::InterfaceUpd(msg) => {
+            // Interface update notification.
+            ibus::rx::process_iface_update(instance, msg);
+        }
+        IbusMsg::InterfaceAddressAdd(msg) => {
+            // Interface address addition notification.
+            ibus::rx::process_addr_add(instance, msg);
+        }
+        IbusMsg::InterfaceAddressDel(msg) => {
+            // Interface address deletion notification.
+            ibus::rx::process_addr_del(instance, msg);
+        }
         IbusMsg::NexthopUpd { addr, metric } => {
             // Nexthop tracking update notification.
             ibus::rx::process_nht_update(instance, addr, metric);

--- a/holo-bgp/src/neighbor.rs
+++ b/holo-bgp/src/neighbor.rs
@@ -636,17 +636,14 @@ impl Neighbor {
 
     // Registers, updates, or unregisters the BFD session for this neighbor.
     pub(crate) fn bfd_update_session(&mut self, instance: &InstanceUpView<'_>) {
-        let Some(sess_key) =
-            self.bfd_session_key(&instance.state.interfaces)
+        let Some(sess_key) = self.bfd_session_key(&instance.state.interfaces)
         else {
             self.bfd_clear_session(instance);
             return;
         };
 
-        let needs_register = self
-            .bfd
-            .as_ref()
-            .is_none_or(|bfd| bfd.sess_key != sess_key);
+        let needs_register =
+            self.bfd.as_ref().is_none_or(|bfd| bfd.sess_key != sess_key);
         if !needs_register {
             return;
         }
@@ -682,11 +679,15 @@ impl Neighbor {
 
         match state {
             bfd::State::Down if self.state != fsm::State::Idle => {
-                let msg =
-                    NotificationMsg::new(ErrorCode::Cease, CeaseSubcode::BfdDown);
+                let msg = NotificationMsg::new(
+                    ErrorCode::Cease,
+                    CeaseSubcode::BfdDown,
+                );
                 self.fsm_event(instance, fsm::Event::Stop(Some(msg)));
             }
-            bfd::State::Up if self.config.enabled && self.state == fsm::State::Idle => {
+            bfd::State::Up
+                if self.config.enabled && self.state == fsm::State::Idle =>
+            {
                 self.fsm_event(instance, fsm::Event::Start);
             }
             _ => {}
@@ -737,14 +738,17 @@ impl Neighbor {
             && !self.config.transport.ebgp_multihop_enabled
         {
             let ifname = self.bfd_single_hop_ifname(interfaces)?;
-            return Some(bfd::SessionKey::new_ip_single_hop(ifname, self.remote_addr));
+            return Some(bfd::SessionKey::new_ip_single_hop(
+                ifname,
+                self.remote_addr,
+            ));
         }
 
-        let src = self
-            .config
-            .transport
-            .local_addr
-            .or_else(|| self.conn_info.as_ref().map(|conn_info| conn_info.local_addr))?;
+        let src = self.config.transport.local_addr.or_else(|| {
+            self.conn_info
+                .as_ref()
+                .map(|conn_info| conn_info.local_addr)
+        })?;
         Some(bfd::SessionKey::new_ip_multihop(src, self.remote_addr))
     }
 
@@ -756,15 +760,20 @@ impl Neighbor {
         interfaces
             .iter()
             .find(|(_, iface)| {
-                iface.addrs.iter().any(|addr| match (addr, self.remote_addr) {
-                    (ipnetwork::IpNetwork::V4(prefix), IpAddr::V4(addr)) => {
-                        prefix.contains(addr)
-                    }
-                    (ipnetwork::IpNetwork::V6(prefix), IpAddr::V6(addr)) => {
-                        prefix.contains(addr)
-                    }
-                    _ => false,
-                })
+                iface
+                    .addrs
+                    .iter()
+                    .any(|addr| match (addr, self.remote_addr) {
+                        (
+                            ipnetwork::IpNetwork::V4(prefix),
+                            IpAddr::V4(addr),
+                        ) => prefix.contains(addr),
+                        (
+                            ipnetwork::IpNetwork::V6(prefix),
+                            IpAddr::V6(addr),
+                        ) => prefix.contains(addr),
+                        _ => false,
+                    })
             })
             .map(|(ifname, _)| ifname.clone())
     }
@@ -1332,16 +1341,16 @@ where
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use ipnetwork::Ipv4Network;
+
+    use super::*;
 
     fn interfaces() -> BTreeMap<String, InterfaceState> {
         BTreeMap::from([(
             "eth0".to_owned(),
             InterfaceState {
                 addrs: BTreeSet::from([ipnetwork::IpNetwork::V4(
-                    Ipv4Network::new(Ipv4Addr::new(192, 0, 2, 1), 24)
-                        .unwrap(),
+                    Ipv4Network::new(Ipv4Addr::new(192, 0, 2, 1), 24).unwrap(),
                 )]),
             },
         )])
@@ -1372,7 +1381,8 @@ mod tests {
         let mut nbr =
             bfd_neighbor(Ipv4Addr::new(198, 51, 100, 2), PeerType::External);
         nbr.config.transport.ebgp_multihop_enabled = true;
-        nbr.config.transport.local_addr = Some(Ipv4Addr::new(192, 0, 2, 1).into());
+        nbr.config.transport.local_addr =
+            Some(Ipv4Addr::new(192, 0, 2, 1).into());
 
         assert_eq!(
             nbr.bfd_session_key(&interfaces()),
@@ -1385,7 +1395,8 @@ mod tests {
 
     #[test]
     fn bfd_ibgp_waits_until_source_address_is_known() {
-        let nbr = bfd_neighbor(Ipv4Addr::new(198, 51, 100, 2), PeerType::Internal);
+        let nbr =
+            bfd_neighbor(Ipv4Addr::new(198, 51, 100, 2), PeerType::Internal);
 
         assert_eq!(nbr.bfd_session_key(&interfaces()), None);
     }

--- a/holo-bgp/src/neighbor.rs
+++ b/holo-bgp/src/neighbor.rs
@@ -13,8 +13,10 @@ use std::time::Duration;
 use arbitrary::Arbitrary;
 use chrono::{DateTime, Utc};
 use holo_protocol::InstanceChannelsTx;
+use holo_utils::bfd;
 use holo_utils::bgp::{AfiSafi, RouteType, WellKnownCommunities};
 use holo_utils::ibus::IbusChannelsTx;
+use holo_utils::protocol::Protocol;
 use holo_utils::socket::{TTL_MAX, TcpConnInfo, TcpStream};
 use holo_utils::task::{IntervalTask, Task, TimeoutTask};
 use num_traits::{FromPrimitive, ToPrimitive};
@@ -24,7 +26,7 @@ use tokio::sync::mpsc::{Sender, UnboundedSender};
 use crate::af::{AddressFamily, Ipv4Unicast, Ipv6Unicast};
 use crate::debug::Debug;
 use crate::error::Error;
-use crate::instance::{Instance, InstanceUpView};
+use crate::instance::{Instance, InstanceUpView, InterfaceState};
 use crate::northbound::configuration::{InstanceCfg, NeighborCfg};
 use crate::northbound::notification;
 use crate::northbound::rpc::ClearType;
@@ -67,6 +69,7 @@ pub struct Neighbor {
     pub tasks: NeighborTasks,
     pub update_queues: NeighborUpdateQueues,
     pub msg_txp: Option<UnboundedSender<NbrTxMsg>>,
+    pub bfd: Option<NeighborBfd>,
 }
 
 // BGP peer type.
@@ -106,6 +109,12 @@ pub struct NeighborTasks {
     pub tcp_rx: Option<Task<()>>,
     pub keepalive: Option<IntervalTask>,
     pub holdtime: Option<TimeoutTask>,
+}
+
+#[derive(Debug)]
+pub struct NeighborBfd {
+    pub sess_key: bfd::SessionKey,
+    pub state: Option<bfd::State>,
 }
 
 // Neighbor Tx update queues.
@@ -214,6 +223,7 @@ impl Neighbor {
             tasks: Default::default(),
             update_queues: Default::default(),
             msg_txp: None,
+            bfd: None,
         }
     }
 
@@ -234,6 +244,9 @@ impl Neighbor {
             fsm::State::Idle => match event {
                 fsm::Event::Start
                 | fsm::Event::Timer(fsm::Timer::AutoStart) => {
+                    if self.is_bfd_down() {
+                        return;
+                    }
                     self.connect_retry_start(
                         &instance.tx.protocol_input.nbr_timer,
                     );
@@ -520,6 +533,7 @@ impl Neighbor {
     ) {
         // Store TCP connection information.
         self.conn_info = Some(conn_info);
+        self.bfd_update_session(instance);
 
         // Split TCP stream into two halves.
         let (read_half, write_half) = stream.into_split();
@@ -618,6 +632,141 @@ impl Neighbor {
 
         // Trigger the BGP Decision Process.
         instance_tx.protocol_input.trigger_decision_process();
+    }
+
+    // Registers, updates, or unregisters the BFD session for this neighbor.
+    pub(crate) fn bfd_update_session(&mut self, instance: &InstanceUpView<'_>) {
+        let Some(sess_key) =
+            self.bfd_session_key(&instance.state.interfaces)
+        else {
+            self.bfd_clear_session(instance);
+            return;
+        };
+
+        let needs_register = self
+            .bfd
+            .as_ref()
+            .is_none_or(|bfd| bfd.sess_key != sess_key);
+        if !needs_register {
+            return;
+        }
+
+        self.bfd_clear_session(instance);
+        self.bfd_register(sess_key.clone(), instance);
+        self.bfd = Some(NeighborBfd {
+            sess_key,
+            state: None,
+        });
+    }
+
+    // Unregisters and removes the BFD session associated with this neighbor.
+    pub(crate) fn bfd_clear_session(&mut self, instance: &InstanceUpView<'_>) {
+        if let Some(bfd) = self.bfd.take() {
+            self.bfd_unregister(bfd.sess_key, instance);
+        }
+    }
+
+    // Updates the BFD state for this neighbor and resets BGP on BFD down.
+    pub(crate) fn bfd_state_update(
+        &mut self,
+        instance: &mut InstanceUpView<'_>,
+        state: bfd::State,
+    ) {
+        let Some(bfd) = self.bfd.as_mut() else {
+            return;
+        };
+        if bfd.state == Some(state) {
+            return;
+        }
+        bfd.state = Some(state);
+
+        match state {
+            bfd::State::Down if self.state != fsm::State::Idle => {
+                let msg =
+                    NotificationMsg::new(ErrorCode::Cease, CeaseSubcode::BfdDown);
+                self.fsm_event(instance, fsm::Event::Stop(Some(msg)));
+            }
+            bfd::State::Up if self.config.enabled && self.state == fsm::State::Idle => {
+                self.fsm_event(instance, fsm::Event::Start);
+            }
+            _ => {}
+        }
+    }
+
+    // Returns whether this neighbor is blocked by a BFD Down state.
+    pub(crate) fn is_bfd_down(&self) -> bool {
+        self.bfd
+            .as_ref()
+            .is_some_and(|bfd| bfd.state == Some(bfd::State::Down))
+    }
+
+    // Registers a BFD session for this neighbor with the provider.
+    fn bfd_register(
+        &self,
+        sess_key: bfd::SessionKey,
+        instance: &InstanceUpView<'_>,
+    ) {
+        let client_id =
+            bfd::ClientId::new(Protocol::BGP, instance.name.to_owned());
+        instance.tx.ibus.bfd_session_reg(
+            sess_key,
+            client_id,
+            Some(self.config.bfd.params),
+        );
+    }
+
+    // Unregisters the BFD session associated with the given session key.
+    fn bfd_unregister(
+        &self,
+        sess_key: bfd::SessionKey,
+        instance: &InstanceUpView<'_>,
+    ) {
+        instance.tx.ibus.bfd_session_unreg(sess_key);
+    }
+
+    // Builds the BFD session key matching the BGP transport.
+    pub(crate) fn bfd_session_key(
+        &self,
+        interfaces: &BTreeMap<String, InterfaceState>,
+    ) -> Option<bfd::SessionKey> {
+        if !self.config.enabled || !self.config.bfd.enabled {
+            return None;
+        }
+
+        if self.peer_type == PeerType::External
+            && !self.config.transport.ebgp_multihop_enabled
+        {
+            let ifname = self.bfd_single_hop_ifname(interfaces)?;
+            return Some(bfd::SessionKey::new_ip_single_hop(ifname, self.remote_addr));
+        }
+
+        let src = self
+            .config
+            .transport
+            .local_addr
+            .or_else(|| self.conn_info.as_ref().map(|conn_info| conn_info.local_addr))?;
+        Some(bfd::SessionKey::new_ip_multihop(src, self.remote_addr))
+    }
+
+    // Returns the directly connected interface for a single-hop BFD peer.
+    fn bfd_single_hop_ifname(
+        &self,
+        interfaces: &BTreeMap<String, InterfaceState>,
+    ) -> Option<String> {
+        interfaces
+            .iter()
+            .find(|(_, iface)| {
+                iface.addrs.iter().any(|addr| match (addr, self.remote_addr) {
+                    (ipnetwork::IpNetwork::V4(prefix), IpAddr::V4(addr)) => {
+                        prefix.contains(addr)
+                    }
+                    (ipnetwork::IpNetwork::V6(prefix), IpAddr::V6(addr)) => {
+                        prefix.contains(addr)
+                    }
+                    _ => false,
+                })
+            })
+            .map(|(ifname, _)| ifname.clone())
     }
 
     // Enqueues a single BGP message for transmission.
@@ -1178,5 +1327,66 @@ where
             reach: Default::default(),
             unreach: Default::default(),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ipnetwork::Ipv4Network;
+
+    fn interfaces() -> BTreeMap<String, InterfaceState> {
+        BTreeMap::from([(
+            "eth0".to_owned(),
+            InterfaceState {
+                addrs: BTreeSet::from([ipnetwork::IpNetwork::V4(
+                    Ipv4Network::new(Ipv4Addr::new(192, 0, 2, 1), 24)
+                        .unwrap(),
+                )]),
+            },
+        )])
+    }
+
+    fn bfd_neighbor(remote_addr: Ipv4Addr, peer_type: PeerType) -> Neighbor {
+        let mut nbr = Neighbor::new(remote_addr.into(), peer_type);
+        nbr.config.enabled = true;
+        nbr.config.bfd.enabled = true;
+        nbr
+    }
+
+    #[test]
+    fn bfd_direct_ebgp_uses_single_hop_session() {
+        let nbr = bfd_neighbor(Ipv4Addr::new(192, 0, 2, 2), PeerType::External);
+
+        assert_eq!(
+            nbr.bfd_session_key(&interfaces()),
+            Some(bfd::SessionKey::IpSingleHop {
+                ifname: "eth0".to_owned(),
+                dst: IpAddr::V4(Ipv4Addr::new(192, 0, 2, 2)),
+            })
+        );
+    }
+
+    #[test]
+    fn bfd_ebgp_multihop_uses_multihop_session() {
+        let mut nbr =
+            bfd_neighbor(Ipv4Addr::new(198, 51, 100, 2), PeerType::External);
+        nbr.config.transport.ebgp_multihop_enabled = true;
+        nbr.config.transport.local_addr = Some(Ipv4Addr::new(192, 0, 2, 1).into());
+
+        assert_eq!(
+            nbr.bfd_session_key(&interfaces()),
+            Some(bfd::SessionKey::IpMultihop {
+                src: IpAddr::V4(Ipv4Addr::new(192, 0, 2, 1)),
+                dst: IpAddr::V4(Ipv4Addr::new(198, 51, 100, 2)),
+            })
+        );
+    }
+
+    #[test]
+    fn bfd_ibgp_waits_until_source_address_is_known() {
+        let nbr = bfd_neighbor(Ipv4Addr::new(198, 51, 100, 2), PeerType::Internal);
+
+        assert_eq!(nbr.bfd_session_key(&interfaces()), None);
     }
 }

--- a/holo-bgp/src/northbound/configuration.rs
+++ b/holo-bgp/src/northbound/configuration.rs
@@ -24,12 +24,11 @@ use holo_yang::TryFromYang;
 use crate::af::{Ipv4Unicast, Ipv6Unicast};
 use crate::instance::{Instance, InstanceUpView};
 use crate::neighbor::{Neighbor, PeerType, fsm};
-use crate::network;
 use crate::northbound::yang_gen::bgp;
 use crate::packet::iana::{CeaseSubcode, ErrorCode};
 use crate::packet::message::{Message, NotificationMsg};
 use crate::rib::RouteOrigin;
-use crate::ibus;
+use crate::{ibus, network};
 
 #[derive(Debug, Default, EnumAsInner)]
 pub enum ListEntry {

--- a/holo-bgp/src/northbound/configuration.rs
+++ b/holo-bgp/src/northbound/configuration.rs
@@ -13,6 +13,7 @@ use std::sync::{Arc, LazyLock as Lazy};
 use arc_swap::ArcSwap;
 use enum_as_inner::EnumAsInner;
 use holo_northbound::configuration::{Callbacks, CallbacksBuilder, Provider, ValidationCallbacks, ValidationCallbacksBuilder};
+use holo_utils::bfd;
 use holo_utils::bgp::AfiSafi;
 use holo_utils::ip::{AddressFamily, IpAddrKind};
 use holo_utils::policy::{ApplyPolicyCfg, DefaultPolicyType};
@@ -28,6 +29,7 @@ use crate::northbound::yang_gen::bgp;
 use crate::packet::iana::{CeaseSubcode, ErrorCode};
 use crate::packet::message::{Message, NotificationMsg};
 use crate::rib::RouteOrigin;
+use crate::ibus;
 
 #[derive(Debug, Default, EnumAsInner)]
 pub enum ListEntry {
@@ -48,6 +50,7 @@ pub enum Resource {}
 pub enum Event {
     InstanceUpdate,
     NeighborUpdate(IpAddr),
+    NeighborBfdUpdate(IpAddr),
     NeighborDelete(IpAddr),
     NeighborReset(IpAddr, NotificationMsg),
     NeighborUpdateAuth(IpAddr),
@@ -130,12 +133,19 @@ pub struct NeighborCfg {
     pub private_as_remove: Option<PrivateAsRemove>,
     pub timers: NeighborTimersCfg,
     pub transport: NeighborTransportCfg,
+    pub bfd: NeighborBfdCfg,
     pub log_neighbor_state_changes: bool,
     pub as_path_options: AsPathOptions,
     pub apply_policy: ApplyPolicyCfg,
     pub prefix_limit: PrefixLimitCfg,
     pub afi_safi: BTreeMap<AfiSafi, NeighborAfiSafiCfg>,
     pub trace_opts: NeighborTraceOptions,
+}
+
+#[derive(Debug)]
+pub struct NeighborBfdCfg {
+    pub enabled: bool,
+    pub params: bfd::ClientCfg,
 }
 
 #[derive(Debug)]
@@ -1043,6 +1053,17 @@ fn load_callbacks() -> Callbacks<Instance> {
             event_queue.insert(Event::NeighborReset(nbr.remote_addr, msg));
             event_queue.insert(Event::NeighborUpdateAuth(nbr.remote_addr));
         })
+        .path(bgp::neighbors::neighbor::transport::bfd::enabled::PATH)
+        .modify_apply(|instance, args| {
+            let nbr_addr = args.list_entry.into_neighbor().unwrap();
+            let nbr = instance.neighbors.get_mut(&nbr_addr).unwrap();
+
+            let enabled = args.dnode.get_bool();
+            nbr.config.bfd.enabled = enabled;
+
+            let event_queue = args.event_queue;
+            event_queue.insert(Event::NeighborBfdUpdate(nbr.remote_addr));
+        })
         .path(bgp::neighbors::neighbor::logging_options::log_neighbor_state_changes::PATH)
         .modify_apply(|instance, args| {
             let nbr_addr = args.list_entry.into_neighbor().unwrap();
@@ -1521,13 +1542,31 @@ impl Provider for Instance {
                 };
                 let nbr = neighbors.get_mut(&nbr_addr).unwrap();
 
-                if nbr.config.enabled {
+                nbr.bfd_update_session(&instance);
+
+                if nbr.config.enabled && !nbr.is_bfd_down() {
                     nbr.fsm_event(&mut instance, fsm::Event::Start);
                 } else {
                     let error_code = ErrorCode::Cease;
                     let error_subcode = CeaseSubcode::AdministrativeShutdown;
                     let msg = NotificationMsg::new(error_code, error_subcode);
                     nbr.fsm_event(&mut instance, fsm::Event::Stop(Some(msg)));
+                }
+            }
+            Event::NeighborBfdUpdate(nbr_addr) => {
+                let Some((mut instance, neighbors)) = self.as_up() else {
+                    return;
+                };
+                let nbr = neighbors.get_mut(&nbr_addr).unwrap();
+
+                if nbr.config.bfd.enabled {
+                    ibus::tx::interface_sub(&instance.tx.ibus);
+                    nbr.bfd_update_session(&instance);
+                } else {
+                    nbr.bfd_clear_session(&instance);
+                    if nbr.config.enabled {
+                        nbr.fsm_event(&mut instance, fsm::Event::Start);
+                    }
                 }
             }
             Event::NeighborDelete(nbr_addr) => {
@@ -1545,6 +1584,7 @@ impl Provider for Instance {
                 let error_code = ErrorCode::Cease;
                 let error_subcode = CeaseSubcode::PeerDeConfigured;
                 let msg = NotificationMsg::new(error_code, error_subcode);
+                nbr.bfd_clear_session(&instance);
                 nbr.fsm_event(&mut instance, fsm::Event::Stop(Some(msg)));
                 neighbors.remove(&nbr_addr);
             }
@@ -1777,6 +1817,7 @@ impl Default for NeighborCfg {
             private_as_remove: None,
             timers: Default::default(),
             transport: Default::default(),
+            bfd: Default::default(),
             log_neighbor_state_changes,
             as_path_options: Default::default(),
             apply_policy: Default::default(),
@@ -1817,6 +1858,17 @@ impl Default for NeighborTransportCfg {
             ttl_security: None,
             secure_session_enabled,
             md5_key: None,
+        }
+    }
+}
+
+impl Default for NeighborBfdCfg {
+    fn default() -> NeighborBfdCfg {
+        let enabled = bgp::neighbors::neighbor::transport::bfd::enabled::DFLT;
+
+        NeighborBfdCfg {
+            enabled,
+            params: Default::default(),
         }
     }
 }

--- a/holo-bgp/src/northbound/notification.rs
+++ b/holo-bgp/src/northbound/notification.rs
@@ -5,6 +5,7 @@
 //
 
 use holo_northbound::{YangObject, notification};
+use holo_utils::option::OptionExt;
 use holo_utils::protocol::Protocol;
 use holo_yang::ToYang;
 
@@ -34,13 +35,13 @@ pub(crate) fn backward_transition(instance: &InstanceUpView<'_>, nbr: &Neighbor)
     let data = BackwardTransition {
         remote_addr: Some(nbr.remote_addr),
         notification_received: nbr.notification_rcvd.as_ref().map(|(time, notif)| NotificationReceived {
-            last_notification: Some(*time),
+            last_notification: Some(*time).ignore_in_testing(),
             last_error: Some(notif.to_yang()),
             last_error_code: Some(notif.error_code),
             last_error_subcode: Some(notif.error_subcode),
         }),
         notification_sent: nbr.notification_sent.as_ref().map(|(time, notif)| NotificationSent {
-            last_notification: Some(*time),
+            last_notification: Some(*time).ignore_in_testing(),
             last_error: Some(notif.to_yang()),
             last_error_code: Some(notif.error_code),
             last_error_subcode: Some(notif.error_subcode),

--- a/holo-bgp/src/northbound/state.rs
+++ b/holo-bgp/src/northbound/state.rs
@@ -318,7 +318,7 @@ impl<'a> YangContainer<'a, Instance> for bgp::neighbors::neighbor::errors::recei
     fn new(_instance: &'a Instance, nbr: &Self::ParentListEntry) -> Option<Self> {
         let (time, notif) = nbr.notification_rcvd.as_ref()?;
         Some(Self {
-            last_notification: Some(*time),
+            last_notification: Some(*time).ignore_in_testing(),
             last_error: Some(notif.to_yang()),
             last_error_code: Some(notif.error_code),
             last_error_subcode: Some(notif.error_subcode),
@@ -333,7 +333,7 @@ impl<'a> YangContainer<'a, Instance> for bgp::neighbors::neighbor::errors::sent:
     fn new(_instance: &'a Instance, nbr: &Self::ParentListEntry) -> Option<Self> {
         let (time, notif) = nbr.notification_sent.as_ref()?;
         Some(Self {
-            last_notification: Some(*time),
+            last_notification: Some(*time).ignore_in_testing(),
             last_error: Some(notif.to_yang()),
             last_error_code: Some(notif.error_code),
             last_error_subcode: Some(notif.error_subcode),

--- a/holo-bgp/tests/conformance/bfd-bgp-1/01-input-northbound-config-change.json
+++ b/holo-bgp/tests/conformance/bfd-bgp-1/01-input-northbound-config-change.json
@@ -1,0 +1,34 @@
+{
+  "ietf-routing:routing": {
+    "@": {
+      "yang:operation": "none"
+    },
+    "control-plane-protocols": {
+      "control-plane-protocol": [
+        {
+          "type": "ietf-bgp:bgp",
+          "name": "test",
+          "ietf-bgp:bgp": {
+            "neighbors": {
+              "neighbor": [
+                {
+                  "remote-address": "10.0.1.2",
+                  "transport": {
+                    "bfd": {
+                      "enabled": true,
+                      "@enabled": {
+                        "yang:operation": "replace",
+                        "yang:orig-default": true,
+                        "yang:orig-value": "false"
+                      }
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        }
+      ]
+    }
+  }
+}

--- a/holo-bgp/tests/conformance/bfd-bgp-1/01-output-ibus.jsonl
+++ b/holo-bgp/tests/conformance/bfd-bgp-1/01-output-ibus.jsonl
@@ -1,0 +1,1 @@
+{"InterfaceSub":{"ifname":null,"af":null}}

--- a/holo-bgp/tests/conformance/bfd-bgp-1/02-input-ibus.jsonl
+++ b/holo-bgp/tests/conformance/bfd-bgp-1/02-input-ibus.jsonl
@@ -1,0 +1,2 @@
+{"InterfaceUpd":{"ifname":"eth-rt2","ifindex":3,"mtu":1500,"flags":"OPERATIVE"}}
+{"InterfaceAddressAdd":{"ifname":"eth-rt2","addr":"10.0.1.1/24","flags":""}}

--- a/holo-bgp/tests/conformance/bfd-bgp-1/02-output-ibus.jsonl
+++ b/holo-bgp/tests/conformance/bfd-bgp-1/02-output-ibus.jsonl
@@ -1,0 +1,1 @@
+{"BfdSessionReg":{"sess_key":{"IpSingleHop":{"ifname":"eth-rt2","dst":"10.0.1.2"}},"client_id":{"protocol":"bgp","name":"test"},"client_config":{"local_multiplier":3,"min_tx":1000000,"min_rx":1000000}}}

--- a/holo-bgp/tests/conformance/bfd-bgp-1/03-input-ibus.jsonl
+++ b/holo-bgp/tests/conformance/bfd-bgp-1/03-input-ibus.jsonl
@@ -1,0 +1,1 @@
+{"BfdStateUpd":{"sess_key":{"IpSingleHop":{"ifname":"eth-rt2","dst":"10.0.1.2"}},"state":"Down"}}

--- a/holo-bgp/tests/conformance/bfd-bgp-1/03-output-ibus.jsonl
+++ b/holo-bgp/tests/conformance/bfd-bgp-1/03-output-ibus.jsonl
@@ -1,0 +1,3 @@
+{"NexthopUntrack":{"addr":"10.0.1.2"}}
+{"RouteIpDel":{"protocol":"bgp","prefix":"2.2.2.2/32"}}
+{"RouteIpAdd":{"protocol":"bgp","prefix":"3.3.3.3/32","distance":20,"metric":0,"tag":null,"nexthops":[{"Recursive":{"addr":"10.0.2.4","labels":[],"resolved":[]}},{"Recursive":{"addr":"10.0.3.5","labels":[],"resolved":[]}}]}}

--- a/holo-bgp/tests/conformance/bfd-bgp-1/03-output-northbound-notif.jsonl
+++ b/holo-bgp/tests/conformance/bfd-bgp-1/03-output-northbound-notif.jsonl
@@ -1,0 +1,1 @@
+{"ietf-routing:routing":{"control-plane-protocols":{"control-plane-protocol":[{"type":"ietf-bgp:bgp","name":"test","ietf-bgp:bgp":{"neighbors":{"backward-transition":{"remote-addr":"10.0.1.2","notification-sent":{"last-error":"iana-bgp-notification:cease-bfd-down","last-error-code":6,"last-error-subcode":10}}}}}]}}}

--- a/holo-bgp/tests/conformance/bfd-bgp-1/03-output-northbound-state.json
+++ b/holo-bgp/tests/conformance/bfd-bgp-1/03-output-northbound-state.json
@@ -1,0 +1,619 @@
+{
+  "ietf-routing:routing": {
+    "control-plane-protocols": {
+      "control-plane-protocol": [
+        {
+          "type": "ietf-bgp:bgp",
+          "name": "test",
+          "ietf-bgp:bgp": {
+            "global": {
+              "afi-safis": {
+                "afi-safi": [
+                  {
+                    "name": "iana-bgp-types:ipv4-unicast",
+                    "statistics": {
+                      "total-prefixes": 5
+                    }
+                  }
+                ]
+              },
+              "statistics": {
+                "total-prefixes": 5
+              }
+            },
+            "neighbors": {
+              "neighbor": [
+                {
+                  "remote-address": "10.0.1.2",
+                  "peer-type": "external",
+                  "afi-safis": {
+                    "afi-safi": [
+                      {
+                        "name": "iana-bgp-types:ipv4-unicast",
+                        "prefixes": {
+                          "received": 0,
+                          "sent": 0,
+                          "installed": 0
+                        }
+                      }
+                    ]
+                  },
+                  "session-state": "idle",
+                  "errors": {
+                    "sent": {
+                      "last-error": "iana-bgp-notification:cease-bfd-down",
+                      "last-error-code": 6,
+                      "last-error-subcode": 10,
+                      "last-error-data": ""
+                    }
+                  }
+                },
+                {
+                  "remote-address": "10.0.2.4",
+                  "local-address": "10.0.2.1",
+                  "peer-type": "external",
+                  "identifier": "4.4.4.4",
+                  "timers": {
+                    "negotiated-hold-time": 90
+                  },
+                  "afi-safis": {
+                    "afi-safi": [
+                      {
+                        "name": "iana-bgp-types:ipv4-unicast",
+                        "prefixes": {
+                          "received": 3,
+                          "sent": 2,
+                          "installed": 3
+                        }
+                      }
+                    ]
+                  },
+                  "session-state": "established",
+                  "capabilities": {
+                    "advertised-capabilities": [
+                      {
+                        "code": 1,
+                        "index": 0,
+                        "name": "iana-bgp-types:mp-bgp",
+                        "value": {
+                          "mpbgp": {
+                            "afi": "ipv4",
+                            "safi": "unicast-safi",
+                            "name": "iana-bgp-types:ipv4-unicast"
+                          }
+                        }
+                      },
+                      {
+                        "code": 65,
+                        "index": 1,
+                        "name": "iana-bgp-types:asn32",
+                        "value": {
+                          "asn32": {
+                            "as": 65001
+                          }
+                        }
+                      },
+                      {
+                        "code": 2,
+                        "index": 2,
+                        "name": "iana-bgp-types:route-refresh"
+                      }
+                    ],
+                    "received-capabilities": [
+                      {
+                        "code": 1,
+                        "index": 0,
+                        "name": "iana-bgp-types:mp-bgp",
+                        "value": {
+                          "mpbgp": {
+                            "afi": "ipv4",
+                            "safi": "unicast-safi",
+                            "name": "iana-bgp-types:ipv4-unicast"
+                          }
+                        }
+                      },
+                      {
+                        "code": 65,
+                        "index": 1,
+                        "name": "iana-bgp-types:asn32",
+                        "value": {
+                          "asn32": {
+                            "as": 65004
+                          }
+                        }
+                      },
+                      {
+                        "code": 2,
+                        "index": 2,
+                        "name": "iana-bgp-types:route-refresh"
+                      }
+                    ],
+                    "negotiated-capabilities": [
+                      "iana-bgp-types:mp-bgp",
+                      "iana-bgp-types:asn32",
+                      "iana-bgp-types:route-refresh"
+                    ]
+                  }
+                },
+                {
+                  "remote-address": "10.0.3.5",
+                  "local-address": "10.0.3.1",
+                  "peer-type": "external",
+                  "identifier": "5.5.5.5",
+                  "timers": {
+                    "negotiated-hold-time": 90
+                  },
+                  "afi-safis": {
+                    "afi-safi": [
+                      {
+                        "name": "iana-bgp-types:ipv4-unicast",
+                        "prefixes": {
+                          "received": 3,
+                          "sent": 4,
+                          "installed": 3
+                        }
+                      }
+                    ]
+                  },
+                  "session-state": "established",
+                  "capabilities": {
+                    "advertised-capabilities": [
+                      {
+                        "code": 1,
+                        "index": 0,
+                        "name": "iana-bgp-types:mp-bgp",
+                        "value": {
+                          "mpbgp": {
+                            "afi": "ipv4",
+                            "safi": "unicast-safi",
+                            "name": "iana-bgp-types:ipv4-unicast"
+                          }
+                        }
+                      },
+                      {
+                        "code": 65,
+                        "index": 1,
+                        "name": "iana-bgp-types:asn32",
+                        "value": {
+                          "asn32": {
+                            "as": 65001
+                          }
+                        }
+                      },
+                      {
+                        "code": 2,
+                        "index": 2,
+                        "name": "iana-bgp-types:route-refresh"
+                      }
+                    ],
+                    "received-capabilities": [
+                      {
+                        "code": 1,
+                        "index": 0,
+                        "name": "iana-bgp-types:mp-bgp",
+                        "value": {
+                          "mpbgp": {
+                            "afi": "ipv4",
+                            "safi": "unicast-safi",
+                            "name": "iana-bgp-types:ipv4-unicast"
+                          }
+                        }
+                      },
+                      {
+                        "code": 65,
+                        "index": 1,
+                        "name": "iana-bgp-types:asn32",
+                        "value": {
+                          "asn32": {
+                            "as": 65005
+                          }
+                        }
+                      },
+                      {
+                        "code": 2,
+                        "index": 2,
+                        "name": "iana-bgp-types:route-refresh"
+                      }
+                    ],
+                    "negotiated-capabilities": [
+                      "iana-bgp-types:mp-bgp",
+                      "iana-bgp-types:asn32",
+                      "iana-bgp-types:route-refresh"
+                    ]
+                  }
+                }
+              ]
+            },
+            "rib": {
+              "attr-sets": {
+                "attr-set": [
+                  {
+                    "index": "9414355416643581871",
+                    "attributes": {
+                      "origin": "incomplete"
+                    }
+                  },
+                  {
+                    "index": "5246163599190634569",
+                    "attributes": {
+                      "origin": "incomplete",
+                      "as-path": {
+                        "segment": [
+                          {
+                            "type": "iana-bgp-types:as-sequence",
+                            "member": [
+                              65002,
+                              65003
+                            ]
+                          }
+                        ]
+                      },
+                      "next-hop": "10.0.1.2"
+                    }
+                  },
+                  {
+                    "index": "5498876665348766646",
+                    "attributes": {
+                      "origin": "incomplete",
+                      "as-path": {
+                        "segment": [
+                          {
+                            "type": "iana-bgp-types:as-sequence",
+                            "member": [
+                              65004
+                            ]
+                          }
+                        ]
+                      },
+                      "next-hop": "10.0.2.4"
+                    }
+                  },
+                  {
+                    "index": "2211548866643936648",
+                    "attributes": {
+                      "origin": "incomplete",
+                      "as-path": {
+                        "segment": [
+                          {
+                            "type": "iana-bgp-types:as-sequence",
+                            "member": [
+                              65004,
+                              65006
+                            ]
+                          }
+                        ]
+                      },
+                      "next-hop": "10.0.2.4"
+                    }
+                  },
+                  {
+                    "index": "12590424143591910245",
+                    "attributes": {
+                      "origin": "incomplete",
+                      "as-path": {
+                        "segment": [
+                          {
+                            "type": "iana-bgp-types:as-sequence",
+                            "member": [
+                              65004,
+                              65006,
+                              65003
+                            ]
+                          }
+                        ]
+                      },
+                      "next-hop": "10.0.2.4"
+                    }
+                  },
+                  {
+                    "index": "11002054795911351509",
+                    "attributes": {
+                      "origin": "incomplete",
+                      "as-path": {
+                        "segment": [
+                          {
+                            "type": "iana-bgp-types:as-sequence",
+                            "member": [
+                              65005
+                            ]
+                          }
+                        ]
+                      },
+                      "next-hop": "10.0.3.5"
+                    }
+                  },
+                  {
+                    "index": "4767695059371701948",
+                    "attributes": {
+                      "origin": "incomplete",
+                      "as-path": {
+                        "segment": [
+                          {
+                            "type": "iana-bgp-types:as-sequence",
+                            "member": [
+                              65005,
+                              65006
+                            ]
+                          }
+                        ]
+                      },
+                      "next-hop": "10.0.3.5"
+                    }
+                  },
+                  {
+                    "index": "10641704557835844179",
+                    "attributes": {
+                      "origin": "incomplete",
+                      "as-path": {
+                        "segment": [
+                          {
+                            "type": "iana-bgp-types:as-sequence",
+                            "member": [
+                              65005,
+                              65006,
+                              65003
+                            ]
+                          }
+                        ]
+                      },
+                      "next-hop": "10.0.3.5"
+                    }
+                  }
+                ]
+              },
+              "afi-safis": {
+                "afi-safi": [
+                  {
+                    "name": "iana-bgp-types:ipv4-unicast",
+                    "ipv4-unicast": {
+                      "loc-rib": {
+                        "routes": {
+                          "route": [
+                            {
+                              "prefix": "1.1.1.1/32",
+                              "origin": "ietf-routing:direct",
+                              "path-id": 0,
+                              "attr-index": "9414355416643581871"
+                            },
+                            {
+                              "prefix": "3.3.3.3/32",
+                              "origin": "10.0.2.4",
+                              "path-id": 0,
+                              "attr-index": "12590424143591910245"
+                            },
+                            {
+                              "prefix": "4.4.4.4/32",
+                              "origin": "10.0.2.4",
+                              "path-id": 0,
+                              "attr-index": "5498876665348766646"
+                            },
+                            {
+                              "prefix": "5.5.5.5/32",
+                              "origin": "10.0.3.5",
+                              "path-id": 0,
+                              "attr-index": "11002054795911351509"
+                            },
+                            {
+                              "prefix": "6.6.6.6/32",
+                              "origin": "10.0.2.4",
+                              "path-id": 0,
+                              "attr-index": "2211548866643936648"
+                            }
+                          ]
+                        }
+                      },
+                      "neighbors": {
+                        "neighbor": [
+                          {
+                            "neighbor-address": "10.0.2.4",
+                            "adj-rib-in-pre": {
+                              "routes": {
+                                "route": [
+                                  {
+                                    "prefix": "3.3.3.3/32",
+                                    "path-id": 0,
+                                    "attr-index": "12590424143591910245",
+                                    "eligible-route": true
+                                  },
+                                  {
+                                    "prefix": "4.4.4.4/32",
+                                    "path-id": 0,
+                                    "attr-index": "5498876665348766646",
+                                    "eligible-route": true
+                                  },
+                                  {
+                                    "prefix": "6.6.6.6/32",
+                                    "path-id": 0,
+                                    "attr-index": "2211548866643936648",
+                                    "eligible-route": true
+                                  }
+                                ]
+                              }
+                            },
+                            "adj-rib-in-post": {
+                              "routes": {
+                                "route": [
+                                  {
+                                    "prefix": "3.3.3.3/32",
+                                    "path-id": 0,
+                                    "attr-index": "12590424143591910245",
+                                    "eligible-route": true
+                                  },
+                                  {
+                                    "prefix": "4.4.4.4/32",
+                                    "path-id": 0,
+                                    "attr-index": "5498876665348766646",
+                                    "eligible-route": true
+                                  },
+                                  {
+                                    "prefix": "6.6.6.6/32",
+                                    "path-id": 0,
+                                    "attr-index": "2211548866643936648",
+                                    "eligible-route": true
+                                  }
+                                ]
+                              }
+                            },
+                            "adj-rib-out-pre": {
+                              "routes": {
+                                "route": [
+                                  {
+                                    "prefix": "1.1.1.1/32",
+                                    "path-id": 0,
+                                    "attr-index": "9414355416643581871",
+                                    "eligible-route": true
+                                  },
+                                  {
+                                    "prefix": "5.5.5.5/32",
+                                    "path-id": 0,
+                                    "attr-index": "11002054795911351509",
+                                    "eligible-route": true
+                                  }
+                                ]
+                              }
+                            },
+                            "adj-rib-out-post": {
+                              "routes": {
+                                "route": [
+                                  {
+                                    "prefix": "1.1.1.1/32",
+                                    "path-id": 0,
+                                    "attr-index": "9414355416643581871",
+                                    "eligible-route": true
+                                  },
+                                  {
+                                    "prefix": "5.5.5.5/32",
+                                    "path-id": 0,
+                                    "attr-index": "11002054795911351509",
+                                    "eligible-route": true
+                                  }
+                                ]
+                              }
+                            }
+                          },
+                          {
+                            "neighbor-address": "10.0.3.5",
+                            "adj-rib-in-pre": {
+                              "routes": {
+                                "route": [
+                                  {
+                                    "prefix": "3.3.3.3/32",
+                                    "path-id": 0,
+                                    "attr-index": "10641704557835844179",
+                                    "eligible-route": true
+                                  },
+                                  {
+                                    "prefix": "5.5.5.5/32",
+                                    "path-id": 0,
+                                    "attr-index": "11002054795911351509",
+                                    "eligible-route": true
+                                  },
+                                  {
+                                    "prefix": "6.6.6.6/32",
+                                    "path-id": 0,
+                                    "attr-index": "4767695059371701948",
+                                    "eligible-route": true
+                                  }
+                                ]
+                              }
+                            },
+                            "adj-rib-in-post": {
+                              "routes": {
+                                "route": [
+                                  {
+                                    "prefix": "3.3.3.3/32",
+                                    "path-id": 0,
+                                    "attr-index": "10641704557835844179",
+                                    "eligible-route": true,
+                                    "reject-reason": "iana-bgp-rib-types:higher-router-id"
+                                  },
+                                  {
+                                    "prefix": "5.5.5.5/32",
+                                    "path-id": 0,
+                                    "attr-index": "11002054795911351509",
+                                    "eligible-route": true
+                                  },
+                                  {
+                                    "prefix": "6.6.6.6/32",
+                                    "path-id": 0,
+                                    "attr-index": "4767695059371701948",
+                                    "eligible-route": true,
+                                    "reject-reason": "iana-bgp-rib-types:higher-router-id"
+                                  }
+                                ]
+                              }
+                            },
+                            "adj-rib-out-pre": {
+                              "routes": {
+                                "route": [
+                                  {
+                                    "prefix": "1.1.1.1/32",
+                                    "path-id": 0,
+                                    "attr-index": "9414355416643581871",
+                                    "eligible-route": true
+                                  },
+                                  {
+                                    "prefix": "3.3.3.3/32",
+                                    "path-id": 0,
+                                    "attr-index": "12590424143591910245",
+                                    "eligible-route": true
+                                  },
+                                  {
+                                    "prefix": "4.4.4.4/32",
+                                    "path-id": 0,
+                                    "attr-index": "5498876665348766646",
+                                    "eligible-route": true
+                                  },
+                                  {
+                                    "prefix": "6.6.6.6/32",
+                                    "path-id": 0,
+                                    "attr-index": "2211548866643936648",
+                                    "eligible-route": true
+                                  }
+                                ]
+                              }
+                            },
+                            "adj-rib-out-post": {
+                              "routes": {
+                                "route": [
+                                  {
+                                    "prefix": "1.1.1.1/32",
+                                    "path-id": 0,
+                                    "attr-index": "9414355416643581871",
+                                    "eligible-route": true
+                                  },
+                                  {
+                                    "prefix": "3.3.3.3/32",
+                                    "path-id": 0,
+                                    "attr-index": "5246163599190634569",
+                                    "eligible-route": true
+                                  },
+                                  {
+                                    "prefix": "4.4.4.4/32",
+                                    "path-id": 0,
+                                    "attr-index": "5498876665348766646",
+                                    "eligible-route": true
+                                  },
+                                  {
+                                    "prefix": "6.6.6.6/32",
+                                    "path-id": 0,
+                                    "attr-index": "2211548866643936648",
+                                    "eligible-route": true
+                                  }
+                                ]
+                              }
+                            }
+                          }
+                        ]
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        }
+      ]
+    }
+  }
+}

--- a/holo-bgp/tests/conformance/bfd-bgp-1/03-output-protocol.jsonl
+++ b/holo-bgp/tests/conformance/bfd-bgp-1/03-output-protocol.jsonl
@@ -1,0 +1,3 @@
+{"NbrTx":{"SendMessage":{"nbr_addr":"10.0.1.2","msg":{"Notification":{"error_code":6,"error_subcode":10,"data":[]}}}}}
+{"NbrTx":{"SendMessageList":{"nbr_addr":"10.0.2.4","msg_list":[{"Update":{"unreach":{"prefixes":["2.2.2.2/32","3.3.3.3/32"]}}}]}}}
+{"NbrTx":{"SendMessageList":{"nbr_addr":"10.0.3.5","msg_list":[{"Update":{"unreach":{"prefixes":["2.2.2.2/32"]}}}]}}}

--- a/holo-bgp/tests/conformance/bfd-bgp-1/04-input-northbound-config-change.json
+++ b/holo-bgp/tests/conformance/bfd-bgp-1/04-input-northbound-config-change.json
@@ -1,0 +1,34 @@
+{
+  "ietf-routing:routing": {
+    "@": {
+      "yang:operation": "none"
+    },
+    "control-plane-protocols": {
+      "control-plane-protocol": [
+        {
+          "type": "ietf-bgp:bgp",
+          "name": "test",
+          "ietf-bgp:bgp": {
+            "neighbors": {
+              "neighbor": [
+                {
+                  "remote-address": "10.0.1.2",
+                  "transport": {
+                    "bfd": {
+                      "enabled": false,
+                      "@enabled": {
+                        "yang:operation": "replace",
+                        "yang:orig-default": false,
+                        "yang:orig-value": "true"
+                      }
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        }
+      ]
+    }
+  }
+}

--- a/holo-bgp/tests/conformance/bfd-bgp-1/04-output-ibus.jsonl
+++ b/holo-bgp/tests/conformance/bfd-bgp-1/04-output-ibus.jsonl
@@ -1,0 +1,1 @@
+{"BfdSessionUnreg":{"sess_key":{"IpSingleHop":{"ifname":"eth-rt2","dst":"10.0.1.2"}}}}

--- a/holo-bgp/tests/conformance/bfd-bgp-1/04-output-northbound-state.json
+++ b/holo-bgp/tests/conformance/bfd-bgp-1/04-output-northbound-state.json
@@ -1,0 +1,619 @@
+{
+  "ietf-routing:routing": {
+    "control-plane-protocols": {
+      "control-plane-protocol": [
+        {
+          "type": "ietf-bgp:bgp",
+          "name": "test",
+          "ietf-bgp:bgp": {
+            "global": {
+              "afi-safis": {
+                "afi-safi": [
+                  {
+                    "name": "iana-bgp-types:ipv4-unicast",
+                    "statistics": {
+                      "total-prefixes": 5
+                    }
+                  }
+                ]
+              },
+              "statistics": {
+                "total-prefixes": 5
+              }
+            },
+            "neighbors": {
+              "neighbor": [
+                {
+                  "remote-address": "10.0.1.2",
+                  "peer-type": "external",
+                  "afi-safis": {
+                    "afi-safi": [
+                      {
+                        "name": "iana-bgp-types:ipv4-unicast",
+                        "prefixes": {
+                          "received": 0,
+                          "sent": 0,
+                          "installed": 0
+                        }
+                      }
+                    ]
+                  },
+                  "session-state": "connect",
+                  "errors": {
+                    "sent": {
+                      "last-error": "iana-bgp-notification:cease-bfd-down",
+                      "last-error-code": 6,
+                      "last-error-subcode": 10,
+                      "last-error-data": ""
+                    }
+                  }
+                },
+                {
+                  "remote-address": "10.0.2.4",
+                  "local-address": "10.0.2.1",
+                  "peer-type": "external",
+                  "identifier": "4.4.4.4",
+                  "timers": {
+                    "negotiated-hold-time": 90
+                  },
+                  "afi-safis": {
+                    "afi-safi": [
+                      {
+                        "name": "iana-bgp-types:ipv4-unicast",
+                        "prefixes": {
+                          "received": 3,
+                          "sent": 2,
+                          "installed": 3
+                        }
+                      }
+                    ]
+                  },
+                  "session-state": "established",
+                  "capabilities": {
+                    "advertised-capabilities": [
+                      {
+                        "code": 1,
+                        "index": 0,
+                        "name": "iana-bgp-types:mp-bgp",
+                        "value": {
+                          "mpbgp": {
+                            "afi": "ipv4",
+                            "safi": "unicast-safi",
+                            "name": "iana-bgp-types:ipv4-unicast"
+                          }
+                        }
+                      },
+                      {
+                        "code": 65,
+                        "index": 1,
+                        "name": "iana-bgp-types:asn32",
+                        "value": {
+                          "asn32": {
+                            "as": 65001
+                          }
+                        }
+                      },
+                      {
+                        "code": 2,
+                        "index": 2,
+                        "name": "iana-bgp-types:route-refresh"
+                      }
+                    ],
+                    "received-capabilities": [
+                      {
+                        "code": 1,
+                        "index": 0,
+                        "name": "iana-bgp-types:mp-bgp",
+                        "value": {
+                          "mpbgp": {
+                            "afi": "ipv4",
+                            "safi": "unicast-safi",
+                            "name": "iana-bgp-types:ipv4-unicast"
+                          }
+                        }
+                      },
+                      {
+                        "code": 65,
+                        "index": 1,
+                        "name": "iana-bgp-types:asn32",
+                        "value": {
+                          "asn32": {
+                            "as": 65004
+                          }
+                        }
+                      },
+                      {
+                        "code": 2,
+                        "index": 2,
+                        "name": "iana-bgp-types:route-refresh"
+                      }
+                    ],
+                    "negotiated-capabilities": [
+                      "iana-bgp-types:mp-bgp",
+                      "iana-bgp-types:asn32",
+                      "iana-bgp-types:route-refresh"
+                    ]
+                  }
+                },
+                {
+                  "remote-address": "10.0.3.5",
+                  "local-address": "10.0.3.1",
+                  "peer-type": "external",
+                  "identifier": "5.5.5.5",
+                  "timers": {
+                    "negotiated-hold-time": 90
+                  },
+                  "afi-safis": {
+                    "afi-safi": [
+                      {
+                        "name": "iana-bgp-types:ipv4-unicast",
+                        "prefixes": {
+                          "received": 3,
+                          "sent": 4,
+                          "installed": 3
+                        }
+                      }
+                    ]
+                  },
+                  "session-state": "established",
+                  "capabilities": {
+                    "advertised-capabilities": [
+                      {
+                        "code": 1,
+                        "index": 0,
+                        "name": "iana-bgp-types:mp-bgp",
+                        "value": {
+                          "mpbgp": {
+                            "afi": "ipv4",
+                            "safi": "unicast-safi",
+                            "name": "iana-bgp-types:ipv4-unicast"
+                          }
+                        }
+                      },
+                      {
+                        "code": 65,
+                        "index": 1,
+                        "name": "iana-bgp-types:asn32",
+                        "value": {
+                          "asn32": {
+                            "as": 65001
+                          }
+                        }
+                      },
+                      {
+                        "code": 2,
+                        "index": 2,
+                        "name": "iana-bgp-types:route-refresh"
+                      }
+                    ],
+                    "received-capabilities": [
+                      {
+                        "code": 1,
+                        "index": 0,
+                        "name": "iana-bgp-types:mp-bgp",
+                        "value": {
+                          "mpbgp": {
+                            "afi": "ipv4",
+                            "safi": "unicast-safi",
+                            "name": "iana-bgp-types:ipv4-unicast"
+                          }
+                        }
+                      },
+                      {
+                        "code": 65,
+                        "index": 1,
+                        "name": "iana-bgp-types:asn32",
+                        "value": {
+                          "asn32": {
+                            "as": 65005
+                          }
+                        }
+                      },
+                      {
+                        "code": 2,
+                        "index": 2,
+                        "name": "iana-bgp-types:route-refresh"
+                      }
+                    ],
+                    "negotiated-capabilities": [
+                      "iana-bgp-types:mp-bgp",
+                      "iana-bgp-types:asn32",
+                      "iana-bgp-types:route-refresh"
+                    ]
+                  }
+                }
+              ]
+            },
+            "rib": {
+              "attr-sets": {
+                "attr-set": [
+                  {
+                    "index": "9414355416643581871",
+                    "attributes": {
+                      "origin": "incomplete"
+                    }
+                  },
+                  {
+                    "index": "5246163599190634569",
+                    "attributes": {
+                      "origin": "incomplete",
+                      "as-path": {
+                        "segment": [
+                          {
+                            "type": "iana-bgp-types:as-sequence",
+                            "member": [
+                              65002,
+                              65003
+                            ]
+                          }
+                        ]
+                      },
+                      "next-hop": "10.0.1.2"
+                    }
+                  },
+                  {
+                    "index": "5498876665348766646",
+                    "attributes": {
+                      "origin": "incomplete",
+                      "as-path": {
+                        "segment": [
+                          {
+                            "type": "iana-bgp-types:as-sequence",
+                            "member": [
+                              65004
+                            ]
+                          }
+                        ]
+                      },
+                      "next-hop": "10.0.2.4"
+                    }
+                  },
+                  {
+                    "index": "2211548866643936648",
+                    "attributes": {
+                      "origin": "incomplete",
+                      "as-path": {
+                        "segment": [
+                          {
+                            "type": "iana-bgp-types:as-sequence",
+                            "member": [
+                              65004,
+                              65006
+                            ]
+                          }
+                        ]
+                      },
+                      "next-hop": "10.0.2.4"
+                    }
+                  },
+                  {
+                    "index": "12590424143591910245",
+                    "attributes": {
+                      "origin": "incomplete",
+                      "as-path": {
+                        "segment": [
+                          {
+                            "type": "iana-bgp-types:as-sequence",
+                            "member": [
+                              65004,
+                              65006,
+                              65003
+                            ]
+                          }
+                        ]
+                      },
+                      "next-hop": "10.0.2.4"
+                    }
+                  },
+                  {
+                    "index": "11002054795911351509",
+                    "attributes": {
+                      "origin": "incomplete",
+                      "as-path": {
+                        "segment": [
+                          {
+                            "type": "iana-bgp-types:as-sequence",
+                            "member": [
+                              65005
+                            ]
+                          }
+                        ]
+                      },
+                      "next-hop": "10.0.3.5"
+                    }
+                  },
+                  {
+                    "index": "4767695059371701948",
+                    "attributes": {
+                      "origin": "incomplete",
+                      "as-path": {
+                        "segment": [
+                          {
+                            "type": "iana-bgp-types:as-sequence",
+                            "member": [
+                              65005,
+                              65006
+                            ]
+                          }
+                        ]
+                      },
+                      "next-hop": "10.0.3.5"
+                    }
+                  },
+                  {
+                    "index": "10641704557835844179",
+                    "attributes": {
+                      "origin": "incomplete",
+                      "as-path": {
+                        "segment": [
+                          {
+                            "type": "iana-bgp-types:as-sequence",
+                            "member": [
+                              65005,
+                              65006,
+                              65003
+                            ]
+                          }
+                        ]
+                      },
+                      "next-hop": "10.0.3.5"
+                    }
+                  }
+                ]
+              },
+              "afi-safis": {
+                "afi-safi": [
+                  {
+                    "name": "iana-bgp-types:ipv4-unicast",
+                    "ipv4-unicast": {
+                      "loc-rib": {
+                        "routes": {
+                          "route": [
+                            {
+                              "prefix": "1.1.1.1/32",
+                              "origin": "ietf-routing:direct",
+                              "path-id": 0,
+                              "attr-index": "9414355416643581871"
+                            },
+                            {
+                              "prefix": "3.3.3.3/32",
+                              "origin": "10.0.2.4",
+                              "path-id": 0,
+                              "attr-index": "12590424143591910245"
+                            },
+                            {
+                              "prefix": "4.4.4.4/32",
+                              "origin": "10.0.2.4",
+                              "path-id": 0,
+                              "attr-index": "5498876665348766646"
+                            },
+                            {
+                              "prefix": "5.5.5.5/32",
+                              "origin": "10.0.3.5",
+                              "path-id": 0,
+                              "attr-index": "11002054795911351509"
+                            },
+                            {
+                              "prefix": "6.6.6.6/32",
+                              "origin": "10.0.2.4",
+                              "path-id": 0,
+                              "attr-index": "2211548866643936648"
+                            }
+                          ]
+                        }
+                      },
+                      "neighbors": {
+                        "neighbor": [
+                          {
+                            "neighbor-address": "10.0.2.4",
+                            "adj-rib-in-pre": {
+                              "routes": {
+                                "route": [
+                                  {
+                                    "prefix": "3.3.3.3/32",
+                                    "path-id": 0,
+                                    "attr-index": "12590424143591910245",
+                                    "eligible-route": true
+                                  },
+                                  {
+                                    "prefix": "4.4.4.4/32",
+                                    "path-id": 0,
+                                    "attr-index": "5498876665348766646",
+                                    "eligible-route": true
+                                  },
+                                  {
+                                    "prefix": "6.6.6.6/32",
+                                    "path-id": 0,
+                                    "attr-index": "2211548866643936648",
+                                    "eligible-route": true
+                                  }
+                                ]
+                              }
+                            },
+                            "adj-rib-in-post": {
+                              "routes": {
+                                "route": [
+                                  {
+                                    "prefix": "3.3.3.3/32",
+                                    "path-id": 0,
+                                    "attr-index": "12590424143591910245",
+                                    "eligible-route": true
+                                  },
+                                  {
+                                    "prefix": "4.4.4.4/32",
+                                    "path-id": 0,
+                                    "attr-index": "5498876665348766646",
+                                    "eligible-route": true
+                                  },
+                                  {
+                                    "prefix": "6.6.6.6/32",
+                                    "path-id": 0,
+                                    "attr-index": "2211548866643936648",
+                                    "eligible-route": true
+                                  }
+                                ]
+                              }
+                            },
+                            "adj-rib-out-pre": {
+                              "routes": {
+                                "route": [
+                                  {
+                                    "prefix": "1.1.1.1/32",
+                                    "path-id": 0,
+                                    "attr-index": "9414355416643581871",
+                                    "eligible-route": true
+                                  },
+                                  {
+                                    "prefix": "5.5.5.5/32",
+                                    "path-id": 0,
+                                    "attr-index": "11002054795911351509",
+                                    "eligible-route": true
+                                  }
+                                ]
+                              }
+                            },
+                            "adj-rib-out-post": {
+                              "routes": {
+                                "route": [
+                                  {
+                                    "prefix": "1.1.1.1/32",
+                                    "path-id": 0,
+                                    "attr-index": "9414355416643581871",
+                                    "eligible-route": true
+                                  },
+                                  {
+                                    "prefix": "5.5.5.5/32",
+                                    "path-id": 0,
+                                    "attr-index": "11002054795911351509",
+                                    "eligible-route": true
+                                  }
+                                ]
+                              }
+                            }
+                          },
+                          {
+                            "neighbor-address": "10.0.3.5",
+                            "adj-rib-in-pre": {
+                              "routes": {
+                                "route": [
+                                  {
+                                    "prefix": "3.3.3.3/32",
+                                    "path-id": 0,
+                                    "attr-index": "10641704557835844179",
+                                    "eligible-route": true
+                                  },
+                                  {
+                                    "prefix": "5.5.5.5/32",
+                                    "path-id": 0,
+                                    "attr-index": "11002054795911351509",
+                                    "eligible-route": true
+                                  },
+                                  {
+                                    "prefix": "6.6.6.6/32",
+                                    "path-id": 0,
+                                    "attr-index": "4767695059371701948",
+                                    "eligible-route": true
+                                  }
+                                ]
+                              }
+                            },
+                            "adj-rib-in-post": {
+                              "routes": {
+                                "route": [
+                                  {
+                                    "prefix": "3.3.3.3/32",
+                                    "path-id": 0,
+                                    "attr-index": "10641704557835844179",
+                                    "eligible-route": true,
+                                    "reject-reason": "iana-bgp-rib-types:higher-router-id"
+                                  },
+                                  {
+                                    "prefix": "5.5.5.5/32",
+                                    "path-id": 0,
+                                    "attr-index": "11002054795911351509",
+                                    "eligible-route": true
+                                  },
+                                  {
+                                    "prefix": "6.6.6.6/32",
+                                    "path-id": 0,
+                                    "attr-index": "4767695059371701948",
+                                    "eligible-route": true,
+                                    "reject-reason": "iana-bgp-rib-types:higher-router-id"
+                                  }
+                                ]
+                              }
+                            },
+                            "adj-rib-out-pre": {
+                              "routes": {
+                                "route": [
+                                  {
+                                    "prefix": "1.1.1.1/32",
+                                    "path-id": 0,
+                                    "attr-index": "9414355416643581871",
+                                    "eligible-route": true
+                                  },
+                                  {
+                                    "prefix": "3.3.3.3/32",
+                                    "path-id": 0,
+                                    "attr-index": "12590424143591910245",
+                                    "eligible-route": true
+                                  },
+                                  {
+                                    "prefix": "4.4.4.4/32",
+                                    "path-id": 0,
+                                    "attr-index": "5498876665348766646",
+                                    "eligible-route": true
+                                  },
+                                  {
+                                    "prefix": "6.6.6.6/32",
+                                    "path-id": 0,
+                                    "attr-index": "2211548866643936648",
+                                    "eligible-route": true
+                                  }
+                                ]
+                              }
+                            },
+                            "adj-rib-out-post": {
+                              "routes": {
+                                "route": [
+                                  {
+                                    "prefix": "1.1.1.1/32",
+                                    "path-id": 0,
+                                    "attr-index": "9414355416643581871",
+                                    "eligible-route": true
+                                  },
+                                  {
+                                    "prefix": "3.3.3.3/32",
+                                    "path-id": 0,
+                                    "attr-index": "5246163599190634569",
+                                    "eligible-route": true
+                                  },
+                                  {
+                                    "prefix": "4.4.4.4/32",
+                                    "path-id": 0,
+                                    "attr-index": "5498876665348766646",
+                                    "eligible-route": true
+                                  },
+                                  {
+                                    "prefix": "6.6.6.6/32",
+                                    "path-id": 0,
+                                    "attr-index": "2211548866643936648",
+                                    "eligible-route": true
+                                  }
+                                ]
+                              }
+                            }
+                          }
+                        ]
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        }
+      ]
+    }
+  }
+}

--- a/holo-bgp/tests/conformance/mod.rs
+++ b/holo-bgp/tests/conformance/mod.rs
@@ -4,4 +4,22 @@
 // SPDX-License-Identifier: MIT
 //
 
+use holo_bgp::instance::Instance;
+use holo_protocol::test::stub::run_test;
+
 mod topologies;
+
+// Test BGP as a BFD client:
+//
+//  * Northbound: enable BFD on a directly connected eBGP neighbor
+//  * Ibus: subscribe to interface updates
+//  * Ibus: learn the connected interface address
+//  * Ibus: register a single-hop BFD session to the neighbor
+//  * Ibus: BFD session goes down
+//  * Protocol: reset the BGP session with Cease/BFD-down
+//  * Northbound: disable BFD on the neighbor
+//  * Ibus: unregister the BFD session
+#[tokio::test]
+async fn bfd_bgp_1() {
+    run_test::<Instance>("bfd-bgp-1", "topo2-1", "rt1").await;
+}

--- a/holo-protocol/src/lib.rs
+++ b/holo-protocol/src/lib.rs
@@ -387,6 +387,34 @@ pub fn spawn_protocol_task<P>(
     ibus_instance_tx: IbusSender,
     ibus_instance_rx: IbusReceiver,
     agg_channels: InstanceAggChannels<P>,
+    shared: InstanceShared,
+) -> NbDaemonSender
+where
+    P: ProtocolInstance,
+{
+    #[cfg(feature = "testing")]
+    let (_test_tx, test_rx) = mpsc::channel(4);
+
+    spawn_protocol_task_inner::<P>(
+        name,
+        nb_provider_tx,
+        ibus_tx,
+        ibus_instance_tx,
+        ibus_instance_rx,
+        agg_channels,
+        #[cfg(feature = "testing")]
+        test_rx,
+        shared,
+    )
+}
+
+pub(crate) fn spawn_protocol_task_inner<P>(
+    name: String,
+    nb_provider_tx: &NbProviderSender,
+    ibus_tx: &IbusChannelsTx,
+    ibus_instance_tx: IbusSender,
+    ibus_instance_rx: IbusReceiver,
+    agg_channels: InstanceAggChannels<P>,
     #[cfg(feature = "testing")] test_rx: Receiver<
         TestMsg<P::ProtocolOutputMsg>,
     >,

--- a/holo-protocol/src/test/stub/mod.rs
+++ b/holo-protocol/src/test/stub/mod.rs
@@ -23,7 +23,7 @@ use crate::test::stub::northbound::NorthboundStub;
 use crate::test::{OutputChannelsRx, setup};
 use crate::{
     InstanceAggChannels, InstanceMsg, InstanceShared, ProtocolInstance,
-    spawn_protocol_task,
+    spawn_protocol_task_inner,
 };
 
 // Environment variable that controls if the test data needs to be updated or
@@ -277,7 +277,7 @@ where
     let channels = InstanceAggChannels::default();
     let instance_tx = channels.tx.clone();
     let (test_tx, test_rx) = mpsc::channel(4);
-    let nb_daemon_tx = spawn_protocol_task::<P>(
+    let nb_daemon_tx = spawn_protocol_task_inner::<P>(
         name.to_owned(),
         &nb_provider_tx,
         &ibus_tx,

--- a/holo-utils/src/task.rs
+++ b/holo-utils/src/task.rs
@@ -221,6 +221,15 @@ impl TimeoutTask {
         }
     }
 
+    #[cfg(feature = "testing")]
+    pub fn new<F, Fut>(_timeout: Duration, _cb: F) -> TimeoutTask
+    where
+        F: FnOnce() -> Fut + Send + 'static,
+        Fut: Future<Output = ()> + Send,
+    {
+        TimeoutTask {}
+    }
+
     /// Resets the timeout, regardless if it has already expired or not.
     ///
     /// If a new timeout value isn't specified, the last value will be reused.

--- a/holo-yang/src/lib.rs
+++ b/holo-yang/src/lib.rs
@@ -384,6 +384,7 @@ pub static YANG_FEATURES: Lazy<HashMap<&'static str, Vec<&'static str>>> =
     Lazy::new(|| {
         hashmap! {
             "iana-bgp-types" => vec![
+                "bfd",
                 "clear-neighbors",
                 "route-refresh",
                 "ttl-security",


### PR DESCRIPTION
Wire BGP as a client of Holo's existing BFD provider.

- Per-neighbor / peer-group `bfd` config enables BFD protection for a neighbor.
- Session registration via the existing ibus BFD client API, choosing the correct session type: **single-hop** for a directly-connected eBGP peer, **multihop** for iBGP or `ebgp-multihop` peers. Registration waits until the peer/source address and outgoing interface are known.
- On BFD **DOWN**, the neighbor is reset with a Cease (BFD-down) notification and its routes are withdrawn (withdrawals propagated to other peers).
- The session is unregistered when BFD config is removed or the neighbor goes down.

Tests: unit tests for session-type selection (direct eBGP → single-hop, ebgp-multihop → multihop, iBGP waits for the source address) and a `bfd-bgp-1` conformance topology exercising register → BFD-down reset/withdraw → unregister.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
