### PR TITLE
bgp: AS-path edge knobs (remove-private-as, allowas-in, as-override, local-as)

### DIFF
--- a/holo-bgp/src/events.rs
+++ b/holo-bgp/src/events.rs
@@ -273,7 +273,7 @@ fn process_nbr_reach_prefixes<A>(
     nbr: &Neighbor,
     rib: &mut Rib,
     nlri_prefixes: Vec<A::IpNetwork>,
-    mut attrs: Attrs,
+    attrs: Attrs,
     local_asn: u32,
     shared: &InstanceShared,
     policy_apply_tasks: &PolicyApplyTasks,
@@ -294,12 +294,6 @@ fn process_nbr_reach_prefixes<A>(
         PeerType::Internal => RouteType::Internal,
         PeerType::External => RouteType::External,
     };
-
-    if nbr.config.as_path_options.replace_peer_as {
-        // Replace occurrences of the peer's AS in the AS_PATH with the local
-        // autonomous system number.
-        attrs.base.as_path.replace(nbr.config.peer_as, local_asn);
-    }
 
     // Update pre-policy Adj-RIB-In routes.
     let table = A::table(&mut rib.tables);
@@ -679,6 +673,7 @@ where
         let best_route = rib::best_path::<A>(
             dest,
             instance.config.asn,
+            neighbors,
             &table.nht,
             selection_cfg,
         );

--- a/holo-bgp/src/neighbor.rs
+++ b/holo-bgp/src/neighbor.rs
@@ -669,11 +669,13 @@ impl Neighbor {
 
     // Sends a BGP OPEN message based on the local configuration.
     fn open_send(&mut self, instance_cfg: &InstanceCfg, identifier: Ipv4Addr) {
+        let local_asn = self.config.local_as.unwrap_or(instance_cfg.asn);
+
         // Base capabilities.
         let mut capabilities: BTreeSet<_> = [
             Capability::RouteRefresh,
             Capability::FourOctetAsNumber {
-                asn: instance_cfg.asn,
+                asn: local_asn,
             },
         ]
         .into();
@@ -702,7 +704,7 @@ impl Neighbor {
         // Fill-in and send message.
         let msg = Message::Open(OpenMsg {
             version: OpenMsg::VERSION,
-            my_as: instance_cfg.asn.try_into().unwrap_or(AS_TRANS),
+            my_as: local_asn.try_into().unwrap_or(AS_TRANS),
             holdtime: self.config.timers.holdtime,
             identifier,
             capabilities,

--- a/holo-bgp/src/neighbor.rs
+++ b/holo-bgp/src/neighbor.rs
@@ -674,9 +674,7 @@ impl Neighbor {
         // Base capabilities.
         let mut capabilities: BTreeSet<_> = [
             Capability::RouteRefresh,
-            Capability::FourOctetAsNumber {
-                asn: local_asn,
-            },
+            Capability::FourOctetAsNumber { asn: local_asn },
         ]
         .into();
 

--- a/holo-bgp/src/northbound/configuration.rs
+++ b/holo-bgp/src/northbound/configuration.rs
@@ -127,6 +127,7 @@ pub struct NeighborCfg {
     pub enabled: bool,
     pub peer_as: u32,
     pub local_as: Option<u32>,
+    pub local_as_options: LocalAsOptionsCfg,
     pub private_as_remove: Option<PrivateAsRemove>,
     pub timers: NeighborTimersCfg,
     pub transport: NeighborTransportCfg,
@@ -136,6 +137,12 @@ pub struct NeighborCfg {
     pub prefix_limit: PrefixLimitCfg,
     pub afi_safi: BTreeMap<AfiSafi, NeighborAfiSafiCfg>,
     pub trace_opts: NeighborTraceOptions,
+}
+
+#[derive(Clone, Copy, Debug)]
+pub struct LocalAsOptionsCfg {
+    pub no_prepend: bool,
+    pub replace_as: bool,
 }
 
 #[derive(Debug)]
@@ -216,6 +223,7 @@ pub struct AsPathOptions {
 
 #[derive(Debug)]
 pub enum PrivateAsRemove {
+    RemoveLeading,
     RemoveAll,
     ReplaceAll,
 }
@@ -835,6 +843,22 @@ fn load_callbacks() -> Callbacks<Instance> {
             let nbr = instance.neighbors.get_mut(&nbr_addr).unwrap();
 
             nbr.config.local_as = None;
+        })
+        .path(bgp::neighbors::neighbor::local_as_options::no_prepend::PATH)
+        .modify_apply(|instance, args| {
+            let nbr_addr = args.list_entry.into_neighbor().unwrap();
+            let nbr = instance.neighbors.get_mut(&nbr_addr).unwrap();
+
+            let no_prepend = args.dnode.get_bool();
+            nbr.config.local_as_options.no_prepend = no_prepend;
+        })
+        .path(bgp::neighbors::neighbor::local_as_options::replace_as::PATH)
+        .modify_apply(|instance, args| {
+            let nbr_addr = args.list_entry.into_neighbor().unwrap();
+            let nbr = instance.neighbors.get_mut(&nbr_addr).unwrap();
+
+            let replace_as = args.dnode.get_bool();
+            nbr.config.local_as_options.replace_as = replace_as;
         })
         .path(bgp::neighbors::neighbor::remove_private_as::PATH)
         .modify_apply(|instance, args| {
@@ -1774,6 +1798,7 @@ impl Default for NeighborCfg {
             enabled,
             peer_as: 0,
             local_as: None,
+            local_as_options: Default::default(),
             private_as_remove: None,
             timers: Default::default(),
             transport: Default::default(),
@@ -1783,6 +1808,18 @@ impl Default for NeighborCfg {
             prefix_limit: Default::default(),
             afi_safi: Default::default(),
             trace_opts: Default::default(),
+        }
+    }
+}
+
+impl Default for LocalAsOptionsCfg {
+    fn default() -> LocalAsOptionsCfg {
+        let no_prepend = bgp::neighbors::neighbor::local_as_options::no_prepend::DFLT;
+        let replace_as = bgp::neighbors::neighbor::local_as_options::replace_as::DFLT;
+
+        LocalAsOptionsCfg {
+            no_prepend,
+            replace_as,
         }
     }
 }

--- a/holo-bgp/src/northbound/yang.rs
+++ b/holo-bgp/src/northbound/yang.rs
@@ -233,6 +233,7 @@ impl ToYang for RouteRejectReason {
 impl TryFromYang for PrivateAsRemove {
     fn try_from_yang(value: &str) -> Option<PrivateAsRemove> {
         match value {
+            "holo-bgp:private-as-remove-leading" => Some(PrivateAsRemove::RemoveLeading),
             "iana-bgp-types:private-as-remove-all" => Some(PrivateAsRemove::RemoveAll),
             "iana-bgp-types:private-as-replace-all" => Some(PrivateAsRemove::ReplaceAll),
             _ => None,

--- a/holo-bgp/src/packet/attribute.rs
+++ b/holo-bgp/src/packet/attribute.rs
@@ -743,9 +743,62 @@ impl AsPath {
         }
     }
 
+    pub(crate) fn replace_private(&mut self, to: u32) {
+        for segment in self.segments.iter_mut() {
+            for member in segment.members.iter_mut() {
+                if is_private_asn(*member) {
+                    *member = to;
+                }
+            }
+        }
+    }
+
+    pub(crate) fn remove_private_all(&mut self) {
+        self.segments = std::mem::take(&mut self.segments)
+            .into_iter()
+            .filter_map(|mut segment| {
+                segment
+                    .members
+                    .retain(|asn| !is_private_asn(*asn));
+                (!segment.members.is_empty()).then_some(segment)
+            })
+            .collect();
+    }
+
+    pub(crate) fn remove_private_leading(&mut self) {
+        while let Some(segment) = self.segments.front_mut() {
+            while segment
+                .members
+                .front()
+                .is_some_and(|asn| is_private_asn(*asn))
+            {
+                segment.members.pop_front();
+            }
+
+            if segment.members.is_empty() {
+                self.segments.pop_front();
+            } else {
+                break;
+            }
+        }
+    }
+
     pub(crate) fn contains(&self, asn: u32) -> bool {
         self.segments.iter().any(|segment| segment.contains(asn))
     }
+
+    pub(crate) fn count(&self, asn: u32) -> u8 {
+        self.segments
+            .iter()
+            .map(|segment| segment.count(asn))
+            .sum::<usize>()
+            .min(u8::MAX as usize) as u8
+    }
+}
+
+pub(crate) fn is_private_asn(asn: u32) -> bool {
+    (64512..=65534).contains(&asn)
+        || (4200000000..=4294967294).contains(&asn)
 }
 
 // ===== impl AsPathSegment =====
@@ -824,6 +877,10 @@ impl AsPathSegment {
 
     fn contains(&self, asn: u32) -> bool {
         self.members.iter().any(|member| asn == *member)
+    }
+
+    fn count(&self, asn: u32) -> usize {
+        self.members.iter().filter(|member| asn == **member).count()
     }
 }
 

--- a/holo-bgp/src/packet/attribute.rs
+++ b/holo-bgp/src/packet/attribute.rs
@@ -757,9 +757,7 @@ impl AsPath {
         self.segments = std::mem::take(&mut self.segments)
             .into_iter()
             .filter_map(|mut segment| {
-                segment
-                    .members
-                    .retain(|asn| !is_private_asn(*asn));
+                segment.members.retain(|asn| !is_private_asn(*asn));
                 (!segment.members.is_empty()).then_some(segment)
             })
             .collect();
@@ -797,8 +795,7 @@ impl AsPath {
 }
 
 pub(crate) fn is_private_asn(asn: u32) -> bool {
-    (64512..=65534).contains(&asn)
-        || (4200000000..=4294967294).contains(&asn)
+    (64512..=65534).contains(&asn) || (4200000000..=4294967294).contains(&asn)
 }
 
 // ===== impl AsPathSegment =====

--- a/holo-bgp/src/rib.rs
+++ b/holo-bgp/src/rib.rs
@@ -981,14 +981,16 @@ pub(crate) fn nexthop_untrack<A>(
 
 #[cfg(test)]
 mod tests {
+    use std::collections::VecDeque;
+
+    use holo_utils::socket::TcpConnInfo;
+
     use super::*;
     use crate::af::Ipv4Unicast;
     use crate::northbound::configuration::LocalAsOptionsCfg;
     use crate::packet::attribute::{
         AsPath, AsPathSegment, AsPathSegmentType, BaseAttrs,
     };
-    use holo_utils::socket::TcpConnInfo;
-    use std::collections::VecDeque;
 
     fn make_route(
         origin: RouteOrigin,
@@ -1047,8 +1049,10 @@ mod tests {
     }
 
     fn external_neighbor(peer_as: u32) -> Neighbor {
-        let mut nbr =
-            Neighbor::new(IpAddr::V4(Ipv4Addr::new(192, 0, 2, 2)), PeerType::External);
+        let mut nbr = Neighbor::new(
+            IpAddr::V4(Ipv4Addr::new(192, 0, 2, 2)),
+            PeerType::External,
+        );
         nbr.config.peer_as = peer_as;
         nbr.conn_info = Some(TcpConnInfo {
             local_addr: IpAddr::V4(Ipv4Addr::new(192, 0, 2, 1)),

--- a/holo-bgp/src/rib.rs
+++ b/holo-bgp/src/rib.rs
@@ -19,9 +19,10 @@ use serde::{Deserialize, Serialize};
 use crate::af::{AddressFamily, Ipv4Unicast, Ipv6Unicast};
 use crate::debug::Debug;
 use crate::ibus;
-use crate::neighbor::{Neighbor, PeerType};
+use crate::neighbor::{Neighbor, Neighbors, PeerType};
 use crate::northbound::configuration::{
-    DistanceCfg, InstanceTraceOptions, MultipathCfg, RouteSelectionCfg,
+    DistanceCfg, InstanceTraceOptions, MultipathCfg, PrivateAsRemove,
+    RouteSelectionCfg,
 };
 use crate::packet::attribute::{
     Attrs, BaseAttrs, Comms, ExtComms, Extv6Comms, LargeComms, UnknownAttr,
@@ -709,6 +710,7 @@ where
 pub(crate) fn best_path<A>(
     dest: &mut Destination,
     local_asn: u32,
+    neighbors: &Neighbors,
     nht: &HashMap<IpAddr, NhtEntry<A>>,
     selection_cfg: &RouteSelectionCfg,
 ) -> Option<Box<Route>>
@@ -730,7 +732,7 @@ where
         route.ineligible_reason = None;
 
         // First, check if the route is eligible.
-        if route.attrs.base.value.as_path.contains(local_asn) {
+        if is_as_loop(route, local_asn, neighbors) {
             route.ineligible_reason = Some(RouteIneligibleReason::AsLoop);
             continue;
         }
@@ -771,6 +773,23 @@ where
 
     // Return a cloned copy of the best route found, if any.
     best_route.cloned()
+}
+
+fn is_as_loop(route: &Route, local_asn: u32, neighbors: &Neighbors) -> bool {
+    let count = route.attrs.base.value.as_path.count(local_asn);
+    if count == 0 {
+        return false;
+    }
+
+    let allowed = match &route.origin {
+        RouteOrigin::Neighbor { remote_addr, .. } => neighbors
+            .get(remote_addr)
+            .map(|nbr| nbr.config.as_path_options.allow_own_as)
+            .unwrap_or_default(),
+        _ => 0,
+    };
+
+    count > allowed
 }
 
 pub(crate) fn loc_rib_update<A>(
@@ -863,8 +882,42 @@ pub(crate) fn attrs_tx_update<A>(
             }
         }
         PeerType::External => {
-            // Prepend local AS number.
-            attrs.base.as_path.prepend(local_asn);
+            // Egress AS-path knobs are intentionally applied to this
+            // per-advertisement copy, after export policy and before encoding.
+            // Transform the original route path before local prepends so
+            // leading-private removal sees the received path, not our ASN.
+            match nbr.config.private_as_remove {
+                Some(PrivateAsRemove::RemoveLeading) => {
+                    attrs.base.as_path.remove_private_leading();
+                }
+                Some(PrivateAsRemove::RemoveAll) => {
+                    attrs.base.as_path.remove_private_all();
+                }
+                Some(PrivateAsRemove::ReplaceAll) => {
+                    attrs.base.as_path.replace_private(local_asn);
+                }
+                None => {}
+            }
+
+            if nbr.config.as_path_options.replace_peer_as {
+                attrs.base.as_path.replace(nbr.config.peer_as, local_asn);
+            }
+
+            if let Some(local_as) = nbr.config.local_as
+                && !nbr.config.local_as_options.no_prepend
+                && !nbr.config.local_as_options.replace_as
+            {
+                attrs.base.as_path.prepend(local_as);
+            }
+
+            // Prepend local AS number. With local-as replace-as, present the
+            // configured local-as in place of the global ASN.
+            let prepend_asn = if nbr.config.local_as_options.replace_as {
+                nbr.config.local_as.unwrap_or(local_asn)
+            } else {
+                local_asn
+            };
+            attrs.base.as_path.prepend(prepend_asn);
 
             // Do not propagate the MULTI_EXIT_DISC attribute.
             attrs.base.med = None;
@@ -929,7 +982,13 @@ pub(crate) fn nexthop_untrack<A>(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::packet::attribute::BaseAttrs;
+    use crate::af::Ipv4Unicast;
+    use crate::northbound::configuration::LocalAsOptionsCfg;
+    use crate::packet::attribute::{
+        AsPath, AsPathSegment, AsPathSegmentType, BaseAttrs,
+    };
+    use holo_utils::socket::TcpConnInfo;
+    use std::collections::VecDeque;
 
     fn make_route(
         origin: RouteOrigin,
@@ -968,6 +1027,48 @@ mod tests {
 
     fn local_origin() -> RouteOrigin {
         RouteOrigin::Protocol(Protocol::STATIC)
+    }
+
+    fn as_path(asns: impl IntoIterator<Item = u32>) -> AsPath {
+        AsPath {
+            segments: VecDeque::from([AsPathSegment {
+                seg_type: AsPathSegmentType::Sequence,
+                members: asns.into_iter().collect(),
+            }]),
+        }
+    }
+
+    fn as_path_members(as_path: &AsPath) -> Vec<u32> {
+        as_path
+            .segments
+            .iter()
+            .flat_map(|segment| segment.members.iter().copied())
+            .collect()
+    }
+
+    fn external_neighbor(peer_as: u32) -> Neighbor {
+        let mut nbr =
+            Neighbor::new(IpAddr::V4(Ipv4Addr::new(192, 0, 2, 2)), PeerType::External);
+        nbr.config.peer_as = peer_as;
+        nbr.conn_info = Some(TcpConnInfo {
+            local_addr: IpAddr::V4(Ipv4Addr::new(192, 0, 2, 1)),
+            local_port: 179,
+            remote_addr: nbr.remote_addr,
+            remote_port: 179,
+        });
+        nbr
+    }
+
+    fn attrs_tx_path(nbr: &Neighbor, path: &[u32]) -> Vec<u32> {
+        let mut attrs = Attrs {
+            base: BaseAttrs {
+                as_path: as_path(path.iter().copied()),
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        attrs_tx_update::<Ipv4Unicast>(&mut attrs, nbr, 64496, false);
+        as_path_members(&attrs.base.as_path)
     }
 
     #[test]
@@ -1064,5 +1165,131 @@ mod tests {
             RouteCompare::Preferred(RouteRejectReason::PreferExternal) => {}
             other => panic!("expected PreferExternal, got {:?}", other),
         }
+    }
+
+    #[test]
+    fn remove_private_as_default_strips_leading_private_asns() {
+        let mut nbr = external_neighbor(64497);
+        nbr.config.private_as_remove = Some(PrivateAsRemove::RemoveLeading);
+
+        assert_eq!(
+            attrs_tx_path(&nbr, &[64512, 4200000000, 64498, 64513]),
+            vec![64496, 64498, 64513]
+        );
+    }
+
+    #[test]
+    fn remove_private_as_all_strips_all_private_asns() {
+        let mut nbr = external_neighbor(64497);
+        nbr.config.private_as_remove = Some(PrivateAsRemove::RemoveAll);
+
+        assert_eq!(
+            attrs_tx_path(&nbr, &[64512, 64498, 4200000000]),
+            vec![64496, 64498]
+        );
+    }
+
+    #[test]
+    fn remove_private_as_replace_all_preserves_path_length() {
+        let mut nbr = external_neighbor(64497);
+        nbr.config.private_as_remove = Some(PrivateAsRemove::ReplaceAll);
+
+        assert_eq!(
+            attrs_tx_path(&nbr, &[64512, 64498, 4200000000]),
+            vec![64496, 64496, 64498, 64496]
+        );
+    }
+
+    #[test]
+    fn allow_own_as_accepts_only_configured_occurrences() {
+        let mut neighbors = Neighbors::default();
+        let mut nbr = external_neighbor(64497);
+        nbr.config.as_path_options.allow_own_as = 1;
+        neighbors.insert(nbr.remote_addr, nbr);
+
+        let origin = RouteOrigin::Neighbor {
+            identifier: Ipv4Addr::new(192, 0, 2, 2),
+            remote_addr: IpAddr::V4(Ipv4Addr::new(192, 0, 2, 2)),
+        };
+        let route = Route {
+            attrs: RouteAttrs {
+                base: Arc::new(AttrSet {
+                    index: 0,
+                    value: BaseAttrs {
+                        as_path: as_path([64496]),
+                        ..Default::default()
+                    },
+                }),
+                comm: None,
+                ext_comm: None,
+                extv6_comm: None,
+                large_comm: None,
+                unknown: None,
+            },
+            ..make_route(origin, RouteType::External, Some(0))
+        };
+        assert!(!is_as_loop(&route, 64496, &neighbors));
+
+        let route = Route {
+            attrs: RouteAttrs {
+                base: Arc::new(AttrSet {
+                    index: 0,
+                    value: BaseAttrs {
+                        as_path: as_path([64496, 64496]),
+                        ..Default::default()
+                    },
+                }),
+                comm: None,
+                ext_comm: None,
+                extv6_comm: None,
+                large_comm: None,
+                unknown: None,
+            },
+            ..route
+        };
+        assert!(is_as_loop(&route, 64496, &neighbors));
+    }
+
+    #[test]
+    fn as_override_replaces_peer_as_on_egress() {
+        let mut nbr = external_neighbor(64497);
+        nbr.config.as_path_options.replace_peer_as = true;
+
+        assert_eq!(
+            attrs_tx_path(&nbr, &[64497, 64498, 64497]),
+            vec![64496, 64496, 64498, 64496]
+        );
+    }
+
+    #[test]
+    fn local_as_prepends_local_as_and_global_as() {
+        let mut nbr = external_neighbor(64497);
+        nbr.config.local_as = Some(64495);
+
+        assert_eq!(attrs_tx_path(&nbr, &[64498]), vec![64496, 64495, 64498]);
+    }
+
+    #[test]
+    fn local_as_no_prepend_skips_local_as_prepend() {
+        let mut nbr = external_neighbor(64497);
+        nbr.config.local_as = Some(64495);
+        nbr.config.local_as_options = LocalAsOptionsCfg {
+            no_prepend: true,
+            replace_as: false,
+        };
+
+        assert_eq!(attrs_tx_path(&nbr, &[64498]), vec![64496, 64498]);
+    }
+
+    #[test]
+    fn local_as_replace_as_uses_local_as_for_egress_prepend() {
+        let mut nbr = external_neighbor(64497);
+        nbr.config.local_as = Some(64495);
+        nbr.config.local_as_options = LocalAsOptionsCfg {
+            no_prepend: false,
+            replace_as: true,
+        };
+
+        assert_eq!(attrs_tx_path(&nbr, &[64498]), vec![64495, 64498]);
     }
 }

--- a/holo-protocol/src/lib.rs
+++ b/holo-protocol/src/lib.rs
@@ -387,6 +387,34 @@ pub fn spawn_protocol_task<P>(
     ibus_instance_tx: IbusSender,
     ibus_instance_rx: IbusReceiver,
     agg_channels: InstanceAggChannels<P>,
+    shared: InstanceShared,
+) -> NbDaemonSender
+where
+    P: ProtocolInstance,
+{
+    #[cfg(feature = "testing")]
+    let (_test_tx, test_rx) = mpsc::channel(4);
+
+    spawn_protocol_task_inner::<P>(
+        name,
+        nb_provider_tx,
+        ibus_tx,
+        ibus_instance_tx,
+        ibus_instance_rx,
+        agg_channels,
+        #[cfg(feature = "testing")]
+        test_rx,
+        shared,
+    )
+}
+
+pub(crate) fn spawn_protocol_task_inner<P>(
+    name: String,
+    nb_provider_tx: &NbProviderSender,
+    ibus_tx: &IbusChannelsTx,
+    ibus_instance_tx: IbusSender,
+    ibus_instance_rx: IbusReceiver,
+    agg_channels: InstanceAggChannels<P>,
     #[cfg(feature = "testing")] test_rx: Receiver<
         TestMsg<P::ProtocolOutputMsg>,
     >,

--- a/holo-protocol/src/test/stub/mod.rs
+++ b/holo-protocol/src/test/stub/mod.rs
@@ -23,7 +23,7 @@ use crate::test::stub::northbound::NorthboundStub;
 use crate::test::{OutputChannelsRx, setup};
 use crate::{
     InstanceAggChannels, InstanceMsg, InstanceShared, ProtocolInstance,
-    spawn_protocol_task,
+    spawn_protocol_task_inner,
 };
 
 // Environment variable that controls if the test data needs to be updated or
@@ -277,7 +277,7 @@ where
     let channels = InstanceAggChannels::default();
     let instance_tx = channels.tx.clone();
     let (test_tx, test_rx) = mpsc::channel(4);
-    let nb_daemon_tx = spawn_protocol_task::<P>(
+    let nb_daemon_tx = spawn_protocol_task_inner::<P>(
         name.to_owned(),
         &nb_provider_tx,
         &ibus_tx,

--- a/holo-utils/src/task.rs
+++ b/holo-utils/src/task.rs
@@ -221,6 +221,15 @@ impl TimeoutTask {
         }
     }
 
+    #[cfg(feature = "testing")]
+    pub fn new<F, Fut>(_timeout: Duration, _cb: F) -> TimeoutTask
+    where
+        F: FnOnce() -> Fut + Send + 'static,
+        Fut: Future<Output = ()> + Send,
+    {
+        TimeoutTask {}
+    }
+
     /// Resets the timeout, regardless if it has already expired or not.
     ///
     /// If a new timeout value isn't specified, the last value will be reused.

--- a/holo-yang/modules/augmentations/holo-bgp.yang
+++ b/holo-yang/modules/augmentations/holo-bgp.yang
@@ -72,6 +72,13 @@ module holo-bgp {
       "RFC 7313: Enhanced Route Refresh Capability for BGP-4";
   }
 
+  identity private-as-remove-leading {
+    base bt:remove-private-as-option;
+    description
+      "Strip leading private autonomous system numbers from the AS_PATH
+       until the first public AS number is reached.";
+  }
+
   /*
    * Augmentations.
    */
@@ -141,6 +148,26 @@ module holo-bgp {
 
   augment "/rt:routing/rt:control-plane-protocols/"
         + "rt:control-plane-protocol/bgp:bgp/bgp:neighbors/bgp:neighbor" {
+    container local-as-options {
+      description
+        "Additional behavior for the local-as leaf.";
+
+      leaf no-prepend {
+        type boolean;
+        default "false";
+        description
+          "Do not prepend the configured local-as to outbound AS_PATHs.";
+      }
+
+      leaf replace-as {
+        type boolean;
+        default "false";
+        description
+          "Use the configured local-as instead of the global AS for the
+           normal eBGP AS_PATH prepend.";
+      }
+    }
+
     container trace-options {
       list flag {
         key name;


### PR DESCRIPTION
Four per-neighbor AS-path edge knobs (previously deviated), via `ietf-bgp` neighbor/peer-group config:

- **remove-private-as:** strip private ASNs (2-byte 64512–65534, 4-byte 4200000000–4294967294) from the advertised path — default (leading), `all`, and `replace-as` (private replaced by local AS, path length preserved) modes.
- **allowas-in:** accept a route whose AS-path contains the local AS up to the configured occurrence count; default 0 preserves normal own-AS loop rejection.
- **as-override:** replace the neighbour's AS occurrences with the local AS on advertisement.
- **local-as:** present a configured AS to the neighbour, with `no-prepend` and `replace-as` variants.

Unit tests cover each knob and variant: `allow_own_as` boundary, the three private-AS modes, the local-as prepend forms, and as-override.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
