### PR TITLE
bgp: route aggregation (aggregate-address, summary-only, as-set)

### DIFF
--- a/holo-bgp/src/events.rs
+++ b/holo-bgp/src/events.rs
@@ -4,6 +4,7 @@
 // SPDX-License-Identifier: MIT
 //
 
+use std::collections::{BTreeMap, BTreeSet};
 use std::net::IpAddr;
 
 use chrono::Utc;
@@ -662,14 +663,20 @@ where
         .get(&A::AFI_SAFI)
         .map(|afi_safi| &afi_safi.multipath)
         .unwrap_or(&instance.config.multipath);
+    let aggregates = instance
+        .config
+        .afi_safi
+        .get(&A::AFI_SAFI)
+        .map(|afi_safi| afi_safi.aggregates.clone())
+        .unwrap_or_default();
 
     // Phase 2: Route Selection.
     //
     // Process each queued destination in the RIB.
     let table = A::table(&mut instance.state.rib.tables);
     let queued_prefixes = std::mem::take(&mut table.queued_prefixes);
-    let mut reach = vec![];
-    let mut unreach = vec![];
+    let mut reach = BTreeMap::new();
+    let mut unreach = BTreeSet::new();
     for prefix in queued_prefixes.iter().copied() {
         let Some(dest) = table.prefixes.get_mut(&prefix) else {
             continue;
@@ -698,8 +705,51 @@ where
 
         // Group best routes and unfeasible routes separately.
         match best_route {
-            Some(best_route) => reach.push((prefix, best_route)),
-            None => unreach.push(prefix),
+            Some(best_route) => {
+                reach.insert(prefix, best_route);
+            }
+            None => {
+                unreach.insert(prefix);
+            }
+        }
+    }
+
+    let aggregate_reeval = rib::aggregates_update::<A>(
+        table,
+        &mut instance.state.rib.attr_sets,
+        &aggregates,
+        instance.config.asn,
+        instance.state.router_id,
+        selection_cfg,
+        mpath_cfg,
+        &instance.config.distance,
+        &instance.config.trace_opts,
+        &instance.tx.ibus,
+    );
+    for prefix in aggregate_reeval
+        .into_iter()
+        .chain(rib::aggregate_reeval_prefixes(table, &aggregates))
+    {
+        let Some(dest) = table.prefixes.get(&prefix) else {
+            continue;
+        };
+        if let Some(local_route) = &dest.local {
+            reach.insert(
+                prefix,
+                Box::new(Route {
+                    origin: local_route.origin,
+                    attrs: local_route.attrs.clone(),
+                    route_type: local_route.route_type,
+                    igp_cost: None,
+                    last_modified: local_route.last_modified,
+                    ineligible_reason: None,
+                    reject_reason: None,
+                }),
+            );
+            unreach.remove(&prefix);
+        } else {
+            reach.remove(&prefix);
+            unreach.insert(prefix);
         }
     }
 
@@ -718,15 +768,22 @@ where
         // Any routes that fail to meet the distribution criteria are marked
         // as unreachable to ensure previous advertisements are withdrawn.
         let mut nbr_unreach = unreach.clone();
-        let mut nbr_reach = reach.clone();
+        let mut nbr_reach = reach
+            .iter()
+            .map(|(prefix, route)| (*prefix, route.clone()))
+            .collect::<Vec<_>>();
         nbr_unreach.extend(
             nbr_reach
-                .extract_if(.., |(_, route)| !nbr.distribute_filter(route))
+                .extract_if(.., |(prefix, route)| {
+                    rib::aggregate_suppresses(table, &aggregates, *prefix)
+                        || !nbr.distribute_filter(route)
+                })
                 .map(|(prefix, _)| prefix),
         );
 
         // Withdraw unfeasible routes immediately.
         if !nbr_unreach.is_empty() {
+            let nbr_unreach = nbr_unreach.into_iter().collect::<Vec<_>>();
             withdraw_routes::<A>(
                 nbr,
                 table,
@@ -755,6 +812,8 @@ where
         {
             let dest = entry.get();
             if dest.local.is_none()
+                && dest.aggregate.is_none()
+                && dest.redistribute.is_none()
                 && dest.adj_rib.values().all(|adj_rib| {
                     adj_rib.in_pre().is_none()
                         && adj_rib.in_post().is_none()

--- a/holo-bgp/src/ibus/tx.rs
+++ b/holo-bgp/src/ibus/tx.rs
@@ -40,10 +40,16 @@ pub(crate) fn route_install(
         })
         .collect::<BTreeSet<_>>();
 
+    let kind = if route.origin.is_aggregate() {
+        RouteKind::Blackhole
+    } else {
+        RouteKind::Unicast
+    };
+
     // Install route.
     let msg = RouteMsg {
         protocol: Protocol::BGP,
-        kind: RouteKind::Unicast,
+        kind,
         prefix: prefix.into(),
         distance: distance.into(),
         metric: route.attrs.base.value.med.unwrap_or(0),

--- a/holo-bgp/src/northbound/configuration.rs
+++ b/holo-bgp/src/northbound/configuration.rs
@@ -19,6 +19,7 @@ use holo_utils::policy::{ApplyPolicyCfg, DefaultPolicyType};
 use holo_utils::protocol::Protocol;
 use holo_utils::yang::DataNodeRefExt;
 use holo_yang::TryFromYang;
+use ipnetwork::IpNetwork;
 
 use crate::af::{Ipv4Unicast, Ipv6Unicast};
 use crate::instance::{Instance, InstanceUpView};
@@ -34,6 +35,7 @@ pub enum ListEntry {
     #[default]
     None,
     AfiSafi(AfiSafi),
+    Aggregate(AfiSafi, IpNetwork),
     Redistribution(AfiSafi, Protocol),
     TraceOption(InstanceTraceOption),
     Neighbor(IpAddr),
@@ -53,6 +55,7 @@ pub enum Event {
     NeighborUpdateAuth(IpAddr),
     RedistributeIbusSub(Protocol, AddressFamily),
     RedistributeDelete(Protocol, AddressFamily, AfiSafi),
+    AggregateUpdate,
     UpdateTraceOptions,
 }
 
@@ -96,6 +99,7 @@ pub struct InstanceAfiSafiCfg {
     pub prefix_limit: PrefixLimitCfg,
     pub send_default_route: bool,
     pub apply_policy: ApplyPolicyCfg,
+    pub aggregates: BTreeMap<IpNetwork, AggregateCfg>,
     pub redistribution: HashMap<Protocol, RedistributionCfg>,
 }
 
@@ -202,6 +206,12 @@ pub struct PrefixLimitCfg {
     pub warning_threshold_pct: Option<u8>,
     pub teardown: bool,
     pub idle_time: Option<u32>,
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct AggregateCfg {
+    pub summary_only: bool,
+    pub as_set: bool,
 }
 
 #[derive(Debug, Default)]
@@ -532,6 +542,53 @@ fn load_callbacks() -> Callbacks<Instance> {
             let send = args.dnode.get_bool();
             afi_safi.send_default_route = send;
         })
+        .path(bgp::global::afi_safis::afi_safi::ipv4_unicast::aggregate::PATH)
+        .create_apply(|instance, args| {
+            let afi_safi = args.list_entry.into_afi_safi().unwrap();
+            let afi_safi_cfg = instance.config.afi_safi.get_mut(&afi_safi).unwrap();
+
+            let prefix = args.dnode.get_prefix_relative("./prefix").unwrap();
+            afi_safi_cfg.aggregates.insert(prefix, Default::default());
+
+            let event_queue = args.event_queue;
+            event_queue.insert(Event::AggregateUpdate);
+        })
+        .delete_apply(|instance, args| {
+            let (afi_safi, prefix) = args.list_entry.into_aggregate().unwrap();
+            let afi_safi_cfg = instance.config.afi_safi.get_mut(&afi_safi).unwrap();
+
+            afi_safi_cfg.aggregates.remove(&prefix);
+
+            let event_queue = args.event_queue;
+            event_queue.insert(Event::AggregateUpdate);
+        })
+        .lookup(|_instance, list_entry, dnode| {
+            let afi_safi = list_entry.into_afi_safi().unwrap();
+            let prefix = dnode.get_prefix_relative("./prefix").unwrap();
+            ListEntry::Aggregate(afi_safi, prefix)
+        })
+        .path(bgp::global::afi_safis::afi_safi::ipv4_unicast::aggregate::summary_only::PATH)
+        .modify_apply(|instance, args| {
+            let (afi_safi, prefix) = args.list_entry.into_aggregate().unwrap();
+            let afi_safi_cfg = instance.config.afi_safi.get_mut(&afi_safi).unwrap();
+            let aggregate = afi_safi_cfg.aggregates.get_mut(&prefix).unwrap();
+
+            aggregate.summary_only = args.dnode.get_bool();
+
+            let event_queue = args.event_queue;
+            event_queue.insert(Event::AggregateUpdate);
+        })
+        .path(bgp::global::afi_safis::afi_safi::ipv4_unicast::aggregate::as_set::PATH)
+        .modify_apply(|instance, args| {
+            let (afi_safi, prefix) = args.list_entry.into_aggregate().unwrap();
+            let afi_safi_cfg = instance.config.afi_safi.get_mut(&afi_safi).unwrap();
+            let aggregate = afi_safi_cfg.aggregates.get_mut(&prefix).unwrap();
+
+            aggregate.as_set = args.dnode.get_bool();
+
+            let event_queue = args.event_queue;
+            event_queue.insert(Event::AggregateUpdate);
+        })
         .path(bgp::global::afi_safis::afi_safi::ipv4_unicast::redistribution::PATH)
         .create_apply(|instance, args| {
             let afi_safi = args.list_entry.into_afi_safi().unwrap();
@@ -617,6 +674,53 @@ fn load_callbacks() -> Callbacks<Instance> {
 
             let send = args.dnode.get_bool();
             afi_safi.send_default_route = send;
+        })
+        .path(bgp::global::afi_safis::afi_safi::ipv6_unicast::aggregate::PATH)
+        .create_apply(|instance, args| {
+            let afi_safi = args.list_entry.into_afi_safi().unwrap();
+            let afi_safi_cfg = instance.config.afi_safi.get_mut(&afi_safi).unwrap();
+
+            let prefix = args.dnode.get_prefix_relative("./prefix").unwrap();
+            afi_safi_cfg.aggregates.insert(prefix, Default::default());
+
+            let event_queue = args.event_queue;
+            event_queue.insert(Event::AggregateUpdate);
+        })
+        .delete_apply(|instance, args| {
+            let (afi_safi, prefix) = args.list_entry.into_aggregate().unwrap();
+            let afi_safi_cfg = instance.config.afi_safi.get_mut(&afi_safi).unwrap();
+
+            afi_safi_cfg.aggregates.remove(&prefix);
+
+            let event_queue = args.event_queue;
+            event_queue.insert(Event::AggregateUpdate);
+        })
+        .lookup(|_instance, list_entry, dnode| {
+            let afi_safi = list_entry.into_afi_safi().unwrap();
+            let prefix = dnode.get_prefix_relative("./prefix").unwrap();
+            ListEntry::Aggregate(afi_safi, prefix)
+        })
+        .path(bgp::global::afi_safis::afi_safi::ipv6_unicast::aggregate::summary_only::PATH)
+        .modify_apply(|instance, args| {
+            let (afi_safi, prefix) = args.list_entry.into_aggregate().unwrap();
+            let afi_safi_cfg = instance.config.afi_safi.get_mut(&afi_safi).unwrap();
+            let aggregate = afi_safi_cfg.aggregates.get_mut(&prefix).unwrap();
+
+            aggregate.summary_only = args.dnode.get_bool();
+
+            let event_queue = args.event_queue;
+            event_queue.insert(Event::AggregateUpdate);
+        })
+        .path(bgp::global::afi_safis::afi_safi::ipv6_unicast::aggregate::as_set::PATH)
+        .modify_apply(|instance, args| {
+            let (afi_safi, prefix) = args.list_entry.into_aggregate().unwrap();
+            let afi_safi_cfg = instance.config.afi_safi.get_mut(&afi_safi).unwrap();
+            let aggregate = afi_safi_cfg.aggregates.get_mut(&prefix).unwrap();
+
+            aggregate.as_set = args.dnode.get_bool();
+
+            let event_queue = args.event_queue;
+            event_queue.insert(Event::AggregateUpdate);
         })
         .path(bgp::global::afi_safis::afi_safi::ipv6_unicast::redistribution::PATH)
         .create_apply(|instance, args| {
@@ -1593,6 +1697,11 @@ impl Provider for Instance {
                     }
                 }
             }
+            Event::AggregateUpdate => {
+                if let Some((instance, _)) = self.as_up() {
+                    instance.state.schedule_decision_process(instance.tx);
+                }
+            }
             Event::UpdateTraceOptions => {
                 for nbr in self.neighbors.values_mut() {
                     let nbr_trace_opts = &nbr.config.trace_opts;
@@ -1760,6 +1869,7 @@ impl Default for InstanceAfiSafiCfg {
             prefix_limit: Default::default(),
             send_default_route: false,
             apply_policy: Default::default(),
+            aggregates: Default::default(),
             redistribution: Default::default(),
         }
     }

--- a/holo-bgp/src/northbound/yang.rs
+++ b/holo-bgp/src/northbound/yang.rs
@@ -6,6 +6,7 @@
 
 use std::borrow::Cow;
 
+use holo_utils::protocol::Protocol;
 use holo_yang::{ToYang, TryFromYang};
 use num_traits::FromPrimitive;
 
@@ -196,6 +197,7 @@ impl ToYang for RouteOrigin {
                 remote_addr, ..
             } => remote_addr.to_string().into(),
             RouteOrigin::Protocol(protocol) => protocol.to_yang(),
+            RouteOrigin::Aggregate => Protocol::BGP.to_yang(),
         }
     }
 }

--- a/holo-bgp/src/packet/attribute.rs
+++ b/holo-bgp/src/packet/attribute.rs
@@ -719,6 +719,24 @@ impl AsPath {
             .flat_map(|segment| segment.members.iter().copied())
     }
 
+    pub(crate) fn from_set<I>(asns: I) -> AsPath
+    where
+        I: IntoIterator<Item = u32>,
+    {
+        let members = asns.into_iter().collect::<VecDeque<_>>();
+        if members.is_empty() {
+            return AsPath::default();
+        }
+
+        AsPath {
+            segments: [AsPathSegment {
+                seg_type: AsPathSegmentType::Set,
+                members,
+            }]
+            .into(),
+        }
+    }
+
     pub(crate) fn prepend(&mut self, asn: u32) {
         if let Some(segment) = self.segments.front_mut()
             && segment.seg_type == AsPathSegmentType::Sequence

--- a/holo-bgp/src/rib.rs
+++ b/holo-bgp/src/rib.rs
@@ -12,7 +12,9 @@ use std::time::Instant;
 
 use holo_utils::bgp::RouteType;
 use holo_utils::ibus::IbusChannelsTx;
+use holo_utils::ip::IpNetworkKind;
 use holo_utils::protocol::Protocol;
+use ipnetwork::IpNetwork;
 use prefix_trie::map::PrefixMap;
 use serde::{Deserialize, Serialize};
 
@@ -21,11 +23,14 @@ use crate::debug::Debug;
 use crate::ibus;
 use crate::neighbor::{Neighbor, PeerType};
 use crate::northbound::configuration::{
-    DistanceCfg, InstanceTraceOptions, MultipathCfg, RouteSelectionCfg,
+    AggregateCfg, DistanceCfg, InstanceTraceOptions, MultipathCfg,
+    RouteSelectionCfg,
 };
 use crate::packet::attribute::{
-    Attrs, BaseAttrs, Comms, ExtComms, Extv6Comms, LargeComms, UnknownAttr,
+    Aggregator, AsPath, Attrs, BaseAttrs, Comms, ExtComms, Extv6Comms,
+    LargeComms, UnknownAttr,
 };
+use crate::packet::iana::Origin;
 use crate::policy::RoutePolicyInfo;
 
 // Default values.
@@ -58,6 +63,7 @@ pub struct Destination {
     pub local: Option<Box<LocalRoute>>,
     pub adj_rib: BTreeMap<IpAddr, AdjRib>,
     pub redistribute: Option<Box<Route>>,
+    pub aggregate: Option<Box<Route>>,
 }
 
 #[derive(Debug, Default)]
@@ -88,7 +94,7 @@ pub struct Route {
     pub reject_reason: Option<RouteRejectReason>,
 }
 
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd)]
 #[derive(Deserialize, Serialize)]
 pub enum RouteOrigin {
     // Route learned from a neighbor.
@@ -98,6 +104,8 @@ pub enum RouteOrigin {
     },
     // Route was injected or redistributed from another protocol.
     Protocol(Protocol),
+    // Route was locally originated by BGP aggregation.
+    Aggregate,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -527,8 +535,12 @@ impl Route {
             }
         }
 
-        // "Isso non ecziste!"
-        unreachable!()
+        let reason = RouteRejectReason::HigherPeerAddress;
+        match self.origin.cmp(&other.origin) {
+            Ordering::Less => RouteCompare::Preferred(reason),
+            Ordering::Greater => RouteCompare::LessPreferred(reason),
+            Ordering::Equal => unreachable!(),
+        }
     }
 }
 
@@ -536,7 +548,11 @@ impl Route {
 
 impl RouteOrigin {
     pub(crate) fn is_local(&self) -> bool {
-        matches!(self, RouteOrigin::Protocol { .. })
+        matches!(self, RouteOrigin::Protocol { .. } | RouteOrigin::Aggregate)
+    }
+
+    pub(crate) fn is_aggregate(&self) -> bool {
+        matches!(self, RouteOrigin::Aggregate)
     }
 }
 
@@ -725,6 +741,8 @@ where
         .filter_map(|adj_rib| adj_rib.in_post.as_mut())
         // Consider locally redistributed routes too.
         .chain(dest.redistribute.as_mut())
+        // Consider locally originated aggregate routes too.
+        .chain(dest.aggregate.as_mut())
     {
         route.reject_reason = None;
         route.ineligible_reason = None;
@@ -815,7 +833,7 @@ pub(crate) fn loc_rib_update<A>(
         };
 
         // Install local route in the global RIB.
-        if !local_route.origin.is_local() {
+        if !local_route.origin.is_local() || local_route.origin.is_aggregate() {
             ibus::tx::route_install(
                 ibus_tx,
                 prefix,
@@ -840,11 +858,206 @@ pub(crate) fn loc_rib_update<A>(
             attr_sets.remove_route_attr_sets(&local_route.attrs);
 
             // Uninstall route from the global RIB.
-            if !local_route.origin.is_local() {
+            if !local_route.origin.is_local()
+                || local_route.origin.is_aggregate()
+            {
                 ibus::tx::route_uninstall(ibus_tx, prefix);
             }
         }
     }
+}
+
+pub(crate) fn aggregates_update<A>(
+    table: &mut RoutingTable<A>,
+    attr_sets: &mut AttrSetsCxt,
+    aggregates: &BTreeMap<IpNetwork, AggregateCfg>,
+    local_asn: u32,
+    router_id: Ipv4Addr,
+    selection_cfg: &RouteSelectionCfg,
+    mpath_cfg: &MultipathCfg,
+    distance_cfg: &DistanceCfg,
+    trace_opts: &InstanceTraceOptions,
+    ibus_tx: &IbusChannelsTx,
+) -> BTreeSet<A::IpNetwork>
+where
+    A: AddressFamily,
+{
+    let mut affected = BTreeSet::new();
+
+    for (aggregate_prefix, aggregate_cfg) in aggregates {
+        let Some(aggregate_prefix) = A::IpNetwork::get(*aggregate_prefix)
+        else {
+            continue;
+        };
+
+        let contributors = aggregate_contributors(table, aggregate_prefix);
+        let aggregate_route = (!contributors.is_empty()).then(|| {
+            aggregate_route(
+                contributors.iter().map(|(_, route)| route),
+                aggregate_cfg,
+                local_asn,
+                router_id,
+                attr_sets,
+            )
+        });
+
+        let dest = table.prefixes.entry(aggregate_prefix).or_default();
+        let changed = match (&dest.aggregate, &aggregate_route) {
+            (None, None) => false,
+            (Some(_), None) | (None, Some(_)) => true,
+            (Some(old), Some(new)) => {
+                old.attrs != new.attrs || old.route_type != new.route_type
+            }
+        };
+
+        if !changed {
+            continue;
+        }
+
+        if let Some(old_route) = dest.aggregate.take() {
+            attr_sets.remove_route_attr_sets(&old_route.attrs);
+        }
+        dest.aggregate = aggregate_route.map(Box::new);
+
+        let best_route =
+            best_path::<A>(dest, local_asn, &table.nht, selection_cfg);
+        loc_rib_update::<A>(
+            aggregate_prefix,
+            dest,
+            best_route.clone(),
+            attr_sets,
+            selection_cfg,
+            mpath_cfg,
+            distance_cfg,
+            trace_opts,
+            ibus_tx,
+        );
+
+        affected.insert(aggregate_prefix);
+        for (prefix, _) in contributors {
+            affected.insert(prefix);
+        }
+    }
+
+    affected
+}
+
+pub(crate) fn aggregate_suppresses<A>(
+    table: &RoutingTable<A>,
+    aggregates: &BTreeMap<IpNetwork, AggregateCfg>,
+    prefix: A::IpNetwork,
+) -> bool
+where
+    A: AddressFamily,
+{
+    aggregates.iter().any(|(aggregate_prefix, aggregate_cfg)| {
+        if !aggregate_cfg.summary_only {
+            return false;
+        }
+
+        let Some(aggregate_prefix) = A::IpNetwork::get(*aggregate_prefix)
+        else {
+            return false;
+        };
+        if !is_more_specific::<A>(aggregate_prefix, prefix) {
+            return false;
+        }
+
+        table
+            .prefixes
+            .get(&aggregate_prefix)
+            .and_then(|dest| dest.local.as_ref())
+            .is_some_and(|route| route.origin.is_aggregate())
+    })
+}
+
+pub(crate) fn aggregate_reeval_prefixes<A>(
+    table: &RoutingTable<A>,
+    aggregates: &BTreeMap<IpNetwork, AggregateCfg>,
+) -> BTreeSet<A::IpNetwork>
+where
+    A: AddressFamily,
+{
+    if aggregates.is_empty() {
+        return BTreeSet::new();
+    }
+
+    table
+        .prefixes
+        .iter()
+        .filter_map(|(prefix, dest)| dest.local.as_ref().map(|_| prefix))
+        .collect()
+}
+
+fn aggregate_contributors<A>(
+    table: &RoutingTable<A>,
+    aggregate_prefix: A::IpNetwork,
+) -> Vec<(A::IpNetwork, LocalRoute)>
+where
+    A: AddressFamily,
+{
+    table
+        .prefixes
+        .iter()
+        .filter(|(prefix, _)| is_more_specific::<A>(aggregate_prefix, *prefix))
+        .filter_map(|(prefix, dest)| {
+            let route = dest.local.as_deref()?;
+            (!route.origin.is_aggregate()).then_some((prefix, route.clone()))
+        })
+        .collect()
+}
+
+fn aggregate_route<'a>(
+    contributors: impl Iterator<Item = &'a LocalRoute>,
+    aggregate_cfg: &AggregateCfg,
+    local_asn: u32,
+    router_id: Ipv4Addr,
+    attr_sets: &mut AttrSetsCxt,
+) -> Route {
+    let mut contributor_asns = BTreeSet::new();
+    let mut path_info_lost = false;
+
+    for contributor in contributors {
+        let as_path = &contributor.attrs.base.value.as_path;
+        path_info_lost |= as_path.path_length() > 0;
+        contributor_asns.extend(as_path.iter());
+    }
+
+    let attrs = Attrs {
+        base: BaseAttrs {
+            origin: Origin::Incomplete,
+            as_path: if aggregate_cfg.as_set {
+                AsPath::from_set(contributor_asns)
+            } else {
+                AsPath::default()
+            },
+            aggregator: Some(Aggregator {
+                asn: local_asn,
+                identifier: router_id,
+            }),
+            atomic_aggregate: (path_info_lost && !aggregate_cfg.as_set)
+                .then_some(()),
+            ..Default::default()
+        },
+        ..Default::default()
+    };
+    let route_attrs = attr_sets.get_route_attr_sets(&attrs);
+    Route::new(RouteOrigin::Aggregate, route_attrs, RouteType::Internal)
+}
+
+fn is_more_specific<A>(aggregate: A::IpNetwork, prefix: A::IpNetwork) -> bool
+where
+    A: AddressFamily,
+{
+    if aggregate == prefix {
+        return false;
+    }
+
+    let aggregate: IpNetwork = aggregate.into();
+    let prefix: IpNetwork = prefix.into();
+    let aggregate_len = aggregate.prefix();
+    let prefix_len = prefix.prefix();
+    aggregate_len < prefix_len && aggregate.contains(prefix.ip())
 }
 
 pub(crate) fn attrs_tx_update<A>(
@@ -929,7 +1142,9 @@ pub(crate) fn nexthop_untrack<A>(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::packet::attribute::BaseAttrs;
+    use crate::packet::attribute::{AsPathSegmentType, BaseAttrs};
+    use ipnetwork::Ipv4Network;
+    use std::collections::VecDeque;
 
     fn make_route(
         origin: RouteOrigin,
@@ -968,6 +1183,48 @@ mod tests {
 
     fn local_origin() -> RouteOrigin {
         RouteOrigin::Protocol(Protocol::STATIC)
+    }
+
+    fn test_attrs(as_path: AsPath) -> RouteAttrs {
+        RouteAttrs {
+            base: Arc::new(AttrSet {
+                index: 0,
+                value: BaseAttrs {
+                    as_path,
+                    ..Default::default()
+                },
+            }),
+            comm: None,
+            ext_comm: None,
+            extv6_comm: None,
+            large_comm: None,
+            unknown: None,
+        }
+    }
+
+    fn test_as_path(asns: impl IntoIterator<Item = u32>) -> AsPath {
+        AsPath {
+            segments: VecDeque::from([
+                crate::packet::attribute::AsPathSegment {
+                    seg_type: AsPathSegmentType::Sequence,
+                    members: asns.into_iter().collect(),
+                },
+            ]),
+        }
+    }
+
+    fn test_local_route(origin: RouteOrigin, as_path: AsPath) -> LocalRoute {
+        LocalRoute {
+            origin,
+            attrs: test_attrs(as_path),
+            route_type: RouteType::Internal,
+            last_modified: Instant::now(),
+            nexthops: None,
+        }
+    }
+
+    fn v4(prefix: &str) -> Ipv4Network {
+        prefix.parse().unwrap()
     }
 
     #[test]
@@ -1064,5 +1321,153 @@ mod tests {
             RouteCompare::Preferred(RouteRejectReason::PreferExternal) => {}
             other => panic!("expected PreferExternal, got {:?}", other),
         }
+    }
+
+    #[test]
+    fn aggregate_contributors_are_active_more_specifics_only() {
+        let mut table = RoutingTable::<Ipv4Unicast>::default();
+        table.prefixes.insert(
+            v4("10.0.0.0/8"),
+            Destination {
+                local: Some(Box::new(test_local_route(
+                    RouteOrigin::Aggregate,
+                    AsPath::default(),
+                ))),
+                ..Default::default()
+            },
+        );
+        table.prefixes.insert(
+            v4("10.1.0.0/16"),
+            Destination {
+                local: Some(Box::new(test_local_route(
+                    local_origin(),
+                    test_as_path([65001]),
+                ))),
+                ..Default::default()
+            },
+        );
+        table
+            .prefixes
+            .insert(v4("10.2.0.0/16"), Destination::default());
+        table.prefixes.insert(
+            v4("192.0.2.0/24"),
+            Destination {
+                local: Some(Box::new(test_local_route(
+                    local_origin(),
+                    test_as_path([65002]),
+                ))),
+                ..Default::default()
+            },
+        );
+
+        let contributors = aggregate_contributors(&table, v4("10.0.0.0/8"));
+        let prefixes = contributors
+            .into_iter()
+            .map(|(prefix, _)| prefix)
+            .collect::<Vec<_>>();
+
+        assert_eq!(prefixes, vec![v4("10.1.0.0/16")]);
+    }
+
+    #[test]
+    fn aggregate_route_sets_aggregator_and_atomic_without_as_set() {
+        let contributors = vec![
+            test_local_route(local_origin(), test_as_path([65001, 65002])),
+            test_local_route(local_origin(), test_as_path([65003])),
+        ];
+        let mut attr_sets = AttrSetsCxt::default();
+        let cfg = AggregateCfg {
+            summary_only: false,
+            as_set: false,
+        };
+
+        let route = aggregate_route(
+            contributors.iter(),
+            &cfg,
+            64496,
+            Ipv4Addr::new(192, 0, 2, 1),
+            &mut attr_sets,
+        );
+
+        let attrs = route.attrs.base.value.clone();
+        let aggregator = attrs.aggregator.unwrap();
+        assert_eq!(route.origin, RouteOrigin::Aggregate);
+        assert_eq!(aggregator.asn, 64496);
+        assert_eq!(aggregator.identifier, Ipv4Addr::new(192, 0, 2, 1));
+        assert!(attrs.atomic_aggregate.is_some());
+        assert!(attrs.as_path.segments.is_empty());
+    }
+
+    #[test]
+    fn aggregate_route_as_set_deduplicates_contributor_asns() {
+        let contributors = vec![
+            test_local_route(local_origin(), test_as_path([65001, 65002])),
+            test_local_route(local_origin(), test_as_path([65002, 65003])),
+        ];
+        let mut attr_sets = AttrSetsCxt::default();
+        let cfg = AggregateCfg {
+            summary_only: false,
+            as_set: true,
+        };
+
+        let route = aggregate_route(
+            contributors.iter(),
+            &cfg,
+            64496,
+            Ipv4Addr::new(192, 0, 2, 1),
+            &mut attr_sets,
+        );
+
+        let attrs = route.attrs.base.value.clone();
+        assert!(attrs.atomic_aggregate.is_none());
+        assert_eq!(attrs.as_path.segments.len(), 1);
+        let segment = attrs.as_path.segments.front().unwrap();
+        assert_eq!(segment.seg_type, AsPathSegmentType::Set);
+        assert_eq!(
+            segment.members.iter().copied().collect::<Vec<_>>(),
+            vec![65001, 65002, 65003]
+        );
+    }
+
+    #[test]
+    fn summary_only_suppresses_only_when_aggregate_is_active() {
+        let mut table = RoutingTable::<Ipv4Unicast>::default();
+        table.prefixes.insert(
+            v4("10.0.0.0/8"),
+            Destination {
+                local: Some(Box::new(test_local_route(
+                    RouteOrigin::Aggregate,
+                    AsPath::default(),
+                ))),
+                ..Default::default()
+            },
+        );
+        table.prefixes.insert(
+            v4("10.1.0.0/16"),
+            Destination {
+                local: Some(Box::new(test_local_route(
+                    local_origin(),
+                    test_as_path([65001]),
+                ))),
+                ..Default::default()
+            },
+        );
+        let aggregates = BTreeMap::from([(
+            IpNetwork::from(v4("10.0.0.0/8")),
+            AggregateCfg {
+                summary_only: true,
+                as_set: false,
+            },
+        )]);
+
+        assert!(aggregate_suppresses(&table, &aggregates, v4("10.1.0.0/16")));
+        assert!(!aggregate_suppresses(&table, &aggregates, v4("10.0.0.0/8")));
+
+        table.prefixes.get_mut(&v4("10.0.0.0/8")).unwrap().local = None;
+        assert!(!aggregate_suppresses(
+            &table,
+            &aggregates,
+            v4("10.1.0.0/16")
+        ));
     }
 }

--- a/holo-bgp/src/rib.rs
+++ b/holo-bgp/src/rib.rs
@@ -1141,10 +1141,12 @@ pub(crate) fn nexthop_untrack<A>(
 
 #[cfg(test)]
 mod tests {
+    use std::collections::VecDeque;
+
+    use ipnetwork::Ipv4Network;
+
     use super::*;
     use crate::packet::attribute::{AsPathSegmentType, BaseAttrs};
-    use ipnetwork::Ipv4Network;
-    use std::collections::VecDeque;
 
     fn make_route(
         origin: RouteOrigin,

--- a/holo-protocol/src/lib.rs
+++ b/holo-protocol/src/lib.rs
@@ -387,6 +387,34 @@ pub fn spawn_protocol_task<P>(
     ibus_instance_tx: IbusSender,
     ibus_instance_rx: IbusReceiver,
     agg_channels: InstanceAggChannels<P>,
+    shared: InstanceShared,
+) -> NbDaemonSender
+where
+    P: ProtocolInstance,
+{
+    #[cfg(feature = "testing")]
+    let (_test_tx, test_rx) = mpsc::channel(4);
+
+    spawn_protocol_task_inner::<P>(
+        name,
+        nb_provider_tx,
+        ibus_tx,
+        ibus_instance_tx,
+        ibus_instance_rx,
+        agg_channels,
+        #[cfg(feature = "testing")]
+        test_rx,
+        shared,
+    )
+}
+
+pub(crate) fn spawn_protocol_task_inner<P>(
+    name: String,
+    nb_provider_tx: &NbProviderSender,
+    ibus_tx: &IbusChannelsTx,
+    ibus_instance_tx: IbusSender,
+    ibus_instance_rx: IbusReceiver,
+    agg_channels: InstanceAggChannels<P>,
     #[cfg(feature = "testing")] test_rx: Receiver<
         TestMsg<P::ProtocolOutputMsg>,
     >,

--- a/holo-protocol/src/test/stub/mod.rs
+++ b/holo-protocol/src/test/stub/mod.rs
@@ -23,7 +23,7 @@ use crate::test::stub::northbound::NorthboundStub;
 use crate::test::{OutputChannelsRx, setup};
 use crate::{
     InstanceAggChannels, InstanceMsg, InstanceShared, ProtocolInstance,
-    spawn_protocol_task,
+    spawn_protocol_task_inner,
 };
 
 // Environment variable that controls if the test data needs to be updated or
@@ -277,7 +277,7 @@ where
     let channels = InstanceAggChannels::default();
     let instance_tx = channels.tx.clone();
     let (test_tx, test_rx) = mpsc::channel(4);
-    let nb_daemon_tx = spawn_protocol_task::<P>(
+    let nb_daemon_tx = spawn_protocol_task_inner::<P>(
         name.to_owned(),
         &nb_provider_tx,
         &ibus_tx,

--- a/holo-utils/src/task.rs
+++ b/holo-utils/src/task.rs
@@ -221,6 +221,15 @@ impl TimeoutTask {
         }
     }
 
+    #[cfg(feature = "testing")]
+    pub fn new<F, Fut>(_timeout: Duration, _cb: F) -> TimeoutTask
+    where
+        F: FnOnce() -> Fut + Send + 'static,
+        Fut: Future<Output = ()> + Send,
+    {
+        TimeoutTask {}
+    }
+
     /// Resets the timeout, regardless if it has already expired or not.
     ///
     /// If a new timeout value isn't specified, the last value will be reused.

--- a/holo-yang/modules/augmentations/holo-bgp.yang
+++ b/holo-yang/modules/augmentations/holo-bgp.yang
@@ -23,6 +23,10 @@ module holo-bgp {
     prefix bgp;
   }
 
+  import ietf-inet-types {
+    prefix inet;
+  }
+
   organization
     "Holo Routing Stack";
 
@@ -185,6 +189,32 @@ module holo-bgp {
   augment "/rt:routing/rt:control-plane-protocols/"
         + "rt:control-plane-protocol/bgp:bgp/bgp:global/"
         + "bgp:afi-safis/bgp:afi-safi/bgp:ipv4-unicast" {
+    list aggregate {
+      key "prefix";
+      description
+        "IPv4 aggregate route origination parameters.";
+
+      leaf prefix {
+        type inet:ipv4-prefix;
+        description
+          "Aggregate IPv4 prefix.";
+      }
+
+      leaf summary-only {
+        type boolean;
+        default "false";
+        description
+          "Suppress advertisement of contributing more-specific routes.";
+      }
+
+      leaf as-set {
+        type boolean;
+        default "false";
+        description
+          "Include contributor ASNs in an AS_SET segment.";
+      }
+    }
+
     list redistribution {
       key "type";
       description
@@ -205,6 +235,32 @@ module holo-bgp {
   augment "/rt:routing/rt:control-plane-protocols/"
         + "rt:control-plane-protocol/bgp:bgp/bgp:global/"
         + "bgp:afi-safis/bgp:afi-safi/bgp:ipv6-unicast" {
+    list aggregate {
+      key "prefix";
+      description
+        "IPv6 aggregate route origination parameters.";
+
+      leaf prefix {
+        type inet:ipv6-prefix;
+        description
+          "Aggregate IPv6 prefix.";
+      }
+
+      leaf summary-only {
+        type boolean;
+        default "false";
+        description
+          "Suppress advertisement of contributing more-specific routes.";
+      }
+
+      leaf as-set {
+        type boolean;
+        default "false";
+        description
+          "Include contributor ASNs in an AS_SET segment.";
+      }
+    }
+
     list redistribution {
       key "type";
       description


### PR DESCRIPTION
BGP route aggregation (`aggregate-address`).

- Per-AF `aggregate` config (via a `holo-bgp` augment on `ietf-bgp`): prefix + `summary-only` + `as-set`.
- The aggregate is originated when ≥1 active, strictly-more-specific contributor exists and withdrawn when the last one leaves; it is installed as a **blackhole/discard** route so traffic to non-covered destinations within it is dropped, not looped.
- `summary-only` suppresses the contributing more-specifics from advertisement while the aggregate is active (and un-suppresses otherwise).
- `as-set` builds a deduplicated AS_SET from the contributors' AS-paths.
- Attributes: **AGGREGATOR** (local AS + router-id); **ATOMIC_AGGREGATE** set only when aggregation loses AS-path info and `as-set` is off. Locally-originated aggregates never contribute to themselves.

Unit tests: contributor membership (active more-specifics only), summary-only suppression tied to aggregate activation, as-set dedup, and AGGREGATOR/ATOMIC_AGGREGATE correctness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
