### PR TITLE
bgp: ADD-PATH support for IPv4/IPv6 unicast (RFC 7911)

### DIFF
--- a/holo-bgp/src/af.rs
+++ b/holo-bgp/src/af.rs
@@ -139,8 +139,14 @@ impl AddressFamily for Ipv4Unicast {
             msgs.extend(
                 prefixes.into_iter().chunks(max as usize).into_iter().map(
                     |chunk| {
+                        let (prefixes, mut path_ids): (Vec<_>, Vec<_>) =
+                            chunk.unzip();
+                        if path_ids.iter().all(|path_id| *path_id == 0) {
+                            path_ids.clear();
+                        }
                         let reach = ReachNlri {
-                            prefixes: chunk.collect(),
+                            prefixes,
+                            path_ids,
                             nexthop,
                         };
                         Message::Update(UpdateMsg {
@@ -163,9 +169,12 @@ impl AddressFamily for Ipv4Unicast {
             msgs.extend(
                 unreach.into_iter().chunks(max as usize).into_iter().map(
                     |chunk| {
-                        let unreach = UnreachNlri {
-                            prefixes: chunk.collect(),
-                        };
+                        let (prefixes, mut path_ids): (Vec<_>, Vec<_>) =
+                            chunk.unzip();
+                        if path_ids.iter().all(|path_id| *path_id == 0) {
+                            path_ids.clear();
+                        }
+                        let unreach = UnreachNlri { prefixes, path_ids };
                         Message::Update(UpdateMsg {
                             reach: None,
                             unreach: Some(unreach),
@@ -276,8 +285,14 @@ impl AddressFamily for Ipv6Unicast {
             msgs.extend(
                 prefixes.into_iter().chunks(max as usize).into_iter().map(
                     |chunk| {
+                        let (prefixes, mut path_ids): (Vec<_>, Vec<_>) =
+                            chunk.unzip();
+                        if path_ids.iter().all(|path_id| *path_id == 0) {
+                            path_ids.clear();
+                        }
                         let mp_reach = MpReachNlri::Ipv6Unicast {
-                            prefixes: chunk.collect(),
+                            prefixes,
+                            path_ids,
                             nexthop,
                             ll_nexthop,
                         };
@@ -304,9 +319,13 @@ impl AddressFamily for Ipv6Unicast {
             msgs.extend(
                 unreach.into_iter().chunks(max as usize).into_iter().map(
                     |chunk| {
-                        let mp_unreach = MpUnreachNlri::Ipv6Unicast {
-                            prefixes: chunk.collect(),
-                        };
+                        let (prefixes, mut path_ids): (Vec<_>, Vec<_>) =
+                            chunk.unzip();
+                        if path_ids.iter().all(|path_id| *path_id == 0) {
+                            path_ids.clear();
+                        }
+                        let mp_unreach =
+                            MpUnreachNlri::Ipv6Unicast { prefixes, path_ids };
                         Message::Update(UpdateMsg {
                             reach: None,
                             unreach: None,

--- a/holo-bgp/src/events.rs
+++ b/holo-bgp/src/events.rs
@@ -4,6 +4,8 @@
 // SPDX-License-Identifier: MIT
 //
 
+use std::collections::hash_map::DefaultHasher;
+use std::hash::{Hash, Hasher};
 use std::net::IpAddr;
 
 use chrono::Utc;
@@ -27,7 +29,9 @@ use crate::packet::message::{
     Capability, Message, MpReachNlri, MpUnreachNlri, RouteRefreshMsg, UpdateMsg,
 };
 use crate::policy::RoutePolicyInfo;
-use crate::rib::{AttrSetsCxt, Rib, Route, RouteOrigin, RoutingTable};
+use crate::rib::{
+    AdjRibKey, AttrSetsCxt, Rib, Route, RouteOrigin, RoutingTable,
+};
 use crate::tasks::messages::output::PolicyApplyMsg;
 use crate::{network, rib};
 
@@ -167,7 +171,7 @@ fn process_nbr_update(
             process_nbr_reach_prefixes::<Ipv4Unicast>(
                 nbr,
                 rib,
-                reach.prefixes,
+                nlri_paths(reach.prefixes, reach.path_ids),
                 attrs,
                 instance.config.asn,
                 instance.shared,
@@ -178,7 +182,7 @@ fn process_nbr_update(
             process_nbr_unreach_prefixes::<Ipv4Unicast>(
                 nbr,
                 rib,
-                reach.prefixes,
+                nlri_paths(reach.prefixes, reach.path_ids),
                 ibus_tx,
             );
         }
@@ -190,12 +194,16 @@ fn process_nbr_update(
     if let Some(mp_reach) = msg.mp_reach {
         if let Some(mut attrs) = msg.attrs {
             match mp_reach {
-                MpReachNlri::Ipv4Unicast { prefixes, nexthop } => {
+                MpReachNlri::Ipv4Unicast {
+                    prefixes,
+                    path_ids,
+                    nexthop,
+                } => {
                     attrs.base.nexthop = Some(nexthop.into());
                     process_nbr_reach_prefixes::<Ipv4Unicast>(
                         nbr,
                         rib,
-                        prefixes,
+                        nlri_paths(prefixes, path_ids),
                         attrs,
                         instance.config.asn,
                         instance.shared,
@@ -204,6 +212,7 @@ fn process_nbr_update(
                 }
                 MpReachNlri::Ipv6Unicast {
                     prefixes,
+                    path_ids,
                     nexthop,
                     ll_nexthop,
                 } => {
@@ -212,7 +221,7 @@ fn process_nbr_update(
                     process_nbr_reach_prefixes::<Ipv6Unicast>(
                         nbr,
                         rib,
-                        prefixes,
+                        nlri_paths(prefixes, path_ids),
                         attrs,
                         instance.config.asn,
                         instance.shared,
@@ -223,14 +232,24 @@ fn process_nbr_update(
         } else {
             // Treat as withdraw.
             match mp_reach {
-                MpReachNlri::Ipv4Unicast { prefixes, .. } => {
+                MpReachNlri::Ipv4Unicast {
+                    prefixes, path_ids, ..
+                } => {
                     process_nbr_unreach_prefixes::<Ipv4Unicast>(
-                        nbr, rib, prefixes, ibus_tx,
+                        nbr,
+                        rib,
+                        nlri_paths(prefixes, path_ids),
+                        ibus_tx,
                     );
                 }
-                MpReachNlri::Ipv6Unicast { prefixes, .. } => {
+                MpReachNlri::Ipv6Unicast {
+                    prefixes, path_ids, ..
+                } => {
                     process_nbr_unreach_prefixes::<Ipv6Unicast>(
-                        nbr, rib, prefixes, ibus_tx,
+                        nbr,
+                        rib,
+                        nlri_paths(prefixes, path_ids),
+                        ibus_tx,
                     );
                 }
             }
@@ -242,7 +261,7 @@ fn process_nbr_update(
         process_nbr_unreach_prefixes::<Ipv4Unicast>(
             nbr,
             rib,
-            unreach.prefixes,
+            nlri_paths(unreach.prefixes, unreach.path_ids),
             ibus_tx,
         );
     }
@@ -250,14 +269,20 @@ fn process_nbr_update(
     // Process multiprotocol unreachable NLRIs.
     if let Some(mp_unreach) = msg.mp_unreach {
         match mp_unreach {
-            MpUnreachNlri::Ipv4Unicast { prefixes } => {
+            MpUnreachNlri::Ipv4Unicast { prefixes, path_ids } => {
                 process_nbr_unreach_prefixes::<Ipv4Unicast>(
-                    nbr, rib, prefixes, ibus_tx,
+                    nbr,
+                    rib,
+                    nlri_paths(prefixes, path_ids),
+                    ibus_tx,
                 );
             }
-            MpUnreachNlri::Ipv6Unicast { prefixes } => {
+            MpUnreachNlri::Ipv6Unicast { prefixes, path_ids } => {
                 process_nbr_unreach_prefixes::<Ipv6Unicast>(
-                    nbr, rib, prefixes, ibus_tx,
+                    nbr,
+                    rib,
+                    nlri_paths(prefixes, path_ids),
+                    ibus_tx,
                 );
             }
         }
@@ -269,10 +294,21 @@ fn process_nbr_update(
     Ok(())
 }
 
+fn nlri_paths<T>(prefixes: Vec<T>, path_ids: Vec<u32>) -> Vec<(T, u32)> {
+    prefixes
+        .into_iter()
+        .enumerate()
+        .map(|(pos, prefix)| {
+            let path_id = path_ids.get(pos).copied().unwrap_or(0);
+            (prefix, path_id)
+        })
+        .collect()
+}
+
 fn process_nbr_reach_prefixes<A>(
     nbr: &Neighbor,
     rib: &mut Rib,
-    nlri_prefixes: Vec<A::IpNetwork>,
+    nlri_prefixes: Vec<(A::IpNetwork, u32)>,
     mut attrs: Attrs,
     local_asn: u32,
     shared: &InstanceShared,
@@ -304,9 +340,15 @@ fn process_nbr_reach_prefixes<A>(
     // Update pre-policy Adj-RIB-In routes.
     let table = A::table(&mut rib.tables);
     let route_attrs = rib.attr_sets.get_route_attr_sets(&attrs);
-    for prefix in &nlri_prefixes {
+    for (prefix, path_id) in &nlri_prefixes {
         let dest = table.prefixes.entry(*prefix).or_default();
-        let adj_rib = dest.adj_rib.entry(nbr.remote_addr).or_default();
+        let adj_rib = dest
+            .adj_rib
+            .entry(AdjRibKey {
+                remote_addr: nbr.remote_addr,
+                path_id: *path_id,
+            })
+            .or_default();
         let route = Route::new(origin, route_attrs.clone(), route_type);
         adj_rib.update_in_pre(Box::new(route), &mut rib.attr_sets);
     }
@@ -321,14 +363,16 @@ fn process_nbr_reach_prefixes<A>(
 
     // Enqueue import policy application.
     let rpinfo = RoutePolicyInfo::new(origin, route_type, None, None, attrs);
+    let path_ids = nlri_prefixes.iter().map(|(_, path_id)| *path_id).collect();
     let msg = PolicyApplyMsg::Neighbor {
         policy_type: PolicyType::Import,
         nbr_addr: nbr.remote_addr,
         afi_safi: A::AFI_SAFI,
         routes: nlri_prefixes
             .into_iter()
-            .map(|prefix| (prefix.into(), rpinfo.clone()))
+            .map(|(prefix, _)| (prefix.into(), rpinfo.clone()))
             .collect(),
+        path_ids,
         policies: apply_policy_cfg
             .import_policy
             .iter()
@@ -343,7 +387,7 @@ fn process_nbr_reach_prefixes<A>(
 fn process_nbr_unreach_prefixes<A>(
     nbr: &Neighbor,
     rib: &mut Rib,
-    nlri_prefixes: Vec<A::IpNetwork>,
+    nlri_prefixes: Vec<(A::IpNetwork, u32)>,
     ibus_tx: &IbusChannelsTx,
 ) where
     A: AddressFamily,
@@ -355,11 +399,15 @@ fn process_nbr_unreach_prefixes<A>(
 
     // Remove routes from Adj-RIB-In.
     let table = A::table(&mut rib.tables);
-    for prefix in nlri_prefixes {
+    for (prefix, path_id) in nlri_prefixes {
         let Some(dest) = table.prefixes.get_mut(&prefix) else {
             continue;
         };
-        let Some(adj_rib) = dest.adj_rib.get_mut(&nbr.remote_addr) else {
+        let key = AdjRibKey {
+            remote_addr: nbr.remote_addr,
+            path_id,
+        };
+        let Some(adj_rib) = dest.adj_rib.get_mut(&key) else {
             continue;
         };
 
@@ -445,6 +493,7 @@ pub(crate) fn process_nbr_policy_import<A>(
     neighbors: &mut Neighbors,
     nbr_addr: IpAddr,
     prefixes: Vec<(IpNetwork, PolicyResult<RoutePolicyInfo>)>,
+    path_ids: Vec<u32>,
 ) -> Result<(), Error>
 where
     A: AddressFamily,
@@ -459,11 +508,18 @@ where
 
     let rib = &mut instance.state.rib;
     let table = A::table(&mut rib.tables);
-    for (prefix, result) in prefixes {
+    for (pos, (prefix, result)) in prefixes.into_iter().enumerate() {
+        let path_id = path_ids.get(pos).copied().unwrap_or(0);
         // Get RIB destination.
         let prefix = A::IpNetwork::get(prefix).unwrap();
         let dest = table.prefixes.entry(prefix).or_default();
-        let adj_rib = dest.adj_rib.entry(nbr.remote_addr).or_default();
+        let adj_rib = dest
+            .adj_rib
+            .entry(AdjRibKey {
+                remote_addr: nbr.remote_addr,
+                path_id,
+            })
+            .or_default();
 
         // Update post-policy Adj-RIB-In routes.
         match result {
@@ -522,6 +578,7 @@ pub(crate) fn process_nbr_policy_export<A>(
     neighbors: &mut Neighbors,
     nbr_addr: IpAddr,
     prefixes: Vec<(IpNetwork, PolicyResult<RoutePolicyInfo>)>,
+    path_ids: Vec<u32>,
 ) -> Result<(), Error>
 where
     A: AddressFamily,
@@ -536,11 +593,18 @@ where
 
     let rib = &mut instance.state.rib;
     let table = A::table(&mut rib.tables);
-    for (prefix, result) in prefixes {
+    for (pos, (prefix, result)) in prefixes.into_iter().enumerate() {
+        let path_id = path_ids.get(pos).copied().unwrap_or(0);
         // Get RIB destination.
         let prefix = A::IpNetwork::get(prefix).unwrap();
         let dest = table.prefixes.entry(prefix).or_default();
-        let adj_rib = dest.adj_rib.entry(nbr.remote_addr).or_default();
+        let adj_rib = dest
+            .adj_rib
+            .entry(AdjRibKey {
+                remote_addr: nbr.remote_addr,
+                path_id,
+            })
+            .or_default();
 
         // Update post-policy Adj-RIB-Out routes.
         match result {
@@ -573,14 +637,18 @@ where
 
                     // Update neighbor's Tx queue.
                     let update_queue = A::update_queue(&mut nbr.update_queues);
-                    update_queue.reach.entry(attrs).or_default().insert(prefix);
+                    update_queue
+                        .reach
+                        .entry(attrs)
+                        .or_default()
+                        .insert((prefix, path_id));
                 }
             }
             PolicyResult::Reject => {
                 if adj_rib.remove_out_post(&mut rib.attr_sets).is_some() {
                     // Update neighbor's Tx queue.
                     let update_queue = A::update_queue(&mut nbr.update_queues);
-                    update_queue.unreach.insert(prefix);
+                    update_queue.unreach.insert((prefix, path_id));
                 }
             }
         }
@@ -663,6 +731,13 @@ where
         .map(|afi_safi| &afi_safi.multipath)
         .unwrap_or(&instance.config.multipath);
 
+    let global_add_path_send_all = instance
+        .config
+        .afi_safi
+        .get(&A::AFI_SAFI)
+        .map(|afi_safi| afi_safi.add_path.send_all)
+        .unwrap_or(false);
+
     // Phase 2: Route Selection.
     //
     // Process each queued destination in the RIB.
@@ -717,12 +792,15 @@ where
         //
         // Any routes that fail to meet the distribution criteria are marked
         // as unreachable to ensure previous advertisements are withdrawn.
-        let mut nbr_unreach = unreach.clone();
-        let mut nbr_reach = reach.clone();
+        let add_path_all =
+            add_path_send_all_enabled::<A>(nbr, global_add_path_send_all);
+        let mut nbr_unreach =
+            unreach_routes::<A>(nbr, table, &unreach, add_path_all);
+        let mut nbr_reach = add_path_routes::<A>(table, &reach, add_path_all);
         nbr_unreach.extend(
             nbr_reach
-                .extract_if(.., |(_, route)| !nbr.distribute_filter(route))
-                .map(|(prefix, _)| prefix),
+                .extract_if(.., |(_, _, route)| !nbr.distribute_filter(route))
+                .map(|(prefix, path_id, _)| (prefix, path_id)),
         );
 
         // Withdraw unfeasible routes immediately.
@@ -770,25 +848,137 @@ where
     Ok(())
 }
 
+fn add_path_routes<A>(
+    table: &mut RoutingTable<A>,
+    best_routes: &[(A::IpNetwork, Box<Route>)],
+    add_path_all: bool,
+) -> Vec<(A::IpNetwork, u32, Box<Route>)>
+where
+    A: AddressFamily,
+{
+    if !add_path_all {
+        return best_routes
+            .iter()
+            .map(|(prefix, route)| (*prefix, 0, route.clone()))
+            .collect();
+    }
+
+    let mut routes = Vec::new();
+    for (prefix, _) in best_routes {
+        let Some(dest) = table.prefixes.get(prefix) else {
+            continue;
+        };
+
+        if let Some(local_route) = &dest.local {
+            routes.push((
+                *prefix,
+                0,
+                Box::new(Route {
+                    origin: local_route.origin,
+                    attrs: local_route.attrs.clone(),
+                    route_type: local_route.route_type,
+                    igp_cost: None,
+                    last_modified: local_route.last_modified,
+                    ineligible_reason: None,
+                    reject_reason: None,
+                }),
+            ));
+        }
+
+        for (key, adj_rib) in &dest.adj_rib {
+            let Some(route) = adj_rib.in_post() else {
+                continue;
+            };
+            if !route.is_eligible() {
+                continue;
+            }
+
+            let mut hasher = DefaultHasher::new();
+            key.remote_addr.hash(&mut hasher);
+            key.path_id.hash(&mut hasher);
+            let mut path_id = hasher.finish() as u32;
+            if path_id == 0 {
+                path_id = 1;
+            }
+            routes.push((*prefix, path_id, Box::new(route.clone())));
+        }
+    }
+
+    routes
+}
+
+fn unreach_routes<A>(
+    nbr: &Neighbor,
+    table: &mut RoutingTable<A>,
+    prefixes: &[A::IpNetwork],
+    add_path_all: bool,
+) -> Vec<(A::IpNetwork, u32)>
+where
+    A: AddressFamily,
+{
+    let mut routes = Vec::new();
+    for prefix in prefixes {
+        if add_path_all {
+            if let Some(dest) = table.prefixes.get(prefix) {
+                let pos = routes.len();
+                for (key, adj_rib) in &dest.adj_rib {
+                    if key.remote_addr == nbr.remote_addr
+                        && adj_rib.out_post().is_some()
+                    {
+                        routes.push((*prefix, key.path_id));
+                    }
+                }
+                if routes.len() != pos {
+                    continue;
+                }
+            }
+        }
+        routes.push((*prefix, 0));
+    }
+
+    routes
+}
+
+pub(crate) fn add_path_send_all_enabled<A>(
+    nbr: &Neighbor,
+    global_add_path_send_all: bool,
+) -> bool
+where
+    A: AddressFamily,
+{
+    let neighbor_add_path = nbr.config.add_path;
+    let send_all = if neighbor_add_path.receive || neighbor_add_path.send_all {
+        neighbor_add_path.send_all
+    } else {
+        global_add_path_send_all
+    };
+
+    nbr.add_path_tx_negotiated(A::AFI, A::SAFI) && send_all
+}
+
 fn withdraw_routes<A>(
     nbr: &mut Neighbor,
     table: &mut RoutingTable<A>,
-    routes: &[A::IpNetwork],
+    routes: &[(A::IpNetwork, u32)],
     attr_sets: &mut AttrSetsCxt,
 ) where
     A: AddressFamily,
 {
     // Update Adj-RIB-Out.
-    for prefix in routes {
+    for (prefix, path_id) in routes {
         let dest = table.prefixes.get_mut(prefix).unwrap();
-        let Some(adj_rib) = dest.adj_rib.get_mut(&nbr.remote_addr) else {
+        let key = AdjRibKey {
+            remote_addr: nbr.remote_addr,
+            path_id: *path_id,
+        };
+        let Some(adj_rib) = dest.adj_rib.get_mut(&key) else {
             continue;
         };
 
         adj_rib.remove_out_pre(attr_sets);
         if adj_rib.remove_out_post(attr_sets).is_some() {
             let update_queue = A::update_queue(&mut nbr.update_queues);
-            update_queue.unreach.insert(*prefix);
+            update_queue.unreach.insert((*prefix, key.path_id));
         }
     }
 
@@ -802,7 +992,7 @@ fn withdraw_routes<A>(
 pub(crate) fn advertise_routes<A>(
     nbr: &mut Neighbor,
     table: &mut RoutingTable<A>,
-    routes: Vec<(A::IpNetwork, Box<Route>)>,
+    routes: Vec<(A::IpNetwork, u32, Box<Route>)>,
     shared: &InstanceShared,
     attr_sets: &mut AttrSetsCxt,
     policy_apply_tasks: &PolicyApplyTasks,
@@ -810,9 +1000,15 @@ pub(crate) fn advertise_routes<A>(
     A: AddressFamily,
 {
     // Update pre-policy Adj-RIB-Out routes.
-    for (prefix, route) in &routes {
+    for (prefix, path_id, route) in &routes {
         let dest = table.prefixes.get_mut(prefix).unwrap();
-        let adj_rib = dest.adj_rib.entry(nbr.remote_addr).or_default();
+        let adj_rib = dest
+            .adj_rib
+            .entry(AdjRibKey {
+                remote_addr: nbr.remote_addr,
+                path_id: *path_id,
+            })
+            .or_default();
         adj_rib.update_out_pre(route.clone(), attr_sets);
     }
 
@@ -825,9 +1021,13 @@ pub(crate) fn advertise_routes<A>(
         .unwrap_or(&nbr.config.apply_policy);
 
     // Enqueue export policy application.
+    let mut path_ids = Vec::with_capacity(routes.len());
     let routes = routes
         .into_iter()
-        .map(|(prefix, route)| (prefix.into(), route.policy_info()))
+        .map(|(prefix, path_id, route)| {
+            path_ids.push(path_id);
+            (prefix.into(), route.policy_info())
+        })
         .collect::<Vec<_>>();
     if !routes.is_empty() {
         let msg = PolicyApplyMsg::Neighbor {
@@ -835,6 +1035,7 @@ pub(crate) fn advertise_routes<A>(
             nbr_addr: nbr.remote_addr,
             afi_safi: A::AFI_SAFI,
             routes,
+            path_ids,
             policies: apply_policy_cfg
                 .export_policy
                 .iter()

--- a/holo-bgp/src/instance.rs
+++ b/holo-bgp/src/instance.rs
@@ -534,25 +534,26 @@ fn process_protocol_msg(
                 afi_safi,
                 nbr_addr,
                 routes,
+                path_ids,
             } => match (policy_type, afi_safi) {
                 (PolicyType::Import, AfiSafi::Ipv4Unicast) => {
                     events::process_nbr_policy_import::<Ipv4Unicast>(
-                        instance, neighbors, nbr_addr, routes,
+                        instance, neighbors, nbr_addr, routes, path_ids,
                     )?
                 }
                 (PolicyType::Import, AfiSafi::Ipv6Unicast) => {
                     events::process_nbr_policy_import::<Ipv6Unicast>(
-                        instance, neighbors, nbr_addr, routes,
+                        instance, neighbors, nbr_addr, routes, path_ids,
                     )?
                 }
                 (PolicyType::Export, AfiSafi::Ipv4Unicast) => {
                     events::process_nbr_policy_export::<Ipv4Unicast>(
-                        instance, neighbors, nbr_addr, routes,
+                        instance, neighbors, nbr_addr, routes, path_ids,
                     )?
                 }
                 (PolicyType::Export, AfiSafi::Ipv6Unicast) => {
                     events::process_nbr_policy_export::<Ipv6Unicast>(
-                        instance, neighbors, nbr_addr, routes,
+                        instance, neighbors, nbr_addr, routes, path_ids,
                     )?
                 }
             },

--- a/holo-bgp/src/neighbor.rs
+++ b/holo-bgp/src/neighbor.rs
@@ -33,10 +33,11 @@ use crate::packet::iana::{
     Afi, CeaseSubcode, ErrorCode, FsmErrorSubcode, Safi,
 };
 use crate::packet::message::{
-    Capability, DecodeCxt, EncodeCxt, KeepaliveMsg, Message,
-    NegotiatedCapability, NotificationMsg, OpenMsg, RouteRefreshMsg,
+    AddPathMode, AddPathTuple, Capability, DecodeCxt, EncodeCxt, KeepaliveMsg,
+    Message, NegotiatedCapability, NotificationMsg, OpenMsg, RouteRefreshMsg,
+    negotiate_capabilities,
 };
-use crate::rib::{Rib, Route, RouteOrigin};
+use crate::rib::{AdjRibKey, Rib, Route, RouteOrigin};
 #[cfg(feature = "testing")]
 use crate::tasks::messages::ProtocolOutputMsg;
 use crate::tasks::messages::input::{NbrTimerMsg, TcpConnectMsg};
@@ -118,8 +119,8 @@ pub struct NeighborUpdateQueues {
 // Neighbor Tx update queue.
 #[derive(Debug)]
 pub struct NeighborUpdateQueue<A: AddressFamily> {
-    pub reach: BTreeMap<Attrs, BTreeSet<A::IpNetwork>>,
-    pub unreach: BTreeSet<A::IpNetwork>,
+    pub reach: BTreeMap<Attrs, BTreeSet<(A::IpNetwork, u32)>>,
+    pub unreach: BTreeSet<(A::IpNetwork, u32)>,
 }
 
 // Type aliases.
@@ -520,6 +521,7 @@ impl Neighbor {
     ) {
         // Store TCP connection information.
         self.conn_info = Some(conn_info);
+        let capabilities_adv = self.advertised_capabilities(instance.config);
 
         // Split TCP stream into two halves.
         let (read_half, write_half) = stream.into_split();
@@ -544,6 +546,7 @@ impl Neighbor {
             peer_type: self.peer_type,
             peer_as: self.config.peer_as,
             reject_as_sets: instance.config.reject_as_sets,
+            capabilities_adv,
             capabilities: Default::default(),
         };
         let tcp_rx_task = tasks::nbr_rx(
@@ -563,20 +566,10 @@ impl Neighbor {
     // Initializes the BGP session.
     fn session_init(&mut self, instance: &mut InstanceUpView<'_>) {
         // Compute the negotiated capabilities.
-        self.capabilities_nego = self
-            .capabilities_adv
-            .iter()
-            .map(|cap| cap.as_negotiated())
-            .collect::<BTreeSet<_>>()
-            .intersection(
-                &self
-                    .capabilities_rcvd
-                    .iter()
-                    .map(|cap| cap.as_negotiated())
-                    .collect::<BTreeSet<_>>(),
-            )
-            .cloned()
-            .collect();
+        self.capabilities_nego = negotiate_capabilities(
+            &self.capabilities_adv,
+            &self.capabilities_rcvd,
+        );
 
         // Update the Tx task with the negotiated capabilities.
         let msg = NbrTxMsg::UpdateCapabilities(self.capabilities_nego.clone());
@@ -669,32 +662,7 @@ impl Neighbor {
 
     // Sends a BGP OPEN message based on the local configuration.
     fn open_send(&mut self, instance_cfg: &InstanceCfg, identifier: Ipv4Addr) {
-        // Base capabilities.
-        let mut capabilities: BTreeSet<_> = [
-            Capability::RouteRefresh,
-            Capability::FourOctetAsNumber {
-                asn: instance_cfg.asn,
-            },
-        ]
-        .into();
-
-        // Multiprotocol capabilities.
-        if let Some(afi_safi) = self.config.afi_safi.get(&AfiSafi::Ipv4Unicast)
-            && afi_safi.enabled
-        {
-            capabilities.insert(Capability::MultiProtocol {
-                afi: Afi::Ipv4,
-                safi: Safi::Unicast,
-            });
-        }
-        if let Some(afi_safi) = self.config.afi_safi.get(&AfiSafi::Ipv6Unicast)
-            && afi_safi.enabled
-        {
-            capabilities.insert(Capability::MultiProtocol {
-                afi: Afi::Ipv6,
-                safi: Safi::Unicast,
-            });
-        }
+        let capabilities = self.advertised_capabilities(instance_cfg);
 
         // Keep track of the advertised capabilities.
         self.capabilities_adv.clone_from(&capabilities);
@@ -708,6 +676,97 @@ impl Neighbor {
             capabilities,
         });
         self.message_send(msg);
+    }
+
+    fn advertised_capabilities(
+        &self,
+        instance_cfg: &InstanceCfg,
+    ) -> BTreeSet<Capability> {
+        // Base capabilities.
+        let mut capabilities: BTreeSet<_> = [
+            Capability::RouteRefresh,
+            Capability::FourOctetAsNumber {
+                asn: instance_cfg.asn,
+            },
+        ]
+        .into();
+
+        let mut add_path_tuples = BTreeSet::new();
+
+        // Multiprotocol capabilities.
+        if let Some(afi_safi) = self.config.afi_safi.get(&AfiSafi::Ipv4Unicast)
+            && afi_safi.enabled
+        {
+            capabilities.insert(Capability::MultiProtocol {
+                afi: Afi::Ipv4,
+                safi: Safi::Unicast,
+            });
+            if let Some(mode) =
+                self.add_path_mode(AfiSafi::Ipv4Unicast, instance_cfg)
+            {
+                add_path_tuples.insert(AddPathTuple {
+                    afi: Afi::Ipv4,
+                    safi: Safi::Unicast,
+                    mode,
+                });
+            }
+        }
+        if let Some(afi_safi) = self.config.afi_safi.get(&AfiSafi::Ipv6Unicast)
+            && afi_safi.enabled
+        {
+            capabilities.insert(Capability::MultiProtocol {
+                afi: Afi::Ipv6,
+                safi: Safi::Unicast,
+            });
+            if let Some(mode) =
+                self.add_path_mode(AfiSafi::Ipv6Unicast, instance_cfg)
+            {
+                add_path_tuples.insert(AddPathTuple {
+                    afi: Afi::Ipv6,
+                    safi: Safi::Unicast,
+                    mode,
+                });
+            }
+        }
+
+        if !add_path_tuples.is_empty() {
+            capabilities.insert(Capability::AddPath(add_path_tuples));
+        }
+
+        capabilities
+    }
+
+    fn add_path_mode(
+        &self,
+        afi_safi: AfiSafi,
+        instance_cfg: &InstanceCfg,
+    ) -> Option<AddPathMode> {
+        let cfg = self.add_path_cfg(afi_safi, instance_cfg);
+        AddPathMode::from_directions(cfg.receive, cfg.send_all)
+    }
+
+    fn add_path_cfg(
+        &self,
+        afi_safi: AfiSafi,
+        instance_cfg: &InstanceCfg,
+    ) -> crate::northbound::configuration::AddPathCfg {
+        let global_cfg = instance_cfg
+            .afi_safi
+            .get(&afi_safi)
+            .map(|afi_safi| afi_safi.add_path);
+        if self.config.add_path.receive || self.config.add_path.send_all {
+            self.config.add_path
+        } else if let Some(cfg) = global_cfg {
+            cfg
+        } else {
+            self.config.add_path
+        }
+    }
+
+    pub(crate) fn add_path_tx_negotiated(&self, afi: Afi, safi: Safi) -> bool {
+        self.capabilities_nego
+            .iter()
+            .any(|cap| cap.add_path_tx(afi, safi))
     }
 
     // Processes the received OPEN message while in the OpenSent state.
@@ -922,10 +981,10 @@ impl Neighbor {
                         ineligible_reason: None,
                         reject_reason: None,
                     };
-                    (prefix, Box::new(route))
+                    (prefix, 0, Box::new(route))
                 })
             })
-            .filter(|(_, route)| self.distribute_filter(route))
+            .filter(|(_, _, route)| self.distribute_filter(route))
             .collect::<Vec<_>>();
 
         // Advertise the best routes.
@@ -946,27 +1005,46 @@ impl Neighbor {
     ) where
         A: AddressFamily,
     {
+        let global_add_path_send_all = instance
+            .config
+            .afi_safi
+            .get(&A::AFI_SAFI)
+            .map(|afi_safi| afi_safi.add_path.send_all)
+            .unwrap_or_default();
+        let add_path_all = events::add_path_send_all_enabled::<A>(
+            self,
+            global_add_path_send_all,
+        );
         let table = A::table(&mut instance.state.rib.tables);
         for (prefix, dest) in &table.prefixes {
-            let Some(adj_rib) = dest.adj_rib.get(&self.remote_addr) else {
-                continue;
-            };
-            let Some(route) = adj_rib.out_post() else {
-                continue;
-            };
+            for (key, adj_rib) in &dest.adj_rib {
+                if key.remote_addr != self.remote_addr {
+                    continue;
+                }
+                if !add_path_all && key.path_id != 0 {
+                    continue;
+                }
+                let Some(route) = adj_rib.out_post() else {
+                    continue;
+                };
 
-            // Update route's attributes before transmission.
-            let mut attrs = route.attrs.get();
-            rib::attrs_tx_update::<A>(
-                &mut attrs,
-                self,
-                instance.config.asn,
-                route.origin.is_local(),
-            );
+                // Update route's attributes before transmission.
+                let mut attrs = route.attrs.get();
+                rib::attrs_tx_update::<A>(
+                    &mut attrs,
+                    self,
+                    instance.config.asn,
+                    route.origin.is_local(),
+                );
 
-            // Update neighbor's Tx queue.
-            let update_queue = A::update_queue(&mut self.update_queues);
-            update_queue.reach.entry(attrs).or_default().insert(prefix);
+                // Update neighbor's Tx queue.
+                let update_queue = A::update_queue(&mut self.update_queues);
+                update_queue
+                    .reach
+                    .entry(attrs)
+                    .or_default()
+                    .insert((prefix, key.path_id));
+            }
         }
     }
 
@@ -978,7 +1056,14 @@ impl Neighbor {
         let table = A::table(&mut rib.tables);
         for (prefix, dest) in table.prefixes.iter_mut() {
             // Clear the Adj-RIB-In and Adj-RIB-Out.
-            if let Some(mut adj_rib) = dest.adj_rib.remove(&self.remote_addr) {
+            let keys = dest
+                .adj_rib
+                .keys()
+                .filter(|key| key.remote_addr == self.remote_addr)
+                .copied()
+                .collect::<Vec<_>>();
+            for key in keys {
+                let mut adj_rib = dest.adj_rib.remove(&key).unwrap();
                 // Update nexthop tracking.
                 if let Some(adj_in_route) = adj_rib.in_post() {
                     rib::nexthop_untrack(

--- a/holo-bgp/src/network.rs
+++ b/holo-bgp/src/network.rs
@@ -4,7 +4,6 @@
 // SPDX-License-Identifier: MIT
 //
 
-use std::collections::BTreeSet;
 use std::net::{IpAddr, SocketAddr};
 use std::sync::Arc;
 
@@ -19,7 +18,9 @@ use tokio::sync::mpsc::error::SendError;
 use tokio::sync::mpsc::{Sender, UnboundedReceiver};
 
 use crate::error::{Error, IoError, NbrRxError};
-use crate::packet::message::{DecodeCxt, EncodeCxt, Message};
+use crate::packet::message::{
+    DecodeCxt, EncodeCxt, Message, negotiate_capabilities,
+};
 use crate::tasks::messages::input::{NbrRxMsg, TcpAcceptMsg};
 use crate::tasks::messages::output::NbrTxMsg;
 
@@ -270,12 +271,10 @@ pub(crate) async fn nbr_read_loop(
             // Keep track of received capabilities as they influence how some
             // messages should be decoded.
             if let Ok(Message::Open(msg)) = &msg {
-                let capabilities = msg
-                    .capabilities
-                    .iter()
-                    .map(|cap| cap.as_negotiated())
-                    .collect::<BTreeSet<_>>();
-                cxt.capabilities = capabilities;
+                cxt.capabilities = negotiate_capabilities(
+                    &cxt.capabilities_adv,
+                    &msg.capabilities,
+                );
             }
 
             // Notify that the BGP message was received.

--- a/holo-bgp/src/northbound/configuration.rs
+++ b/holo-bgp/src/northbound/configuration.rs
@@ -1699,7 +1699,10 @@ impl Provider for Instance {
                     let nbr_trace_opts = &nbr.config.trace_opts;
                     let instance_trace_opts = &self.config.trace_opts;
 
-                    let disabled = TraceOptionPacketType { tx: false, rx: false };
+                    let disabled = TraceOptionPacketType {
+                        tx: false,
+                        rx: false,
+                    };
                     let open = nbr_trace_opts
                         .packets
                         .open
@@ -1825,7 +1828,10 @@ impl Default for DistanceCfg {
         let external = bgp::global::distance::external::DFLT;
         let internal = bgp::global::distance::internal::DFLT;
 
-        DistanceCfg { external, internal }
+        DistanceCfg {
+            external,
+            internal,
+        }
     }
 }
 
@@ -1970,7 +1976,10 @@ impl Default for AsPathOptions {
 
 impl Default for TraceOptionPacketResolved {
     fn default() -> TraceOptionPacketResolved {
-        let disabled = TraceOptionPacketType { tx: false, rx: false };
+        let disabled = TraceOptionPacketType {
+            tx: false,
+            rx: false,
+        };
         TraceOptionPacketResolved {
             open: disabled,
             update: disabled,
@@ -1986,6 +1995,9 @@ impl Default for TraceOptionPacketType {
         let tx = bgp::global::trace_options::flag::send::DFLT;
         let rx = bgp::global::trace_options::flag::receive::DFLT;
 
-        TraceOptionPacketType { tx, rx }
+        TraceOptionPacketType {
+            tx,
+            rx,
+        }
     }
 }

--- a/holo-bgp/src/northbound/configuration.rs
+++ b/holo-bgp/src/northbound/configuration.rs
@@ -91,6 +91,7 @@ pub struct MultipathCfg {
 #[derive(Debug)]
 pub struct InstanceAfiSafiCfg {
     pub enabled: bool,
+    pub add_path: AddPathCfg,
     pub multipath: MultipathCfg,
     pub route_selection: RouteSelectionCfg,
     pub prefix_limit: PrefixLimitCfg,
@@ -131,6 +132,7 @@ pub struct NeighborCfg {
     pub timers: NeighborTimersCfg,
     pub transport: NeighborTransportCfg,
     pub log_neighbor_state_changes: bool,
+    pub add_path: AddPathCfg,
     pub as_path_options: AsPathOptions,
     pub apply_policy: ApplyPolicyCfg,
     pub prefix_limit: PrefixLimitCfg,
@@ -163,6 +165,7 @@ pub struct NeighborTransportCfg {
 #[derive(Debug)]
 pub struct NeighborAfiSafiCfg {
     pub enabled: bool,
+    pub add_path: AddPathCfg,
     pub prefix_limit: PrefixLimitCfg,
     pub send_default_route: bool,
     pub apply_policy: ApplyPolicyCfg,
@@ -212,6 +215,12 @@ pub struct AsPathOptions {
     pub allow_own_as: u8,
     pub replace_peer_as: bool,
     pub disable_peer_as_filter: bool,
+}
+
+#[derive(Clone, Copy, Debug, Default)]
+pub struct AddPathCfg {
+    pub receive: bool,
+    pub send_all: bool,
 }
 
 #[derive(Debug)]
@@ -392,6 +401,56 @@ fn load_callbacks() -> Callbacks<Instance> {
 
             let enable = args.dnode.get_bool();
             afi_safi.route_selection.enable_med = enable;
+        })
+        .path(bgp::global::afi_safis::afi_safi::add_paths::receive::PATH)
+        .modify_apply(|instance, args| {
+            let afi_safi = args.list_entry.into_afi_safi().unwrap();
+            let afi_safi = instance.config.afi_safi.get_mut(&afi_safi).unwrap();
+
+            afi_safi.add_path.receive = args.dnode.get_bool();
+
+            let event_queue = args.event_queue;
+            for nbr_addr in instance.neighbors.keys() {
+                let msg = NotificationMsg::new(ErrorCode::Cease, CeaseSubcode::OtherConfigurationChange);
+                event_queue.insert(Event::NeighborReset(*nbr_addr, msg));
+            }
+        })
+        .delete_apply(|instance, args| {
+            let afi_safi = args.list_entry.into_afi_safi().unwrap();
+            let afi_safi = instance.config.afi_safi.get_mut(&afi_safi).unwrap();
+
+            afi_safi.add_path.receive = bgp::global::afi_safis::afi_safi::add_paths::receive::DFLT;
+
+            let event_queue = args.event_queue;
+            for nbr_addr in instance.neighbors.keys() {
+                let msg = NotificationMsg::new(ErrorCode::Cease, CeaseSubcode::OtherConfigurationChange);
+                event_queue.insert(Event::NeighborReset(*nbr_addr, msg));
+            }
+        })
+        .path(bgp::global::afi_safis::afi_safi::add_paths::all::PATH)
+        .create_apply(|instance, args| {
+            let afi_safi = args.list_entry.into_afi_safi().unwrap();
+            let afi_safi = instance.config.afi_safi.get_mut(&afi_safi).unwrap();
+
+            afi_safi.add_path.send_all = true;
+
+            let event_queue = args.event_queue;
+            for nbr_addr in instance.neighbors.keys() {
+                let msg = NotificationMsg::new(ErrorCode::Cease, CeaseSubcode::OtherConfigurationChange);
+                event_queue.insert(Event::NeighborReset(*nbr_addr, msg));
+            }
+        })
+        .delete_apply(|instance, args| {
+            let afi_safi = args.list_entry.into_afi_safi().unwrap();
+            let afi_safi = instance.config.afi_safi.get_mut(&afi_safi).unwrap();
+
+            afi_safi.add_path.send_all = false;
+
+            let event_queue = args.event_queue;
+            for nbr_addr in instance.neighbors.keys() {
+                let msg = NotificationMsg::new(ErrorCode::Cease, CeaseSubcode::OtherConfigurationChange);
+                event_queue.insert(Event::NeighborReset(*nbr_addr, msg));
+            }
         })
         .path(bgp::global::afi_safis::afi_safi::use_multiple_paths::enabled::PATH)
         .modify_apply(|instance, args| {
@@ -1051,6 +1110,48 @@ fn load_callbacks() -> Callbacks<Instance> {
             let log = args.dnode.get_bool();
             nbr.config.log_neighbor_state_changes = log;
         })
+        .path(bgp::neighbors::neighbor::add_paths::receive::PATH)
+        .modify_apply(|instance, args| {
+            let nbr_addr = args.list_entry.into_neighbor().unwrap();
+            let nbr = instance.neighbors.get_mut(&nbr_addr).unwrap();
+
+            nbr.config.add_path.receive = args.dnode.get_bool();
+
+            let event_queue = args.event_queue;
+            let msg = NotificationMsg::new(ErrorCode::Cease, CeaseSubcode::OtherConfigurationChange);
+            event_queue.insert(Event::NeighborReset(nbr.remote_addr, msg));
+        })
+        .delete_apply(|instance, args| {
+            let nbr_addr = args.list_entry.into_neighbor().unwrap();
+            let nbr = instance.neighbors.get_mut(&nbr_addr).unwrap();
+
+            nbr.config.add_path.receive = bgp::neighbors::neighbor::add_paths::receive::DFLT;
+
+            let event_queue = args.event_queue;
+            let msg = NotificationMsg::new(ErrorCode::Cease, CeaseSubcode::OtherConfigurationChange);
+            event_queue.insert(Event::NeighborReset(nbr.remote_addr, msg));
+        })
+        .path(bgp::neighbors::neighbor::add_paths::all::PATH)
+        .create_apply(|instance, args| {
+            let nbr_addr = args.list_entry.into_neighbor().unwrap();
+            let nbr = instance.neighbors.get_mut(&nbr_addr).unwrap();
+
+            nbr.config.add_path.send_all = true;
+
+            let event_queue = args.event_queue;
+            let msg = NotificationMsg::new(ErrorCode::Cease, CeaseSubcode::OtherConfigurationChange);
+            event_queue.insert(Event::NeighborReset(nbr.remote_addr, msg));
+        })
+        .delete_apply(|instance, args| {
+            let nbr_addr = args.list_entry.into_neighbor().unwrap();
+            let nbr = instance.neighbors.get_mut(&nbr_addr).unwrap();
+
+            nbr.config.add_path.send_all = false;
+
+            let event_queue = args.event_queue;
+            let msg = NotificationMsg::new(ErrorCode::Cease, CeaseSubcode::OtherConfigurationChange);
+            event_queue.insert(Event::NeighborReset(nbr.remote_addr, msg));
+        })
         .path(bgp::neighbors::neighbor::as_path_options::allow_own_as::PATH)
         .modify_apply(|instance, args| {
             let nbr_addr = args.list_entry.into_neighbor().unwrap();
@@ -1598,10 +1699,7 @@ impl Provider for Instance {
                     let nbr_trace_opts = &nbr.config.trace_opts;
                     let instance_trace_opts = &self.config.trace_opts;
 
-                    let disabled = TraceOptionPacketType {
-                        tx: false,
-                        rx: false,
-                    };
+                    let disabled = TraceOptionPacketType { tx: false, rx: false };
                     let open = nbr_trace_opts
                         .packets
                         .open
@@ -1727,10 +1825,7 @@ impl Default for DistanceCfg {
         let external = bgp::global::distance::external::DFLT;
         let internal = bgp::global::distance::internal::DFLT;
 
-        DistanceCfg {
-            external,
-            internal,
-        }
+        DistanceCfg { external, internal }
     }
 }
 
@@ -1755,6 +1850,7 @@ impl Default for InstanceAfiSafiCfg {
         // TODO: fetch defaults from YANG module
         InstanceAfiSafiCfg {
             enabled: false,
+            add_path: Default::default(),
             multipath: Default::default(),
             route_selection: Default::default(),
             prefix_limit: Default::default(),
@@ -1778,6 +1874,7 @@ impl Default for NeighborCfg {
             timers: Default::default(),
             transport: Default::default(),
             log_neighbor_state_changes,
+            add_path: Default::default(),
             as_path_options: Default::default(),
             apply_policy: Default::default(),
             prefix_limit: Default::default(),
@@ -1827,6 +1924,7 @@ impl Default for NeighborAfiSafiCfg {
 
         NeighborAfiSafiCfg {
             enabled,
+            add_path: Default::default(),
             prefix_limit: Default::default(),
             send_default_route: false,
             apply_policy: Default::default(),
@@ -1872,10 +1970,7 @@ impl Default for AsPathOptions {
 
 impl Default for TraceOptionPacketResolved {
     fn default() -> TraceOptionPacketResolved {
-        let disabled = TraceOptionPacketType {
-            tx: false,
-            rx: false,
-        };
+        let disabled = TraceOptionPacketType { tx: false, rx: false };
         TraceOptionPacketResolved {
             open: disabled,
             update: disabled,
@@ -1891,9 +1986,6 @@ impl Default for TraceOptionPacketType {
         let tx = bgp::global::trace_options::flag::send::DFLT;
         let rx = bgp::global::trace_options::flag::receive::DFLT;
 
-        TraceOptionPacketType {
-            tx,
-            rx,
-        }
+        TraceOptionPacketType { tx, rx }
     }
 }

--- a/holo-bgp/src/northbound/state.rs
+++ b/holo-bgp/src/northbound/state.rs
@@ -48,7 +48,9 @@ impl<'a> YangList<'a, Instance> for bgp::global::afi_safis::afi_safi::AfiSafi<'a
     }
 
     fn new(_instance: &'a Instance, afi_safi: &Self::ListEntry) -> Self {
-        Self { name: afi_safi.to_yang() }
+        Self {
+            name: afi_safi.to_yang(),
+        }
     }
 }
 
@@ -119,7 +121,9 @@ impl<'a> YangContainer<'a, Instance> for bgp::neighbors::neighbor::timers::Timer
     type ParentListEntry = &'a Neighbor;
 
     fn new(_instance: &'a Instance, nbr: &Self::ParentListEntry) -> Option<Self> {
-        Some(Self { negotiated_hold_time: nbr.holdtime_nego })
+        Some(Self {
+            negotiated_hold_time: nbr.holdtime_nego,
+        })
     }
 }
 
@@ -144,7 +148,10 @@ impl<'a> YangList<'a, Instance> for bgp::neighbors::neighbor::afi_safis::afi_saf
     }
 
     fn new(_instance: &'a Instance, (_, afi_safi): &Self::ListEntry) -> Self {
-        Self { name: afi_safi.to_yang(), active: None }
+        Self {
+            name: afi_safi.to_yang(),
+            active: None,
+        }
     }
 }
 
@@ -377,7 +384,9 @@ impl<'a> YangList<'a, Instance> for bgp::rib::attr_sets::attr_set::AttrSet {
     }
 
     fn new(_instance: &'a Instance, attr_set: &Self::ListEntry) -> Self {
-        Self { index: attr_set.index }
+        Self {
+            index: attr_set.index,
+        }
     }
 }
 
@@ -549,7 +558,9 @@ impl<'a> YangList<'a, Instance> for bgp::rib::afi_safis::afi_safi::AfiSafi<'a> {
     }
 
     fn new(_instance: &'a Instance, afi_safi: &Self::ListEntry) -> Self {
-        Self { name: afi_safi.to_yang() }
+        Self {
+            name: afi_safi.to_yang(),
+        }
     }
 }
 
@@ -620,7 +631,9 @@ impl<'a> YangList<'a, Instance> for bgp::rib::afi_safis::afi_safi::ipv4_unicast:
     }
 
     fn new(_instance: &'a Instance, nbr: &Self::ListEntry) -> Self {
-        Self { neighbor_address: nbr.remote_addr }
+        Self {
+            neighbor_address: nbr.remote_addr,
+        }
     }
 }
 
@@ -912,7 +925,9 @@ impl<'a> YangList<'a, Instance> for bgp::rib::afi_safis::afi_safi::ipv6_unicast:
     }
 
     fn new(_instance: &'a Instance, nbr: &Self::ListEntry) -> Self {
-        Self { neighbor_address: nbr.remote_addr }
+        Self {
+            neighbor_address: nbr.remote_addr,
+        }
     }
 }
 

--- a/holo-bgp/src/northbound/state.rs
+++ b/holo-bgp/src/northbound/state.rs
@@ -48,9 +48,7 @@ impl<'a> YangList<'a, Instance> for bgp::global::afi_safis::afi_safi::AfiSafi<'a
     }
 
     fn new(_instance: &'a Instance, afi_safi: &Self::ListEntry) -> Self {
-        Self {
-            name: afi_safi.to_yang(),
-        }
+        Self { name: afi_safi.to_yang() }
     }
 }
 
@@ -121,9 +119,7 @@ impl<'a> YangContainer<'a, Instance> for bgp::neighbors::neighbor::timers::Timer
     type ParentListEntry = &'a Neighbor;
 
     fn new(_instance: &'a Instance, nbr: &Self::ParentListEntry) -> Option<Self> {
-        Some(Self {
-            negotiated_hold_time: nbr.holdtime_nego,
-        })
+        Some(Self { negotiated_hold_time: nbr.holdtime_nego })
     }
 }
 
@@ -148,10 +144,7 @@ impl<'a> YangList<'a, Instance> for bgp::neighbors::neighbor::afi_safis::afi_saf
     }
 
     fn new(_instance: &'a Instance, (_, afi_safi): &Self::ListEntry) -> Self {
-        Self {
-            name: afi_safi.to_yang(),
-            active: None,
-        }
+        Self { name: afi_safi.to_yang(), active: None }
     }
 }
 
@@ -166,7 +159,7 @@ impl<'a> YangContainer<'a, Instance> for bgp::neighbors::neighbor::afi_safis::af
         {
             prefixes
                 .values()
-                .filter_map(|dest| dest.adj_rib.get(addr))
+                .flat_map(|dest| dest.adj_rib.iter().filter(move |(key, _)| key.remote_addr == *addr).map(|(_, adj)| adj))
                 .fold((0, 0, 0), |(r, s, i), adj| (r + adj.in_pre().is_some() as u32, s + adj.out_post().is_some() as u32, i + adj.in_post().is_some() as u32))
         }
         let (r, s, i) = match afi_safi {
@@ -384,9 +377,7 @@ impl<'a> YangList<'a, Instance> for bgp::rib::attr_sets::attr_set::AttrSet {
     }
 
     fn new(_instance: &'a Instance, attr_set: &Self::ListEntry) -> Self {
-        Self {
-            index: attr_set.index,
-        }
+        Self { index: attr_set.index }
     }
 }
 
@@ -558,9 +549,7 @@ impl<'a> YangList<'a, Instance> for bgp::rib::afi_safis::afi_safi::AfiSafi<'a> {
     }
 
     fn new(_instance: &'a Instance, afi_safi: &Self::ListEntry) -> Self {
-        Self {
-            name: afi_safi.to_yang(),
-        }
+        Self { name: afi_safi.to_yang() }
     }
 }
 
@@ -631,27 +620,30 @@ impl<'a> YangList<'a, Instance> for bgp::rib::afi_safis::afi_safi::ipv4_unicast:
     }
 
     fn new(_instance: &'a Instance, nbr: &Self::ListEntry) -> Self {
-        Self {
-            neighbor_address: nbr.remote_addr,
-        }
+        Self { neighbor_address: nbr.remote_addr }
     }
 }
 
 impl<'a> YangList<'a, Instance> for bgp::rib::afi_safis::afi_safi::ipv4_unicast::neighbors::neighbor::adj_rib_in_pre::routes::route::Route<'a> {
     type ParentListEntry = &'a Neighbor;
-    type ListEntry = (Ipv4Network, &'a Route);
+    type ListEntry = (Ipv4Network, u32, &'a Route);
 
     fn iter(instance: &'a Instance, &nbr: &Self::ParentListEntry) -> Option<impl ListIterator<'a, Self::ListEntry>> {
         let rib = &instance.state.as_ref()?.rib;
         let iter = rib.tables.ipv4_unicast.prefixes.iter();
-        let iter = iter.filter_map(move |(prefix, dest)| dest.adj_rib.get(&nbr.remote_addr).and_then(|adj_rib| adj_rib.in_pre()).map(|route| (prefix, route)));
+        let iter = iter.flat_map(move |(prefix, dest)| {
+            dest.adj_rib
+                .iter()
+                .filter(move |(key, _)| key.remote_addr == nbr.remote_addr)
+                .filter_map(move |(key, adj_rib)| adj_rib.in_pre().map(|route| (prefix, key.path_id, route)))
+        });
         Some(iter)
     }
 
-    fn new(_instance: &'a Instance, (prefix, route): &Self::ListEntry) -> Self {
+    fn new(_instance: &'a Instance, (prefix, path_id, route): &Self::ListEntry) -> Self {
         Self {
             prefix: *prefix,
-            path_id: 0,
+            path_id: *path_id,
             attr_index: Some(route.attrs.base.index),
             community_index: route.attrs.comm.as_ref().map(|c| c.index),
             ext_community_index: route.attrs.ext_comm.as_ref().map(|c| c.index),
@@ -665,10 +657,10 @@ impl<'a> YangList<'a, Instance> for bgp::rib::afi_safis::afi_safi::ipv4_unicast:
 }
 
 impl<'a> YangList<'a, Instance> for bgp::rib::afi_safis::afi_safi::ipv4_unicast::neighbors::neighbor::adj_rib_in_pre::routes::route::unknown_attributes::unknown_attribute::UnknownAttribute<'a> {
-    type ParentListEntry = (Ipv4Network, &'a Route);
+    type ParentListEntry = (Ipv4Network, u32, &'a Route);
     type ListEntry = &'a UnknownAttr;
 
-    fn iter(_instance: &'a Instance, (_, route): &Self::ParentListEntry) -> Option<impl ListIterator<'a, Self::ListEntry>> {
+    fn iter(_instance: &'a Instance, (_, _, route): &Self::ParentListEntry) -> Option<impl ListIterator<'a, Self::ListEntry>> {
         let unknown = route.attrs.unknown.as_ref()?;
         let iter = unknown.iter();
         Some(iter)
@@ -689,19 +681,24 @@ impl<'a> YangList<'a, Instance> for bgp::rib::afi_safis::afi_safi::ipv4_unicast:
 
 impl<'a> YangList<'a, Instance> for bgp::rib::afi_safis::afi_safi::ipv4_unicast::neighbors::neighbor::adj_rib_in_post::routes::route::Route<'a> {
     type ParentListEntry = &'a Neighbor;
-    type ListEntry = (Ipv4Network, &'a Route);
+    type ListEntry = (Ipv4Network, u32, &'a Route);
 
     fn iter(instance: &'a Instance, &nbr: &Self::ParentListEntry) -> Option<impl ListIterator<'a, Self::ListEntry>> {
         let rib = &instance.state.as_ref()?.rib;
         let iter = rib.tables.ipv4_unicast.prefixes.iter();
-        let iter = iter.filter_map(move |(prefix, dest)| dest.adj_rib.get(&nbr.remote_addr).and_then(|adj_rib| adj_rib.in_post()).map(|route| (prefix, route)));
+        let iter = iter.flat_map(move |(prefix, dest)| {
+            dest.adj_rib
+                .iter()
+                .filter(move |(key, _)| key.remote_addr == nbr.remote_addr)
+                .filter_map(move |(key, adj_rib)| adj_rib.in_post().map(|route| (prefix, key.path_id, route)))
+        });
         Some(iter)
     }
 
-    fn new(_instance: &'a Instance, (prefix, route): &Self::ListEntry) -> Self {
+    fn new(_instance: &'a Instance, (prefix, path_id, route): &Self::ListEntry) -> Self {
         Self {
             prefix: *prefix,
-            path_id: 0,
+            path_id: *path_id,
             attr_index: Some(route.attrs.base.index),
             community_index: route.attrs.comm.as_ref().map(|c| c.index),
             ext_community_index: route.attrs.ext_comm.as_ref().map(|c| c.index),
@@ -716,10 +713,10 @@ impl<'a> YangList<'a, Instance> for bgp::rib::afi_safis::afi_safi::ipv4_unicast:
 }
 
 impl<'a> YangList<'a, Instance> for bgp::rib::afi_safis::afi_safi::ipv4_unicast::neighbors::neighbor::adj_rib_in_post::routes::route::unknown_attributes::unknown_attribute::UnknownAttribute<'a> {
-    type ParentListEntry = (Ipv4Network, &'a Route);
+    type ParentListEntry = (Ipv4Network, u32, &'a Route);
     type ListEntry = &'a UnknownAttr;
 
-    fn iter(_instance: &'a Instance, (_, route): &Self::ParentListEntry) -> Option<impl ListIterator<'a, Self::ListEntry>> {
+    fn iter(_instance: &'a Instance, (_, _, route): &Self::ParentListEntry) -> Option<impl ListIterator<'a, Self::ListEntry>> {
         let unknown = route.attrs.unknown.as_ref()?;
         let iter = unknown.iter();
         Some(iter)
@@ -740,19 +737,24 @@ impl<'a> YangList<'a, Instance> for bgp::rib::afi_safis::afi_safi::ipv4_unicast:
 
 impl<'a> YangList<'a, Instance> for bgp::rib::afi_safis::afi_safi::ipv4_unicast::neighbors::neighbor::adj_rib_out_pre::routes::route::Route<'a> {
     type ParentListEntry = &'a Neighbor;
-    type ListEntry = (Ipv4Network, &'a Route);
+    type ListEntry = (Ipv4Network, u32, &'a Route);
 
     fn iter(instance: &'a Instance, &nbr: &Self::ParentListEntry) -> Option<impl ListIterator<'a, Self::ListEntry>> {
         let rib = &instance.state.as_ref()?.rib;
         let iter = rib.tables.ipv4_unicast.prefixes.iter();
-        let iter = iter.filter_map(move |(prefix, dest)| dest.adj_rib.get(&nbr.remote_addr).and_then(|adj_rib| adj_rib.out_pre()).map(|route| (prefix, route)));
+        let iter = iter.flat_map(move |(prefix, dest)| {
+            dest.adj_rib
+                .iter()
+                .filter(move |(key, _)| key.remote_addr == nbr.remote_addr)
+                .filter_map(move |(key, adj_rib)| adj_rib.out_pre().map(|route| (prefix, key.path_id, route)))
+        });
         Some(iter)
     }
 
-    fn new(_instance: &'a Instance, (prefix, route): &Self::ListEntry) -> Self {
+    fn new(_instance: &'a Instance, (prefix, path_id, route): &Self::ListEntry) -> Self {
         Self {
             prefix: *prefix,
-            path_id: 0,
+            path_id: *path_id,
             attr_index: Some(route.attrs.base.index),
             community_index: route.attrs.comm.as_ref().map(|c| c.index),
             ext_community_index: route.attrs.ext_comm.as_ref().map(|c| c.index),
@@ -766,10 +768,10 @@ impl<'a> YangList<'a, Instance> for bgp::rib::afi_safis::afi_safi::ipv4_unicast:
 }
 
 impl<'a> YangList<'a, Instance> for bgp::rib::afi_safis::afi_safi::ipv4_unicast::neighbors::neighbor::adj_rib_out_pre::routes::route::unknown_attributes::unknown_attribute::UnknownAttribute<'a> {
-    type ParentListEntry = (Ipv4Network, &'a Route);
+    type ParentListEntry = (Ipv4Network, u32, &'a Route);
     type ListEntry = &'a UnknownAttr;
 
-    fn iter(_instance: &'a Instance, (_, route): &Self::ParentListEntry) -> Option<impl ListIterator<'a, Self::ListEntry>> {
+    fn iter(_instance: &'a Instance, (_, _, route): &Self::ParentListEntry) -> Option<impl ListIterator<'a, Self::ListEntry>> {
         let unknown = route.attrs.unknown.as_ref()?;
         let iter = unknown.iter();
         Some(iter)
@@ -790,19 +792,24 @@ impl<'a> YangList<'a, Instance> for bgp::rib::afi_safis::afi_safi::ipv4_unicast:
 
 impl<'a> YangList<'a, Instance> for bgp::rib::afi_safis::afi_safi::ipv4_unicast::neighbors::neighbor::adj_rib_out_post::routes::route::Route<'a> {
     type ParentListEntry = &'a Neighbor;
-    type ListEntry = (Ipv4Network, &'a Route);
+    type ListEntry = (Ipv4Network, u32, &'a Route);
 
     fn iter(instance: &'a Instance, &nbr: &Self::ParentListEntry) -> Option<impl ListIterator<'a, Self::ListEntry>> {
         let rib = &instance.state.as_ref()?.rib;
         let iter = rib.tables.ipv4_unicast.prefixes.iter();
-        let iter = iter.filter_map(move |(prefix, dest)| dest.adj_rib.get(&nbr.remote_addr).and_then(|adj_rib| adj_rib.out_post()).map(|route| (prefix, route)));
+        let iter = iter.flat_map(move |(prefix, dest)| {
+            dest.adj_rib
+                .iter()
+                .filter(move |(key, _)| key.remote_addr == nbr.remote_addr)
+                .filter_map(move |(key, adj_rib)| adj_rib.out_post().map(|route| (prefix, key.path_id, route)))
+        });
         Some(iter)
     }
 
-    fn new(_instance: &'a Instance, (prefix, route): &Self::ListEntry) -> Self {
+    fn new(_instance: &'a Instance, (prefix, path_id, route): &Self::ListEntry) -> Self {
         Self {
             prefix: *prefix,
-            path_id: 0,
+            path_id: *path_id,
             attr_index: Some(route.attrs.base.index),
             community_index: route.attrs.comm.as_ref().map(|c| c.index),
             ext_community_index: route.attrs.ext_comm.as_ref().map(|c| c.index),
@@ -816,10 +823,10 @@ impl<'a> YangList<'a, Instance> for bgp::rib::afi_safis::afi_safi::ipv4_unicast:
 }
 
 impl<'a> YangList<'a, Instance> for bgp::rib::afi_safis::afi_safi::ipv4_unicast::neighbors::neighbor::adj_rib_out_post::routes::route::unknown_attributes::unknown_attribute::UnknownAttribute<'a> {
-    type ParentListEntry = (Ipv4Network, &'a Route);
+    type ParentListEntry = (Ipv4Network, u32, &'a Route);
     type ListEntry = &'a UnknownAttr;
 
-    fn iter(_instance: &'a Instance, (_, route): &Self::ParentListEntry) -> Option<impl ListIterator<'a, Self::ListEntry>> {
+    fn iter(_instance: &'a Instance, (_, _, route): &Self::ParentListEntry) -> Option<impl ListIterator<'a, Self::ListEntry>> {
         let unknown = route.attrs.unknown.as_ref()?;
         let iter = unknown.iter();
         Some(iter)
@@ -905,27 +912,30 @@ impl<'a> YangList<'a, Instance> for bgp::rib::afi_safis::afi_safi::ipv6_unicast:
     }
 
     fn new(_instance: &'a Instance, nbr: &Self::ListEntry) -> Self {
-        Self {
-            neighbor_address: nbr.remote_addr,
-        }
+        Self { neighbor_address: nbr.remote_addr }
     }
 }
 
 impl<'a> YangList<'a, Instance> for bgp::rib::afi_safis::afi_safi::ipv6_unicast::neighbors::neighbor::adj_rib_in_pre::routes::route::Route<'a> {
     type ParentListEntry = &'a Neighbor;
-    type ListEntry = (Ipv6Network, &'a Route);
+    type ListEntry = (Ipv6Network, u32, &'a Route);
 
     fn iter(instance: &'a Instance, &nbr: &Self::ParentListEntry) -> Option<impl ListIterator<'a, Self::ListEntry>> {
         let rib = &instance.state.as_ref()?.rib;
         let iter = rib.tables.ipv6_unicast.prefixes.iter();
-        let iter = iter.filter_map(move |(prefix, dest)| dest.adj_rib.get(&nbr.remote_addr).and_then(|adj_rib| adj_rib.in_pre()).map(|route| (prefix, route)));
+        let iter = iter.flat_map(move |(prefix, dest)| {
+            dest.adj_rib
+                .iter()
+                .filter(move |(key, _)| key.remote_addr == nbr.remote_addr)
+                .filter_map(move |(key, adj_rib)| adj_rib.in_pre().map(|route| (prefix, key.path_id, route)))
+        });
         Some(iter)
     }
 
-    fn new(_instance: &'a Instance, (prefix, route): &Self::ListEntry) -> Self {
+    fn new(_instance: &'a Instance, (prefix, path_id, route): &Self::ListEntry) -> Self {
         Self {
             prefix: *prefix,
-            path_id: 0,
+            path_id: *path_id,
             attr_index: Some(route.attrs.base.index),
             community_index: route.attrs.comm.as_ref().map(|c| c.index),
             ext_community_index: route.attrs.ext_comm.as_ref().map(|c| c.index),
@@ -939,10 +949,10 @@ impl<'a> YangList<'a, Instance> for bgp::rib::afi_safis::afi_safi::ipv6_unicast:
 }
 
 impl<'a> YangList<'a, Instance> for bgp::rib::afi_safis::afi_safi::ipv6_unicast::neighbors::neighbor::adj_rib_in_pre::routes::route::unknown_attributes::unknown_attribute::UnknownAttribute<'a> {
-    type ParentListEntry = (Ipv6Network, &'a Route);
+    type ParentListEntry = (Ipv6Network, u32, &'a Route);
     type ListEntry = &'a UnknownAttr;
 
-    fn iter(_instance: &'a Instance, (_, route): &Self::ParentListEntry) -> Option<impl ListIterator<'a, Self::ListEntry>> {
+    fn iter(_instance: &'a Instance, (_, _, route): &Self::ParentListEntry) -> Option<impl ListIterator<'a, Self::ListEntry>> {
         let unknown = route.attrs.unknown.as_ref()?;
         let iter = unknown.iter();
         Some(iter)
@@ -963,19 +973,24 @@ impl<'a> YangList<'a, Instance> for bgp::rib::afi_safis::afi_safi::ipv6_unicast:
 
 impl<'a> YangList<'a, Instance> for bgp::rib::afi_safis::afi_safi::ipv6_unicast::neighbors::neighbor::adj_rib_in_post::routes::route::Route<'a> {
     type ParentListEntry = &'a Neighbor;
-    type ListEntry = (Ipv6Network, &'a Route);
+    type ListEntry = (Ipv6Network, u32, &'a Route);
 
     fn iter(instance: &'a Instance, &nbr: &Self::ParentListEntry) -> Option<impl ListIterator<'a, Self::ListEntry>> {
         let rib = &instance.state.as_ref()?.rib;
         let iter = rib.tables.ipv6_unicast.prefixes.iter();
-        let iter = iter.filter_map(move |(prefix, dest)| dest.adj_rib.get(&nbr.remote_addr).and_then(|adj_rib| adj_rib.in_post()).map(|route| (prefix, route)));
+        let iter = iter.flat_map(move |(prefix, dest)| {
+            dest.adj_rib
+                .iter()
+                .filter(move |(key, _)| key.remote_addr == nbr.remote_addr)
+                .filter_map(move |(key, adj_rib)| adj_rib.in_post().map(|route| (prefix, key.path_id, route)))
+        });
         Some(iter)
     }
 
-    fn new(_instance: &'a Instance, (prefix, route): &Self::ListEntry) -> Self {
+    fn new(_instance: &'a Instance, (prefix, path_id, route): &Self::ListEntry) -> Self {
         Self {
             prefix: *prefix,
-            path_id: 0,
+            path_id: *path_id,
             attr_index: Some(route.attrs.base.index),
             community_index: route.attrs.comm.as_ref().map(|c| c.index),
             ext_community_index: route.attrs.ext_comm.as_ref().map(|c| c.index),
@@ -990,10 +1005,10 @@ impl<'a> YangList<'a, Instance> for bgp::rib::afi_safis::afi_safi::ipv6_unicast:
 }
 
 impl<'a> YangList<'a, Instance> for bgp::rib::afi_safis::afi_safi::ipv6_unicast::neighbors::neighbor::adj_rib_in_post::routes::route::unknown_attributes::unknown_attribute::UnknownAttribute<'a> {
-    type ParentListEntry = (Ipv6Network, &'a Route);
+    type ParentListEntry = (Ipv6Network, u32, &'a Route);
     type ListEntry = &'a UnknownAttr;
 
-    fn iter(_instance: &'a Instance, (_, route): &Self::ParentListEntry) -> Option<impl ListIterator<'a, Self::ListEntry>> {
+    fn iter(_instance: &'a Instance, (_, _, route): &Self::ParentListEntry) -> Option<impl ListIterator<'a, Self::ListEntry>> {
         let unknown = route.attrs.unknown.as_ref()?;
         let iter = unknown.iter();
         Some(iter)
@@ -1014,19 +1029,24 @@ impl<'a> YangList<'a, Instance> for bgp::rib::afi_safis::afi_safi::ipv6_unicast:
 
 impl<'a> YangList<'a, Instance> for bgp::rib::afi_safis::afi_safi::ipv6_unicast::neighbors::neighbor::adj_rib_out_pre::routes::route::Route<'a> {
     type ParentListEntry = &'a Neighbor;
-    type ListEntry = (Ipv6Network, &'a Route);
+    type ListEntry = (Ipv6Network, u32, &'a Route);
 
     fn iter(instance: &'a Instance, &nbr: &Self::ParentListEntry) -> Option<impl ListIterator<'a, Self::ListEntry>> {
         let rib = &instance.state.as_ref()?.rib;
         let iter = rib.tables.ipv6_unicast.prefixes.iter();
-        let iter = iter.filter_map(move |(prefix, dest)| dest.adj_rib.get(&nbr.remote_addr).and_then(|adj_rib| adj_rib.out_pre()).map(|route| (prefix, route)));
+        let iter = iter.flat_map(move |(prefix, dest)| {
+            dest.adj_rib
+                .iter()
+                .filter(move |(key, _)| key.remote_addr == nbr.remote_addr)
+                .filter_map(move |(key, adj_rib)| adj_rib.out_pre().map(|route| (prefix, key.path_id, route)))
+        });
         Some(iter)
     }
 
-    fn new(_instance: &'a Instance, (prefix, route): &Self::ListEntry) -> Self {
+    fn new(_instance: &'a Instance, (prefix, path_id, route): &Self::ListEntry) -> Self {
         Self {
             prefix: *prefix,
-            path_id: 0,
+            path_id: *path_id,
             attr_index: Some(route.attrs.base.index),
             community_index: route.attrs.comm.as_ref().map(|c| c.index),
             ext_community_index: route.attrs.ext_comm.as_ref().map(|c| c.index),
@@ -1040,10 +1060,10 @@ impl<'a> YangList<'a, Instance> for bgp::rib::afi_safis::afi_safi::ipv6_unicast:
 }
 
 impl<'a> YangList<'a, Instance> for bgp::rib::afi_safis::afi_safi::ipv6_unicast::neighbors::neighbor::adj_rib_out_pre::routes::route::unknown_attributes::unknown_attribute::UnknownAttribute<'a> {
-    type ParentListEntry = (Ipv6Network, &'a Route);
+    type ParentListEntry = (Ipv6Network, u32, &'a Route);
     type ListEntry = &'a UnknownAttr;
 
-    fn iter(_instance: &'a Instance, (_, route): &Self::ParentListEntry) -> Option<impl ListIterator<'a, Self::ListEntry>> {
+    fn iter(_instance: &'a Instance, (_, _, route): &Self::ParentListEntry) -> Option<impl ListIterator<'a, Self::ListEntry>> {
         let unknown = route.attrs.unknown.as_ref()?;
         let iter = unknown.iter();
         Some(iter)
@@ -1064,19 +1084,24 @@ impl<'a> YangList<'a, Instance> for bgp::rib::afi_safis::afi_safi::ipv6_unicast:
 
 impl<'a> YangList<'a, Instance> for bgp::rib::afi_safis::afi_safi::ipv6_unicast::neighbors::neighbor::adj_rib_out_post::routes::route::Route<'a> {
     type ParentListEntry = &'a Neighbor;
-    type ListEntry = (Ipv6Network, &'a Route);
+    type ListEntry = (Ipv6Network, u32, &'a Route);
 
     fn iter(instance: &'a Instance, &nbr: &Self::ParentListEntry) -> Option<impl ListIterator<'a, Self::ListEntry>> {
         let rib = &instance.state.as_ref()?.rib;
         let iter = rib.tables.ipv6_unicast.prefixes.iter();
-        let iter = iter.filter_map(move |(prefix, dest)| dest.adj_rib.get(&nbr.remote_addr).and_then(|adj_rib| adj_rib.out_post()).map(|route| (prefix, route)));
+        let iter = iter.flat_map(move |(prefix, dest)| {
+            dest.adj_rib
+                .iter()
+                .filter(move |(key, _)| key.remote_addr == nbr.remote_addr)
+                .filter_map(move |(key, adj_rib)| adj_rib.out_post().map(|route| (prefix, key.path_id, route)))
+        });
         Some(iter)
     }
 
-    fn new(_instance: &'a Instance, (prefix, route): &Self::ListEntry) -> Self {
+    fn new(_instance: &'a Instance, (prefix, path_id, route): &Self::ListEntry) -> Self {
         Self {
             prefix: *prefix,
-            path_id: 0,
+            path_id: *path_id,
             attr_index: Some(route.attrs.base.index),
             community_index: route.attrs.comm.as_ref().map(|c| c.index),
             ext_community_index: route.attrs.ext_comm.as_ref().map(|c| c.index),
@@ -1090,10 +1115,10 @@ impl<'a> YangList<'a, Instance> for bgp::rib::afi_safis::afi_safi::ipv6_unicast:
 }
 
 impl<'a> YangList<'a, Instance> for bgp::rib::afi_safis::afi_safi::ipv6_unicast::neighbors::neighbor::adj_rib_out_post::routes::route::unknown_attributes::unknown_attribute::UnknownAttribute<'a> {
-    type ParentListEntry = (Ipv6Network, &'a Route);
+    type ParentListEntry = (Ipv6Network, u32, &'a Route);
     type ListEntry = &'a UnknownAttr;
 
-    fn iter(_instance: &'a Instance, (_, route): &Self::ParentListEntry) -> Option<impl ListIterator<'a, Self::ListEntry>> {
+    fn iter(_instance: &'a Instance, (_, _, route): &Self::ParentListEntry) -> Option<impl ListIterator<'a, Self::ListEntry>> {
         let unknown = route.attrs.unknown.as_ref()?;
         let iter = unknown.iter();
         Some(iter)

--- a/holo-bgp/src/packet/attribute.rs
+++ b/holo-bgp/src/packet/attribute.rs
@@ -24,7 +24,7 @@ use crate::packet::iana::{Afi, AttrType, Origin, Safi};
 use crate::packet::message::{
     DecodeCxt, EncodeCxt, MpReachNlri, MpUnreachNlri, NegotiatedCapability,
     ReachNlri, decode_ipv4_prefix, decode_ipv6_prefix, encode_ipv4_prefix,
-    encode_ipv6_prefix,
+    encode_ipv6_prefix, path_id,
 };
 
 pub const ATTR_MIN_LEN: u16 = 3;
@@ -164,10 +164,10 @@ impl Attrs {
         // "The MP_REACH_NLRI or MP_UNREACH_NLRI attribute (if present) SHALL
         // be encoded as the very first path attribute in an UPDATE message".
         if let Some(mp_reach) = mp_reach {
-            mp_reach.encode(buf);
+            mp_reach.encode(buf, cxt);
         }
         if let Some(mp_unreach) = mp_unreach {
-            mp_unreach.encode(buf);
+            mp_unreach.encode(buf, cxt);
         }
 
         // RFC 4271 - Section 5:
@@ -449,10 +449,10 @@ impl Attrs {
                     ClusterList::decode(&mut buf, cxt, &mut cluster_list)
                 }
                 AttrType::MpReachNlri => {
-                    MpReachNlri::decode(&mut buf, mp_reach)
+                    MpReachNlri::decode(&mut buf, cxt, mp_reach)
                 }
                 AttrType::MpUnreachNlri => {
-                    MpUnreachNlri::decode(&mut buf, mp_unreach)
+                    MpUnreachNlri::decode(&mut buf, cxt, mp_unreach)
                 }
                 AttrType::ExtCommunities => {
                     ExtComms::decode(&mut buf, &mut ext_comm)
@@ -1105,7 +1105,7 @@ impl ClusterList {
 impl MpReachNlri {
     pub const MIN_LEN: u16 = 5;
 
-    fn encode(&self, buf: &mut BytesMut) {
+    fn encode(&self, buf: &mut BytesMut, cxt: &EncodeCxt) {
         buf.put_u8((AttrFlags::OPTIONAL | AttrFlags::EXTENDED).bits());
         buf.put_u8(AttrType::MpReachNlri as u8);
 
@@ -1115,18 +1115,27 @@ impl MpReachNlri {
 
         // Encode attribute data.
         match self {
-            MpReachNlri::Ipv4Unicast { prefixes, nexthop } => {
+            MpReachNlri::Ipv4Unicast {
+                prefixes,
+                path_ids,
+                nexthop,
+            } => {
                 buf.put_u16(Afi::Ipv4 as u16);
                 buf.put_u8(Safi::Unicast as u8);
                 buf.put_u8(Ipv4Addr::LENGTH as u8);
                 buf.put_ipv4(nexthop);
                 buf.put_u8(0);
-                for prefix in prefixes {
+                let add_path = cxt.add_path_tx(Afi::Ipv4, Safi::Unicast);
+                for (pos, prefix) in prefixes.iter().enumerate() {
+                    if add_path {
+                        buf.put_u32(path_id(path_ids, pos));
+                    }
                     encode_ipv4_prefix(buf, prefix);
                 }
             }
             MpReachNlri::Ipv6Unicast {
                 prefixes,
+                path_ids,
                 nexthop,
                 ll_nexthop,
             } => {
@@ -1141,7 +1150,11 @@ impl MpReachNlri {
                     buf.put_ipv6(nexthop);
                 }
                 buf.put_u8(0);
-                for prefix in prefixes {
+                let add_path = cxt.add_path_tx(Afi::Ipv6, Safi::Unicast);
+                for (pos, prefix) in prefixes.iter().enumerate() {
+                    if add_path {
+                        buf.put_u32(path_id(path_ids, pos));
+                    }
                     encode_ipv6_prefix(buf, prefix);
                 }
             }
@@ -1154,6 +1167,7 @@ impl MpReachNlri {
 
     pub fn decode(
         buf: &mut Bytes,
+        cxt: &DecodeCxt,
         mp_reach: &mut Option<Self>,
     ) -> Result<(), AttrError> {
         if buf.remaining() < Self::MIN_LEN as usize {
@@ -1177,6 +1191,7 @@ impl MpReachNlri {
         match afi {
             Afi::Ipv4 => {
                 let mut prefixes = Vec::new();
+                let mut path_ids = Vec::new();
 
                 // Parse nexthop.
                 let nexthop_len = buf.try_get_u8()?;
@@ -1189,19 +1204,28 @@ impl MpReachNlri {
 
                 // Parse prefixes.
                 let _reserved = buf.try_get_u8()?;
+                let add_path = cxt.add_path_rx(Afi::Ipv4, Safi::Unicast);
                 while buf.remaining() > 0 {
+                    let path_id = if add_path { buf.try_get_u32()? } else { 0 };
                     if let Some(prefix) =
                         decode_ipv4_prefix(buf).map_err(|_| AttrError::Reset)?
                     {
                         prefixes.push(prefix);
+                        if add_path {
+                            path_ids.push(path_id);
+                        }
                     }
                 }
 
-                *mp_reach =
-                    Some(MpReachNlri::Ipv4Unicast { prefixes, nexthop });
+                *mp_reach = Some(MpReachNlri::Ipv4Unicast {
+                    prefixes,
+                    path_ids,
+                    nexthop,
+                });
             }
             Afi::Ipv6 => {
                 let mut prefixes = Vec::new();
+                let mut path_ids = Vec::new();
                 let mut ll_nexthop = None;
 
                 // Parse nexthops(s).
@@ -1219,16 +1243,22 @@ impl MpReachNlri {
 
                 // Parse prefixes.
                 let _reserved = buf.try_get_u8()?;
+                let add_path = cxt.add_path_rx(Afi::Ipv6, Safi::Unicast);
                 while buf.remaining() > 0 {
+                    let path_id = if add_path { buf.try_get_u32()? } else { 0 };
                     if let Some(prefix) =
                         decode_ipv6_prefix(buf).map_err(|_| AttrError::Reset)?
                     {
                         prefixes.push(prefix);
+                        if add_path {
+                            path_ids.push(path_id);
+                        }
                     }
                 }
 
                 *mp_reach = Some(MpReachNlri::Ipv6Unicast {
                     prefixes,
+                    path_ids,
                     nexthop,
                     ll_nexthop,
                 });
@@ -1244,7 +1274,7 @@ impl MpReachNlri {
 impl MpUnreachNlri {
     pub const MIN_LEN: u16 = 3;
 
-    fn encode(&self, buf: &mut BytesMut) {
+    fn encode(&self, buf: &mut BytesMut, cxt: &EncodeCxt) {
         buf.put_u8((AttrFlags::OPTIONAL | AttrFlags::EXTENDED).bits());
         buf.put_u8(AttrType::MpUnreachNlri as u8);
 
@@ -1254,17 +1284,25 @@ impl MpUnreachNlri {
 
         // Encode attribute data.
         match self {
-            MpUnreachNlri::Ipv4Unicast { prefixes } => {
+            MpUnreachNlri::Ipv4Unicast { prefixes, path_ids } => {
                 buf.put_u16(Afi::Ipv4 as u16);
                 buf.put_u8(Safi::Unicast as u8);
-                for prefix in prefixes {
+                let add_path = cxt.add_path_tx(Afi::Ipv4, Safi::Unicast);
+                for (pos, prefix) in prefixes.iter().enumerate() {
+                    if add_path {
+                        buf.put_u32(path_id(path_ids, pos));
+                    }
                     encode_ipv4_prefix(buf, prefix);
                 }
             }
-            MpUnreachNlri::Ipv6Unicast { prefixes } => {
+            MpUnreachNlri::Ipv6Unicast { prefixes, path_ids } => {
                 buf.put_u16(Afi::Ipv6 as u16);
                 buf.put_u8(Safi::Unicast as u8);
-                for prefix in prefixes {
+                let add_path = cxt.add_path_tx(Afi::Ipv6, Safi::Unicast);
+                for (pos, prefix) in prefixes.iter().enumerate() {
+                    if add_path {
+                        buf.put_u32(path_id(path_ids, pos));
+                    }
                     encode_ipv6_prefix(buf, prefix);
                 }
             }
@@ -1277,6 +1315,7 @@ impl MpUnreachNlri {
 
     pub fn decode(
         buf: &mut Bytes,
+        cxt: &DecodeCxt,
         mp_unreach: &mut Option<Self>,
     ) -> Result<(), AttrError> {
         if buf.remaining() < Self::MIN_LEN as usize {
@@ -1301,29 +1340,43 @@ impl MpUnreachNlri {
         match afi {
             Afi::Ipv4 => {
                 let mut prefixes = Vec::new();
+                let mut path_ids = Vec::new();
 
+                let add_path = cxt.add_path_rx(Afi::Ipv4, Safi::Unicast);
                 while buf.remaining() > 0 {
+                    let path_id = if add_path { buf.try_get_u32()? } else { 0 };
                     if let Some(prefix) =
                         decode_ipv4_prefix(buf).map_err(|_| AttrError::Reset)?
                     {
                         prefixes.push(prefix);
+                        if add_path {
+                            path_ids.push(path_id);
+                        }
                     }
                 }
 
-                *mp_unreach = Some(MpUnreachNlri::Ipv4Unicast { prefixes });
+                *mp_unreach =
+                    Some(MpUnreachNlri::Ipv4Unicast { prefixes, path_ids });
             }
             Afi::Ipv6 => {
                 let mut prefixes = Vec::new();
+                let mut path_ids = Vec::new();
 
+                let add_path = cxt.add_path_rx(Afi::Ipv6, Safi::Unicast);
                 while buf.remaining() > 0 {
+                    let path_id = if add_path { buf.try_get_u32()? } else { 0 };
                     if let Some(prefix) =
                         decode_ipv6_prefix(buf).map_err(|_| AttrError::Reset)?
                     {
                         prefixes.push(prefix);
+                        if add_path {
+                            path_ids.push(path_id);
+                        }
                     }
                 }
 
-                *mp_unreach = Some(MpUnreachNlri::Ipv6Unicast { prefixes });
+                *mp_unreach =
+                    Some(MpUnreachNlri::Ipv6Unicast { prefixes, path_ids });
             }
         }
 

--- a/holo-bgp/src/packet/message.rs
+++ b/holo-bgp/src/packet/message.rs
@@ -132,9 +132,16 @@ pub enum Capability {
 #[derive(Deserialize, Serialize)]
 #[derive(Arbitrary)]
 pub enum NegotiatedCapability {
-    MultiProtocol { afi: Afi, safi: Safi },
+    MultiProtocol {
+        afi: Afi,
+        safi: Safi,
+    },
     FourOctetAsNumber,
-    AddPath,
+    AddPath {
+        afi: Afi,
+        safi: Safi,
+        mode: AddPathMode,
+    },
     RouteRefresh,
     EnhancedRouteRefresh,
 }
@@ -151,6 +158,7 @@ pub struct AddPathTuple {
 #[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd)]
 #[derive(FromPrimitive, ToPrimitive)]
 #[derive(Deserialize, Serialize)]
+#[derive(Arbitrary)]
 pub enum AddPathMode {
     Receive = 1,
     Send = 2,
@@ -189,6 +197,8 @@ pub struct UpdateMsg {
 #[derive(Deserialize, Serialize)]
 pub struct ReachNlri {
     pub prefixes: Vec<Ipv4Network>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub path_ids: Vec<u32>,
     pub nexthop: Ipv4Addr,
 }
 
@@ -196,6 +206,8 @@ pub struct ReachNlri {
 #[derive(Deserialize, Serialize)]
 pub struct UnreachNlri {
     pub prefixes: Vec<Ipv4Network>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub path_ids: Vec<u32>,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -203,10 +215,14 @@ pub struct UnreachNlri {
 pub enum MpReachNlri {
     Ipv4Unicast {
         prefixes: Vec<Ipv4Network>,
+        #[serde(default, skip_serializing_if = "Vec::is_empty")]
+        path_ids: Vec<u32>,
         nexthop: Ipv4Addr,
     },
     Ipv6Unicast {
         prefixes: Vec<Ipv6Network>,
+        #[serde(default, skip_serializing_if = "Vec::is_empty")]
+        path_ids: Vec<u32>,
         nexthop: Ipv6Addr,
         ll_nexthop: Option<Ipv6Addr>,
     },
@@ -215,8 +231,16 @@ pub enum MpReachNlri {
 #[derive(Clone, Debug, Eq, PartialEq)]
 #[derive(Deserialize, Serialize)]
 pub enum MpUnreachNlri {
-    Ipv4Unicast { prefixes: Vec<Ipv4Network> },
-    Ipv6Unicast { prefixes: Vec<Ipv6Network> },
+    Ipv4Unicast {
+        prefixes: Vec<Ipv4Network>,
+        #[serde(default, skip_serializing_if = "Vec::is_empty")]
+        path_ids: Vec<u32>,
+    },
+    Ipv6Unicast {
+        prefixes: Vec<Ipv6Network>,
+        #[serde(default, skip_serializing_if = "Vec::is_empty")]
+        path_ids: Vec<u32>,
+    },
 }
 
 //
@@ -277,6 +301,8 @@ pub struct DecodeCxt {
     pub peer_type: PeerType,
     pub peer_as: u32,
     pub reject_as_sets: bool,
+    #[arbitrary(default)]
+    pub capabilities_adv: BTreeSet<Capability>,
     pub capabilities: BTreeSet<NegotiatedCapability>,
 }
 
@@ -675,19 +701,42 @@ impl Capability {
         }
     }
 
-    pub fn as_negotiated(&self) -> NegotiatedCapability {
+    pub fn as_negotiated(&self) -> Option<NegotiatedCapability> {
         match *self {
             Capability::MultiProtocol { afi, safi } => {
-                NegotiatedCapability::MultiProtocol { afi, safi }
+                Some(NegotiatedCapability::MultiProtocol { afi, safi })
             }
             Capability::FourOctetAsNumber { .. } => {
-                NegotiatedCapability::FourOctetAsNumber
+                Some(NegotiatedCapability::FourOctetAsNumber)
             }
-            Capability::AddPath { .. } => NegotiatedCapability::AddPath,
-            Capability::RouteRefresh => NegotiatedCapability::RouteRefresh,
+            Capability::AddPath { .. } => None,
+            Capability::RouteRefresh => {
+                Some(NegotiatedCapability::RouteRefresh)
+            }
             Capability::EnhancedRouteRefresh => {
-                NegotiatedCapability::EnhancedRouteRefresh
+                Some(NegotiatedCapability::EnhancedRouteRefresh)
             }
+        }
+    }
+}
+
+// ===== impl AddPathMode =====
+
+impl AddPathMode {
+    pub(crate) fn receive(self) -> bool {
+        matches!(self, AddPathMode::Receive | AddPathMode::ReceiveSend)
+    }
+
+    pub(crate) fn send(self) -> bool {
+        matches!(self, AddPathMode::Send | AddPathMode::ReceiveSend)
+    }
+
+    pub(crate) fn from_directions(receive: bool, send: bool) -> Option<Self> {
+        match (receive, send) {
+            (true, true) => Some(AddPathMode::ReceiveSend),
+            (true, false) => Some(AddPathMode::Receive),
+            (false, true) => Some(AddPathMode::Send),
+            (false, false) => None,
         }
     }
 }
@@ -703,13 +752,103 @@ impl NegotiatedCapability {
             NegotiatedCapability::FourOctetAsNumber => {
                 CapabilityCode::FourOctetAsNumber
             }
-            NegotiatedCapability::AddPath => CapabilityCode::AddPath,
+            NegotiatedCapability::AddPath { .. } => CapabilityCode::AddPath,
             NegotiatedCapability::RouteRefresh => CapabilityCode::RouteRefresh,
             NegotiatedCapability::EnhancedRouteRefresh => {
                 CapabilityCode::EnhancedRouteRefresh
             }
         }
     }
+
+    pub(crate) fn add_path_rx(&self, afi: Afi, safi: Safi) -> bool {
+        matches!(
+            self,
+            NegotiatedCapability::AddPath {
+                afi: cap_afi,
+                safi: cap_safi,
+                mode,
+            } if *cap_afi == afi && *cap_safi == safi && mode.receive()
+        )
+    }
+
+    pub(crate) fn add_path_tx(&self, afi: Afi, safi: Safi) -> bool {
+        matches!(
+            self,
+            NegotiatedCapability::AddPath {
+                afi: cap_afi,
+                safi: cap_safi,
+                mode,
+            } if *cap_afi == afi && *cap_safi == safi && mode.send()
+        )
+    }
+}
+
+// ===== impl EncodeCxt =====
+
+impl EncodeCxt {
+    pub(crate) fn add_path_tx(&self, afi: Afi, safi: Safi) -> bool {
+        self.capabilities
+            .iter()
+            .any(|cap| cap.add_path_tx(afi, safi))
+    }
+}
+
+// ===== impl DecodeCxt =====
+
+impl DecodeCxt {
+    pub(crate) fn add_path_rx(&self, afi: Afi, safi: Safi) -> bool {
+        self.capabilities
+            .iter()
+            .any(|cap| cap.add_path_rx(afi, safi))
+    }
+}
+
+pub(crate) fn negotiate_capabilities(
+    advertised: &BTreeSet<Capability>,
+    received: &BTreeSet<Capability>,
+) -> BTreeSet<NegotiatedCapability> {
+    let mut negotiated = advertised
+        .iter()
+        .filter_map(|cap| cap.as_negotiated())
+        .collect::<BTreeSet<_>>()
+        .intersection(
+            &received
+                .iter()
+                .filter_map(|cap| cap.as_negotiated())
+                .collect::<BTreeSet<_>>(),
+        )
+        .cloned()
+        .collect::<BTreeSet<_>>();
+
+    let local_add_path = advertised.iter().find_map(|cap| match cap {
+        Capability::AddPath(tuples) => Some(tuples),
+        _ => None,
+    });
+    let peer_add_path = received.iter().find_map(|cap| match cap {
+        Capability::AddPath(tuples) => Some(tuples),
+        _ => None,
+    });
+    if let (Some(local), Some(peer)) = (local_add_path, peer_add_path) {
+        for local_tuple in local {
+            let Some(peer_tuple) = peer.iter().find(|tuple| {
+                tuple.afi == local_tuple.afi && tuple.safi == local_tuple.safi
+            }) else {
+                continue;
+            };
+
+            let receive = local_tuple.mode.receive() && peer_tuple.mode.send();
+            let send = local_tuple.mode.send() && peer_tuple.mode.receive();
+            if let Some(mode) = AddPathMode::from_directions(receive, send) {
+                negotiated.insert(NegotiatedCapability::AddPath {
+                    afi: local_tuple.afi,
+                    safi: local_tuple.safi,
+                    mode,
+                });
+            }
+        }
+    }
+
+    negotiated
 }
 
 // ===== impl UpdateMsg =====
@@ -725,12 +864,12 @@ impl UpdateMsg {
         buf.put_u16(0);
         if let Some(unreach) = &self.unreach {
             // Encode prefixes.
-            for prefix in &unreach.prefixes {
-                let plen = prefix.prefix();
-                let prefix_bytes = prefix.ip().octets();
-                let plen_wire = prefix_wire_len(plen);
-                buf.put_u8(plen);
-                buf.put(&prefix_bytes[0..plen_wire]);
+            let add_path = cxt.add_path_tx(Afi::Ipv4, Safi::Unicast);
+            for (pos, prefix) in unreach.prefixes.iter().enumerate() {
+                if add_path {
+                    buf.put_u32(path_id(&unreach.path_ids, pos));
+                }
+                encode_ipv4_prefix(buf, prefix);
             }
 
             // Rewrite the "Withdrawn Routes Length" field.
@@ -759,7 +898,11 @@ impl UpdateMsg {
         // Network Layer Reachability Information.
         if let Some(reach) = &self.reach {
             // Encode prefixes.
-            for prefix in &reach.prefixes {
+            let add_path = cxt.add_path_tx(Afi::Ipv4, Safi::Unicast);
+            for (pos, prefix) in reach.prefixes.iter().enumerate() {
+                if add_path {
+                    buf.put_u32(path_id(&reach.path_ids, pos));
+                }
                 encode_ipv4_prefix(buf, prefix);
             }
         }
@@ -785,13 +928,23 @@ impl UpdateMsg {
         // Withdrawn Routes.
         let mut buf_wdraw = buf.copy_to_bytes(wdraw_len as usize);
         let mut prefixes = Vec::new();
+        let mut path_ids = Vec::new();
+        let add_path = cxt.add_path_rx(Afi::Ipv4, Safi::Unicast);
         while buf_wdraw.remaining() > 0 {
+            let path_id = if add_path {
+                buf_wdraw.try_get_u32()?
+            } else {
+                0
+            };
             if let Some(prefix) = decode_ipv4_prefix(&mut buf_wdraw)? {
                 prefixes.push(prefix);
+                if add_path {
+                    path_ids.push(path_id);
+                }
             }
         }
         if !prefixes.is_empty() {
-            unreach = Some(UnreachNlri { prefixes });
+            unreach = Some(UnreachNlri { prefixes, path_ids });
         }
 
         // Total Path Attribute Length.
@@ -821,15 +974,25 @@ impl UpdateMsg {
         //
         // All prefixes are ignored if the NEXT_HOP attribute is missing.
         let mut prefixes = Vec::new();
+        let mut path_ids = Vec::new();
+        let add_path = cxt.add_path_rx(Afi::Ipv4, Safi::Unicast);
         while buf.remaining() > 0 {
+            let path_id = if add_path { buf.try_get_u32()? } else { 0 };
             if let Some(prefix) = decode_ipv4_prefix(buf)? {
                 prefixes.push(prefix);
+                if add_path {
+                    path_ids.push(path_id);
+                }
             }
         }
         if !prefixes.is_empty()
             && let Some(nexthop) = nexthop
         {
-            reach = Some(ReachNlri { prefixes, nexthop });
+            reach = Some(ReachNlri {
+                prefixes,
+                path_ids,
+                nexthop,
+            });
         }
 
         Ok(UpdateMsg {
@@ -1086,4 +1249,8 @@ pub fn decode_ipv6_prefix(
 // Calculates the number of bytes required to encode a prefix.
 fn prefix_wire_len(len: u8) -> usize {
     (len as usize).div_ceil(8)
+}
+
+pub(crate) fn path_id(path_ids: &[u32], pos: usize) -> u32 {
+    path_ids.get(pos).copied().unwrap_or(0)
 }

--- a/holo-bgp/src/policy.rs
+++ b/holo-bgp/src/policy.rs
@@ -50,6 +50,7 @@ pub(crate) fn neighbor_apply(
     nbr_addr: IpAddr,
     afi_safi: AfiSafi,
     routes: Vec<(IpNetwork, RoutePolicyInfo)>,
+    path_ids: Vec<u32>,
     policies: &[Arc<Policy>],
     match_sets: &MatchSets,
     default_policy: DefaultPolicyType,
@@ -78,6 +79,7 @@ pub(crate) fn neighbor_apply(
         nbr_addr,
         afi_safi,
         routes,
+        path_ids,
     });
 }
 

--- a/holo-bgp/src/rib.rs
+++ b/holo-bgp/src/rib.rs
@@ -56,8 +56,14 @@ pub struct RoutingTable<A: AddressFamily> {
 #[derive(Debug, Default)]
 pub struct Destination {
     pub local: Option<Box<LocalRoute>>,
-    pub adj_rib: BTreeMap<IpAddr, AdjRib>,
+    pub adj_rib: BTreeMap<AdjRibKey, AdjRib>,
     pub redistribute: Option<Box<Route>>,
+}
+
+#[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd)]
+pub struct AdjRibKey {
+    pub remote_addr: IpAddr,
+    pub path_id: u32,
 }
 
 #[derive(Debug, Default)]

--- a/holo-bgp/src/tasks.rs
+++ b/holo-bgp/src/tasks.rs
@@ -116,6 +116,8 @@ pub mod messages {
                 nbr_addr: IpAddr,
                 afi_safi: AfiSafi,
                 routes: Vec<(IpNetwork, PolicyResult<RoutePolicyInfo>)>,
+                #[serde(skip)]
+                path_ids: Vec<u32>,
             },
             Redistribute {
                 afi_safi: AfiSafi,
@@ -181,6 +183,8 @@ pub mod messages {
                 nbr_addr: IpAddr,
                 afi_safi: AfiSafi,
                 routes: Vec<(IpNetwork, RoutePolicyInfo)>,
+                #[serde(skip)]
+                path_ids: Vec<u32>,
                 #[serde(skip)]
                 policies: Vec<Arc<Policy>>,
                 #[serde(skip)]
@@ -474,6 +478,7 @@ pub(crate) fn policy_apply(
                         nbr_addr,
                         afi_safi,
                         routes,
+                        path_ids,
                         policies,
                         match_sets,
                         default_policy,
@@ -483,6 +488,7 @@ pub(crate) fn policy_apply(
                             nbr_addr,
                             afi_safi,
                             routes,
+                            path_ids,
                             &policies,
                             &match_sets,
                             default_policy,

--- a/holo-bgp/tests/conformance/add_path.rs
+++ b/holo-bgp/tests/conformance/add_path.rs
@@ -1,0 +1,730 @@
+//
+// Copyright (c) The Holo Core Contributors
+//
+// SPDX-License-Identifier: MIT
+//
+
+use std::collections::{BTreeSet, VecDeque};
+use std::hash::{DefaultHasher, Hash, Hasher};
+use std::net::{IpAddr, Ipv4Addr};
+
+use holo_bgp::instance::Instance;
+use holo_bgp::packet::attribute::{
+    AsPath, AsPathSegment, AsPathSegmentType, Attrs, BaseAttrs,
+};
+use holo_bgp::packet::iana::{Afi, Safi};
+use holo_bgp::packet::message::{
+    AddPathMode, AddPathTuple, Capability, KeepaliveMsg, Message, OpenMsg,
+    ReachNlri, UnreachNlri, UpdateMsg,
+};
+use holo_bgp::policy::RoutePolicyInfo;
+use holo_bgp::rib::RouteOrigin;
+use holo_bgp::tasks::messages::input::{
+    NbrRxMsg, NbrTimerMsg, PolicyResultMsg, ProtocolMsg, TcpAcceptMsg,
+};
+use holo_protocol::InstanceMsg;
+use holo_protocol::test::setup;
+use holo_protocol::test::stub::{Stub, start_test_instance};
+use holo_utils::bgp::{AfiSafi, Origin, RouteType};
+use holo_utils::policy::{PolicyResult, PolicyType};
+use holo_utils::socket::TcpConnInfo;
+use ipnetwork::{IpNetwork, Ipv4Network};
+use serde_json::Value;
+
+const PREFIX: &str = "203.0.113.0/24";
+
+#[tokio::test]
+async fn rx_multiple_paths_are_keyed_by_path_id() {
+    setup();
+
+    let mut stub = start_test_instance::<Instance>("test").await;
+    stub.commit_replace(&config(&[neighbor("192.0.2.1", 65001, true, false)]))
+        .await;
+    stub.reset_output();
+
+    establish_session(
+        &stub,
+        "192.0.2.254",
+        "192.0.2.1",
+        65001,
+        "192.0.2.1",
+        AddPathMode::Send,
+    )
+    .await;
+    drain(&stub).await;
+
+    inject_path(&stub, "192.0.2.1", 1, &[65001, 65002]).await;
+    accept_import(&stub, "192.0.2.1", 1, &[65001, 65002]).await;
+    inject_path(&stub, "192.0.2.1", 2, &[65001]).await;
+    accept_import(&stub, "192.0.2.1", 2, &[65001]).await;
+    nexthop_update(&stub, "192.0.2.1").await;
+    trigger_decision(&stub).await;
+
+    let state_json = state(&stub).await;
+    assert_path_id_present(&state_json, 1);
+    assert_path_id_present(&state_json, 2);
+    assert_local_rib_as_path(&state_json, &[65001]);
+
+    withdraw_path(&stub, "192.0.2.1", 2).await;
+    trigger_decision(&stub).await;
+
+    let state_json = state(&stub).await;
+    assert_path_id_present(&state_json, 1);
+    assert_path_id_absent(&state_json, 2);
+    assert_local_rib_as_path(&state_json, &[65001, 65002]);
+
+    stub.close().await;
+}
+
+#[tokio::test]
+async fn tx_all_paths_and_non_add_path_peer_behavior() {
+    setup();
+
+    let mut stub = start_test_instance::<Instance>("test").await;
+    stub.commit_replace(&config(&[
+        neighbor("192.0.2.1", 65001, true, false),
+        neighbor("192.0.2.2", 65002, false, true),
+        neighbor("192.0.2.3", 65003, false, false),
+    ]))
+    .await;
+    stub.reset_output();
+
+    establish_session(
+        &stub,
+        "192.0.2.254",
+        "192.0.2.1",
+        65001,
+        "192.0.2.1",
+        AddPathMode::Send,
+    )
+    .await;
+    establish_session(
+        &stub,
+        "192.0.2.254",
+        "192.0.2.2",
+        65002,
+        "192.0.2.2",
+        AddPathMode::Receive,
+    )
+    .await;
+    establish_session_without_add_path(
+        &stub,
+        "192.0.2.254",
+        "192.0.2.3",
+        65003,
+        "192.0.2.3",
+    )
+    .await;
+    drain(&stub).await;
+
+    inject_path(&stub, "192.0.2.1", 1, &[65001, 65011]).await;
+    accept_import(&stub, "192.0.2.1", 1, &[65001, 65011]).await;
+    inject_path(&stub, "192.0.2.1", 2, &[65001]).await;
+    accept_import(&stub, "192.0.2.1", 2, &[65001]).await;
+    nexthop_update(&stub, "192.0.2.1").await;
+    trigger_decision(&stub).await;
+
+    let add_path_ids = [
+        advertised_path_id("192.0.2.1", 1),
+        advertised_path_id("192.0.2.1", 2),
+    ];
+    accept_export(&stub, "192.0.2.2", add_path_ids[0], &[65001, 65011]).await;
+    accept_export(&stub, "192.0.2.2", add_path_ids[1], &[65001]).await;
+    accept_export(&stub, "192.0.2.3", 0, &[65001]).await;
+
+    let output = drain(&stub).await;
+    let add_path_reach = reach_path_ids(&output, "192.0.2.2");
+    assert_eq!(add_path_reach.len(), 2);
+    assert!(add_path_reach.contains(&add_path_ids[0]));
+    assert!(add_path_reach.contains(&add_path_ids[1]));
+    assert_ne!(add_path_ids[0], add_path_ids[1]);
+
+    let non_add_path_reach = reach_path_ids(&output, "192.0.2.3");
+    assert_eq!(non_add_path_reach, vec![0]);
+
+    send_route_refresh(&stub, "192.0.2.2").await;
+    let refresh_output = drain(&stub).await;
+    let mut refresh_path_ids = reach_path_ids(&refresh_output, "192.0.2.2");
+    let mut add_path_reach_sorted = add_path_reach;
+    refresh_path_ids.sort();
+    add_path_reach_sorted.sort();
+    assert_eq!(refresh_path_ids, add_path_reach_sorted);
+
+    stub.close().await;
+}
+
+#[tokio::test]
+async fn negotiation_direction_controls_rx_and_tx() {
+    setup();
+
+    let mut stub = start_test_instance::<Instance>("test").await;
+    stub.commit_replace(&config(&[
+        neighbor("192.0.2.1", 65001, true, false),
+        neighbor("192.0.2.2", 65002, false, true),
+    ]))
+    .await;
+    stub.reset_output();
+
+    establish_session(
+        &stub,
+        "192.0.2.254",
+        "192.0.2.1",
+        65001,
+        "192.0.2.1",
+        AddPathMode::Send,
+    )
+    .await;
+    establish_session(
+        &stub,
+        "192.0.2.254",
+        "192.0.2.2",
+        65002,
+        "192.0.2.2",
+        AddPathMode::Receive,
+    )
+    .await;
+    drain(&stub).await;
+
+    inject_path(&stub, "192.0.2.1", 7, &[65001]).await;
+    accept_import(&stub, "192.0.2.1", 7, &[65001]).await;
+    inject_path(&stub, "192.0.2.2", 0, &[65002]).await;
+    accept_import(&stub, "192.0.2.2", 0, &[65002]).await;
+    nexthop_update(&stub, "192.0.2.1").await;
+    nexthop_update(&stub, "192.0.2.2").await;
+    trigger_decision(&stub).await;
+
+    let state = state(&stub).await;
+    assert_path_id_present(&state, 7);
+    assert_path_id_present(&state, 0);
+
+    accept_export(&stub, "192.0.2.1", 0, &[65001]).await;
+    let advertised_id = advertised_path_id("192.0.2.1", 7);
+    accept_export(&stub, "192.0.2.2", advertised_id, &[65001]).await;
+
+    let output = drain(&stub).await;
+    assert_eq!(reach_path_ids(&output, "192.0.2.1"), vec![0]);
+    assert_eq!(reach_path_ids(&output, "192.0.2.2"), vec![advertised_id]);
+
+    stub.close().await;
+}
+
+fn config(neighbors: &[String]) -> String {
+    format!(
+        r#"{{
+  "ietf-routing:routing": {{
+    "control-plane-protocols": {{
+      "control-plane-protocol": [
+        {{
+          "type": "ietf-bgp:bgp",
+          "name": "test",
+          "ietf-bgp:bgp": {{
+            "global": {{
+              "as": 65000,
+              "identifier": "192.0.2.254",
+              "afi-safis": {{
+                "afi-safi": [
+                  {{
+                    "name": "iana-bgp-types:ipv4-unicast"
+                  }}
+                ]
+              }}
+            }},
+            "neighbors": {{
+              "neighbor": [
+                {}
+              ]
+            }}
+          }}
+        }}
+      ]
+    }}
+  }}
+}}"#,
+        neighbors.join(",\n                ")
+    )
+}
+
+fn neighbor(
+    remote_addr: &str,
+    peer_as: u32,
+    add_path_receive: bool,
+    add_path_send_all: bool,
+) -> String {
+    let add_paths = match (add_path_receive, add_path_send_all) {
+        (false, false) => String::new(),
+        (receive, false) => {
+            format!(r#","add-paths":{{"receive":{receive}}}"#)
+        }
+        (receive, true) => {
+            format!(r#","add-paths":{{"receive":{receive},"all":[null]}}"#)
+        }
+    };
+
+    format!(
+        r#"{{
+                  "remote-address": "{remote_addr}",
+                  "peer-as": {peer_as},
+                  "afi-safis": {{
+                    "afi-safi": [
+                      {{
+                        "name": "iana-bgp-types:ipv4-unicast",
+                        "enabled": true,
+                        "apply-policy": {{
+                          "default-import-policy": "accept-route",
+                          "default-export-policy": "accept-route"
+                        }}
+                      }}
+                    ]
+                  }}{add_paths}
+                }}"#
+    )
+}
+
+async fn establish_session(
+    stub: &Stub<Instance>,
+    local_addr: &str,
+    remote_addr: &str,
+    peer_as: u32,
+    identifier: &str,
+    peer_add_path: AddPathMode,
+) {
+    accept_tcp(stub, local_addr, remote_addr).await;
+    recv(
+        stub,
+        remote_addr,
+        Message::Open(open(peer_as, identifier, Some(peer_add_path))),
+    )
+    .await;
+    recv(stub, remote_addr, Message::Keepalive(KeepaliveMsg {})).await;
+}
+
+async fn establish_session_without_add_path(
+    stub: &Stub<Instance>,
+    local_addr: &str,
+    remote_addr: &str,
+    peer_as: u32,
+    identifier: &str,
+) {
+    accept_tcp(stub, local_addr, remote_addr).await;
+    recv(
+        stub,
+        remote_addr,
+        Message::Open(open(peer_as, identifier, None)),
+    )
+    .await;
+    recv(stub, remote_addr, Message::Keepalive(KeepaliveMsg {})).await;
+}
+
+async fn accept_tcp(
+    stub: &Stub<Instance>,
+    local_addr: &str,
+    remote_addr: &str,
+) {
+    stub.send(InstanceMsg::Protocol(ProtocolMsg::NbrTimer(NbrTimerMsg {
+        nbr_addr: ip(remote_addr),
+        timer: holo_bgp::neighbor::fsm::Timer::AutoStart,
+    })))
+    .await;
+    stub.send(InstanceMsg::Protocol(ProtocolMsg::TcpAccept(
+        TcpAcceptMsg {
+            stream: None,
+            conn_info: TcpConnInfo {
+                local_addr: ip(local_addr),
+                local_port: 179,
+                remote_addr: ip(remote_addr),
+                remote_port: 1179,
+            },
+        },
+    )))
+    .await;
+}
+
+fn open(
+    peer_as: u32,
+    identifier: &str,
+    add_path: Option<AddPathMode>,
+) -> OpenMsg {
+    let mut capabilities: BTreeSet<Capability> = [
+        Capability::MultiProtocol {
+            afi: Afi::Ipv4,
+            safi: Safi::Unicast,
+        },
+        Capability::FourOctetAsNumber { asn: peer_as },
+        Capability::RouteRefresh,
+    ]
+    .into();
+
+    if let Some(mode) = add_path {
+        capabilities.insert(Capability::AddPath(
+            [AddPathTuple {
+                afi: Afi::Ipv4,
+                safi: Safi::Unicast,
+                mode,
+            }]
+            .into(),
+        ));
+    }
+
+    OpenMsg {
+        version: OpenMsg::VERSION,
+        my_as: peer_as.try_into().unwrap(),
+        holdtime: 90,
+        identifier: identifier.parse().unwrap(),
+        capabilities,
+    }
+}
+
+async fn inject_path(
+    stub: &Stub<Instance>,
+    nbr_addr: &str,
+    path_id: u32,
+    as_path: &[u32],
+) {
+    let attrs = attrs(nbr_addr, as_path);
+    recv(
+        stub,
+        nbr_addr,
+        Message::Update(UpdateMsg {
+            unreach: None,
+            attrs: Some(attrs),
+            reach: Some(ReachNlri {
+                prefixes: vec![prefix()],
+                path_ids: vec![path_id],
+                nexthop: nbr_addr.parse().unwrap(),
+            }),
+            mp_reach: None,
+            mp_unreach: None,
+        }),
+    )
+    .await;
+}
+
+async fn withdraw_path(stub: &Stub<Instance>, nbr_addr: &str, path_id: u32) {
+    recv(
+        stub,
+        nbr_addr,
+        Message::Update(UpdateMsg {
+            unreach: Some(UnreachNlri {
+                prefixes: vec![prefix()],
+                path_ids: vec![path_id],
+            }),
+            attrs: None,
+            reach: None,
+            mp_reach: None,
+            mp_unreach: None,
+        }),
+    )
+    .await;
+}
+
+async fn send_route_refresh(stub: &Stub<Instance>, nbr_addr: &str) {
+    recv(
+        stub,
+        nbr_addr,
+        Message::RouteRefresh(holo_bgp::packet::message::RouteRefreshMsg {
+            afi: Afi::Ipv4 as u16,
+            safi: Safi::Unicast as u8,
+        }),
+    )
+    .await;
+}
+
+async fn recv(stub: &Stub<Instance>, nbr_addr: &str, msg: Message) {
+    stub.send(InstanceMsg::Protocol(ProtocolMsg::NbrRx(NbrRxMsg {
+        nbr_addr: ip(nbr_addr),
+        msg: Ok(msg),
+    })))
+    .await;
+}
+
+async fn accept_import(
+    stub: &Stub<Instance>,
+    nbr_addr: &str,
+    path_id: u32,
+    as_path: &[u32],
+) {
+    policy_result(
+        stub,
+        PolicyType::Import,
+        nbr_addr,
+        path_id,
+        nbr_addr,
+        nbr_addr,
+        as_path,
+    )
+    .await;
+}
+
+async fn accept_export(
+    stub: &Stub<Instance>,
+    nbr_addr: &str,
+    path_id: u32,
+    as_path: &[u32],
+) {
+    policy_result(
+        stub,
+        PolicyType::Export,
+        nbr_addr,
+        path_id,
+        "192.0.2.1",
+        "192.0.2.1",
+        as_path,
+    )
+    .await;
+}
+
+async fn policy_result(
+    stub: &Stub<Instance>,
+    policy_type: PolicyType,
+    nbr_addr: &str,
+    path_id: u32,
+    origin_remote_addr: &str,
+    nexthop: &str,
+    as_path: &[u32],
+) {
+    stub.send(InstanceMsg::Protocol(ProtocolMsg::PolicyResult(
+        PolicyResultMsg::Neighbor {
+            policy_type,
+            nbr_addr: ip(nbr_addr),
+            afi_safi: AfiSafi::Ipv4Unicast,
+            routes: vec![(
+                IpNetwork::V4(prefix()),
+                PolicyResult::Accept(RoutePolicyInfo {
+                    origin: RouteOrigin::Neighbor {
+                        identifier: Ipv4Addr::new(192, 0, 2, 1),
+                        remote_addr: ip(origin_remote_addr),
+                    },
+                    route_type: RouteType::External,
+                    tag: None,
+                    opaque_attrs: None,
+                    attrs: attrs(nexthop, as_path),
+                }),
+            )],
+            path_ids: vec![path_id],
+        },
+    )))
+    .await;
+}
+
+async fn nexthop_update(stub: &Stub<Instance>, addr: &str) {
+    let msg = format!(
+        r#"{{"Ibus":{{"NexthopUpd":{{"addr":"{addr}","metric":0}}}}}}"#
+    );
+    stub.send(serde_json::from_str(&msg).unwrap()).await;
+}
+
+async fn trigger_decision(stub: &Stub<Instance>) {
+    stub.send(InstanceMsg::Protocol(ProtocolMsg::TriggerDecisionProcess(
+        (),
+    )))
+    .await;
+    stub.sync().await;
+}
+
+async fn drain(stub: &Stub<Instance>) -> Vec<Value> {
+    stub.sync().await;
+    tokio::task::yield_now().await;
+    stub.take_protocol_output()
+        .into_iter()
+        .map(|line| serde_json::from_str(&line).unwrap())
+        .collect()
+}
+
+async fn state(stub: &Stub<Instance>) -> Value {
+    serde_json::from_str(&stub.state_json().await).unwrap()
+}
+
+fn attrs(nexthop: &str, as_path: &[u32]) -> Attrs {
+    Attrs {
+        base: BaseAttrs {
+            origin: Origin::Incomplete,
+            as_path: AsPath {
+                segments: vec![AsPathSegment {
+                    seg_type: AsPathSegmentType::Sequence,
+                    members: as_path.iter().copied().collect::<VecDeque<_>>(),
+                }]
+                .into(),
+            },
+            nexthop: Some(ip(nexthop)),
+            ..Default::default()
+        },
+        ..Default::default()
+    }
+}
+
+fn reach_path_ids(output: &[Value], nbr_addr: &str) -> Vec<u32> {
+    let mut path_ids = vec![];
+    for msg in output {
+        let Some(send_msg_list) =
+            msg.get("NbrTx").and_then(|msg| msg.get("SendMessageList"))
+        else {
+            continue;
+        };
+        if send_msg_list.get("nbr_addr").and_then(Value::as_str)
+            != Some(nbr_addr)
+        {
+            continue;
+        }
+        let Some(msg_list) =
+            send_msg_list.get("msg_list").and_then(Value::as_array)
+        else {
+            continue;
+        };
+        for msg in msg_list {
+            let Some(reach) =
+                msg.get("Update").and_then(|update| update.get("reach"))
+            else {
+                continue;
+            };
+            let Some(prefixes) =
+                reach.get("prefixes").and_then(Value::as_array)
+            else {
+                continue;
+            };
+            if !prefixes
+                .iter()
+                .any(|prefix| prefix.as_str() == Some(PREFIX))
+            {
+                continue;
+            }
+            if let Some(ids) = reach.get("path_ids").and_then(Value::as_array) {
+                path_ids.extend(
+                    ids.iter().map(|path_id| path_id.as_u64().unwrap() as u32),
+                );
+            } else {
+                path_ids.push(0);
+            }
+        }
+    }
+    path_ids
+}
+
+fn assert_path_id_present(state: &Value, path_id: u32) {
+    assert!(
+        has_path_id(state, path_id),
+        "path-id {path_id} missing from state: {state}"
+    );
+}
+
+fn assert_path_id_absent(state: &Value, path_id: u32) {
+    assert!(
+        !has_path_id(state, path_id),
+        "path-id {path_id} unexpectedly present in state: {state}"
+    );
+}
+
+fn has_path_id(value: &Value, path_id: u32) -> bool {
+    match value {
+        Value::Object(map) => {
+            if map.get("path-id").and_then(Value::as_u64)
+                == Some(path_id as u64)
+                && object_contains_prefix(value)
+            {
+                return true;
+            }
+            map.values().any(|value| has_path_id(value, path_id))
+        }
+        Value::Array(values) => {
+            values.iter().any(|value| has_path_id(value, path_id))
+        }
+        _ => false,
+    }
+}
+
+fn object_contains_prefix(value: &Value) -> bool {
+    match value {
+        Value::Object(map) => {
+            map.get("prefix").and_then(Value::as_str) == Some(PREFIX)
+                || map.values().any(object_contains_prefix)
+        }
+        Value::Array(values) => values.iter().any(object_contains_prefix),
+        _ => false,
+    }
+}
+
+fn assert_local_rib_as_path(state: &Value, expected: &[u32]) {
+    let Some(loc_rib) = find_key(state, "loc-rib") else {
+        panic!("loc-rib not found in state: {state}");
+    };
+    let Some(attr_index) = loc_rib_attr_index(loc_rib) else {
+        panic!("{PREFIX} not found in loc-rib: {loc_rib}");
+    };
+    let Some(attr_sets) = find_key(state, "attr-sets") else {
+        panic!("attr-sets not found in state: {state}");
+    };
+    assert!(
+        attr_set_contains_as_path(attr_sets, attr_index, expected),
+        "attr-set {attr_index} did not contain AS path {expected:?}: {attr_sets}"
+    );
+}
+
+fn loc_rib_attr_index(value: &Value) -> Option<&str> {
+    match value {
+        Value::Object(map) => {
+            if map.get("prefix").and_then(Value::as_str) == Some(PREFIX) {
+                return map.get("attr-index").and_then(Value::as_str);
+            }
+            map.values().find_map(loc_rib_attr_index)
+        }
+        Value::Array(values) => values.iter().find_map(loc_rib_attr_index),
+        _ => None,
+    }
+}
+
+fn attr_set_contains_as_path(
+    value: &Value,
+    attr_index: &str,
+    expected: &[u32],
+) -> bool {
+    match value {
+        Value::Object(map) => {
+            if map.get("index").and_then(Value::as_str) == Some(attr_index)
+                && find_key(value, "member")
+                    .and_then(Value::as_array)
+                    .is_some_and(|members| {
+                        members
+                            .iter()
+                            .map(|member| member.as_u64().unwrap() as u32)
+                            .eq(expected.iter().copied())
+                    })
+            {
+                return true;
+            }
+            map.values().any(|value| {
+                attr_set_contains_as_path(value, attr_index, expected)
+            })
+        }
+        Value::Array(values) => values.iter().any(|value| {
+            attr_set_contains_as_path(value, attr_index, expected)
+        }),
+        _ => false,
+    }
+}
+
+fn find_key<'a>(value: &'a Value, key: &str) -> Option<&'a Value> {
+    match value {
+        Value::Object(map) => map
+            .get(key)
+            .or_else(|| map.values().find_map(|value| find_key(value, key))),
+        Value::Array(values) => {
+            values.iter().find_map(|value| find_key(value, key))
+        }
+        _ => None,
+    }
+}
+
+fn advertised_path_id(remote_addr: &str, path_id: u32) -> u32 {
+    let mut hasher = DefaultHasher::new();
+    ip(remote_addr).hash(&mut hasher);
+    path_id.hash(&mut hasher);
+    let path_id = hasher.finish() as u32;
+    if path_id == 0 { 1 } else { path_id }
+}
+
+fn prefix() -> Ipv4Network {
+    PREFIX.parse().unwrap()
+}
+
+fn ip(addr: &str) -> IpAddr {
+    addr.parse().unwrap()
+}

--- a/holo-bgp/tests/conformance/mod.rs
+++ b/holo-bgp/tests/conformance/mod.rs
@@ -4,4 +4,5 @@
 // SPDX-License-Identifier: MIT
 //
 
+mod add_path;
 mod topologies;

--- a/holo-bgp/tests/packet/mod.rs
+++ b/holo-bgp/tests/packet/mod.rs
@@ -35,6 +35,7 @@ fn test_decode_msg(bytes: &[u8], msg_expected: &Message) {
         peer_type: PeerType::Internal,
         peer_as: 65550,
         reject_as_sets: true,
+        capabilities_adv: Default::default(),
         capabilities: [NegotiatedCapability::FourOctetAsNumber].into(),
     };
 

--- a/holo-bgp/tests/packet/update.rs
+++ b/holo-bgp/tests/packet/update.rs
@@ -12,10 +12,10 @@ use holo_bgp::packet::attribute::{
     Aggregator, AsPath, AsPathSegment, AsPathSegmentType, Attrs, BaseAttrs,
     ClusterList, CommList,
 };
-use holo_bgp::packet::iana::Origin;
+use holo_bgp::packet::iana::{Afi, Origin, Safi};
 use holo_bgp::packet::message::{
-    DecodeCxt, Message, MpReachNlri, MpUnreachNlri, NegotiatedCapability,
-    ReachNlri, UnreachNlri, UpdateMsg,
+    AddPathMode, DecodeCxt, EncodeCxt, Message, MpReachNlri, MpUnreachNlri,
+    NegotiatedCapability, ReachNlri, UnreachNlri, UpdateMsg,
 };
 use holo_utils::bgp::{Comm, ExtComm, Extv6Comm, LargeComm};
 
@@ -72,16 +72,19 @@ static UPDATE2: Lazy<(Vec<u8>, Message)> = Lazy::new(|| {
         Message::Update(UpdateMsg {
             reach: Some(ReachNlri {
                 prefixes: vec![net4!("10.0.255.1/32"), net4!("10.0.255.2/32")],
+                path_ids: vec![],
                 nexthop: ip4!("1.1.1.1"),
             }),
             unreach: Some(UnreachNlri {
                 prefixes: vec![net4!("10.0.1.0/24"), net4!("10.0.2.0/24")],
+                path_ids: vec![],
             }),
             mp_reach: Some(MpReachNlri::Ipv6Unicast {
                 prefixes: vec![
                     net6!("2001:db8:1::1/128"),
                     net6!("2001:db8:1::2/128"),
                 ],
+                path_ids: vec![],
                 nexthop: ip6!("3000::1"),
                 ll_nexthop: Some(ip6!("fe80::4207:bd19:111c:8411")),
             }),
@@ -90,6 +93,7 @@ static UPDATE2: Lazy<(Vec<u8>, Message)> = Lazy::new(|| {
                     net6!("2001:db8:2::1/128"),
                     net6!("2001:db8:2::2/128"),
                 ],
+                path_ids: vec![],
             }),
             attrs: Some(Attrs {
                 base: BaseAttrs {
@@ -161,6 +165,7 @@ fn test_decode_malformed_updates() {
         peer_type: PeerType::Internal,
         peer_as: 65550,
         reject_as_sets: true,
+        capabilities_adv: Default::default(),
         capabilities: [NegotiatedCapability::FourOctetAsNumber].into(),
     };
     for bytes in &[
@@ -189,4 +194,138 @@ fn test_decode_malformed_updates() {
             let _ = Message::decode(&bytes[0..msg_size], &cxt);
         }
     }
+}
+
+#[test]
+fn test_add_path_roundtrip() {
+    let msg = Message::Update(UpdateMsg {
+        reach: Some(ReachNlri {
+            prefixes: vec![net4!("10.0.255.1/32"), net4!("10.0.255.1/32")],
+            path_ids: vec![10, 20],
+            nexthop: ip4!("1.1.1.1"),
+        }),
+        unreach: Some(UnreachNlri {
+            prefixes: vec![net4!("10.0.1.0/24"), net4!("10.0.1.0/24")],
+            path_ids: vec![30, 40],
+        }),
+        mp_reach: Some(MpReachNlri::Ipv6Unicast {
+            prefixes: vec![
+                net6!("2001:db8:1::1/128"),
+                net6!("2001:db8:1::1/128"),
+            ],
+            path_ids: vec![50, 60],
+            nexthop: ip6!("3000::1"),
+            ll_nexthop: None,
+        }),
+        mp_unreach: Some(MpUnreachNlri::Ipv6Unicast {
+            prefixes: vec![
+                net6!("2001:db8:2::1/128"),
+                net6!("2001:db8:2::1/128"),
+            ],
+            path_ids: vec![70, 80],
+        }),
+        attrs: Some(Attrs {
+            base: BaseAttrs {
+                nexthop: Some(ip4!("1.1.1.1").into()),
+                ..Default::default()
+            },
+            comm: None,
+            ext_comm: None,
+            extv6_comm: None,
+            large_comm: None,
+            unknown: None,
+        }),
+    });
+    let caps = [
+        NegotiatedCapability::FourOctetAsNumber,
+        NegotiatedCapability::AddPath {
+            afi: Afi::Ipv4,
+            safi: Safi::Unicast,
+            mode: AddPathMode::ReceiveSend,
+        },
+        NegotiatedCapability::AddPath {
+            afi: Afi::Ipv6,
+            safi: Safi::Unicast,
+            mode: AddPathMode::ReceiveSend,
+        },
+    ]
+    .into();
+    let enc = EncodeCxt { capabilities: caps };
+    let dec = DecodeCxt {
+        peer_type: PeerType::Internal,
+        peer_as: 65550,
+        reject_as_sets: true,
+        capabilities_adv: Default::default(),
+        capabilities: enc.capabilities.clone(),
+    };
+
+    let bytes = msg.encode(&enc);
+    let decoded = Message::decode(&bytes, &dec).unwrap();
+    let Message::Update(decoded) = decoded else {
+        panic!("expected UPDATE");
+    };
+    assert_eq!(decoded.reach.unwrap().path_ids, vec![10, 20]);
+    assert_eq!(decoded.unreach.unwrap().path_ids, vec![30, 40]);
+    assert_eq!(
+        decoded.mp_reach.unwrap(),
+        MpReachNlri::Ipv6Unicast {
+            prefixes: vec![
+                net6!("2001:db8:1::1/128"),
+                net6!("2001:db8:1::1/128"),
+            ],
+            path_ids: vec![50, 60],
+            nexthop: ip6!("3000::1"),
+            ll_nexthop: None,
+        }
+    );
+    assert_eq!(
+        decoded.mp_unreach.unwrap(),
+        MpUnreachNlri::Ipv6Unicast {
+            prefixes: vec![
+                net6!("2001:db8:2::1/128"),
+                net6!("2001:db8:2::1/128"),
+            ],
+            path_ids: vec![70, 80],
+        }
+    );
+}
+
+#[test]
+fn test_add_path_ids_omitted_without_negotiation() {
+    let msg = Message::Update(UpdateMsg {
+        reach: None,
+        unreach: Some(UnreachNlri {
+            prefixes: vec![net4!("10.0.1.0/24")],
+            path_ids: vec![30],
+        }),
+        mp_reach: None,
+        mp_unreach: None,
+        attrs: None,
+    });
+    let enc = EncodeCxt {
+        capabilities: [NegotiatedCapability::FourOctetAsNumber].into(),
+    };
+    let dec = DecodeCxt {
+        peer_type: PeerType::Internal,
+        peer_as: 65550,
+        reject_as_sets: true,
+        capabilities_adv: Default::default(),
+        capabilities: enc.capabilities.clone(),
+    };
+
+    let bytes = msg.encode(&enc);
+    let decoded = Message::decode(&bytes, &dec).unwrap();
+    assert_eq!(
+        decoded,
+        Message::Update(UpdateMsg {
+            reach: None,
+            unreach: Some(UnreachNlri {
+                prefixes: vec![net4!("10.0.1.0/24")],
+                path_ids: vec![],
+            }),
+            mp_reach: None,
+            mp_unreach: None,
+            attrs: None,
+        })
+    );
 }

--- a/holo-protocol/src/lib.rs
+++ b/holo-protocol/src/lib.rs
@@ -387,6 +387,34 @@ pub fn spawn_protocol_task<P>(
     ibus_instance_tx: IbusSender,
     ibus_instance_rx: IbusReceiver,
     agg_channels: InstanceAggChannels<P>,
+    shared: InstanceShared,
+) -> NbDaemonSender
+where
+    P: ProtocolInstance,
+{
+    #[cfg(feature = "testing")]
+    let (_test_tx, test_rx) = mpsc::channel(1);
+
+    spawn_protocol_task_inner::<P>(
+        name,
+        nb_provider_tx,
+        ibus_tx,
+        ibus_instance_tx,
+        ibus_instance_rx,
+        agg_channels,
+        #[cfg(feature = "testing")]
+        test_rx,
+        shared,
+    )
+}
+
+pub fn spawn_protocol_task_inner<P>(
+    name: String,
+    nb_provider_tx: &NbProviderSender,
+    ibus_tx: &IbusChannelsTx,
+    ibus_instance_tx: IbusSender,
+    ibus_instance_rx: IbusReceiver,
+    agg_channels: InstanceAggChannels<P>,
     #[cfg(feature = "testing")] test_rx: Receiver<
         TestMsg<P::ProtocolOutputMsg>,
     >,

--- a/holo-protocol/src/test/stub/mod.rs
+++ b/holo-protocol/src/test/stub/mod.rs
@@ -101,7 +101,7 @@ where
 
     // Synchronizes the protocol instance to ensure all previously sent instance
     // messages were already received and processed.
-    async fn sync(&self) {
+    pub async fn sync(&self) {
         let (responder_tx, responder_rx) = oneshot::channel();
         let msg = TestMsg::Synchronize(SynchronizeMsg {
             responder: Some(responder_tx),
@@ -110,6 +110,27 @@ where
         responder_rx
             .await
             .expect("failed to receive Synchronize response");
+    }
+
+    pub async fn commit_replace(&mut self, config: &str) {
+        self.nb.commit_replace(config).await;
+    }
+
+    pub async fn state_json(&self) -> String {
+        let state = self.nb.get_state().await;
+        northbound::dtree_print(&state)
+    }
+
+    pub fn reset_output(&self) {
+        self.messages.reset_output();
+    }
+
+    pub fn take_ibus_output(&self) -> Vec<String> {
+        self.messages.ibus_output()
+    }
+
+    pub fn take_protocol_output(&self) -> Vec<String> {
+        self.messages.protocol_output()
     }
 
     fn assert_nb_notifications(

--- a/holo-protocol/src/test/stub/mod.rs
+++ b/holo-protocol/src/test/stub/mod.rs
@@ -23,7 +23,7 @@ use crate::test::stub::northbound::NorthboundStub;
 use crate::test::{OutputChannelsRx, setup};
 use crate::{
     InstanceAggChannels, InstanceMsg, InstanceShared, ProtocolInstance,
-    spawn_protocol_task,
+    spawn_protocol_task_inner,
 };
 
 // Environment variable that controls if the test data needs to be updated or
@@ -277,7 +277,7 @@ where
     let channels = InstanceAggChannels::default();
     let instance_tx = channels.tx.clone();
     let (test_tx, test_rx) = mpsc::channel(4);
-    let nb_daemon_tx = spawn_protocol_task::<P>(
+    let nb_daemon_tx = spawn_protocol_task_inner::<P>(
         name.to_owned(),
         &nb_provider_tx,
         &ibus_tx,

--- a/holo-protocol/src/test/stub/northbound.rs
+++ b/holo-protocol/src/test/stub/northbound.rs
@@ -122,7 +122,7 @@ impl NorthboundStub {
         self.state_cache = Some(state);
     }
 
-    async fn get_state(&self) -> DataTree<'static> {
+    pub(super) async fn get_state(&self) -> DataTree<'static> {
         // Prepare request.
         let (responder_tx, responder_rx) = oneshot::channel();
         let request = api::daemon::Request::Get(api::daemon::GetRequest {
@@ -255,7 +255,7 @@ impl NorthboundStub {
 
 // ===== helper functions =====
 
-fn dtree_print(dtree: &DataTree<'static>) -> String {
+pub(super) fn dtree_print(dtree: &DataTree<'static>) -> String {
     dtree
         .print_string(DataFormat::JSON, DataPrinterFlags::WITH_SIBLINGS)
         .unwrap()

--- a/holo-utils/src/task.rs
+++ b/holo-utils/src/task.rs
@@ -221,6 +221,15 @@ impl TimeoutTask {
         }
     }
 
+    #[cfg(feature = "testing")]
+    pub fn new<F, Fut>(_timeout: Duration, _cb: F) -> TimeoutTask
+    where
+        F: FnOnce() -> Fut + Send + 'static,
+        Fut: Future<Output = ()> + Send,
+    {
+        TimeoutTask {}
+    }
+
     /// Resets the timeout, regardless if it has already expired or not.
     ///
     /// If a new timeout value isn't specified, the last value will be reused.
@@ -313,6 +322,19 @@ impl IntervalTask {
         IntervalTask {
             inner: IntervalTaskInner::new(task, control_tx, next),
         }
+    }
+
+    #[cfg(feature = "testing")]
+    pub fn new<F, Fut>(
+        _interval: Duration,
+        _tick_on_start: bool,
+        _cb: F,
+    ) -> IntervalTask
+    where
+        F: FnMut() -> Fut + Send + 'static,
+        Fut: Future<Output = ()> + Send,
+    {
+        IntervalTask {}
     }
 
     /// Resets the interval.

--- a/holo-yang/src/lib.rs
+++ b/holo-yang/src/lib.rs
@@ -385,6 +385,7 @@ pub static YANG_FEATURES: Lazy<HashMap<&'static str, Vec<&'static str>>> =
         hashmap! {
             "iana-bgp-types" => vec![
                 "clear-neighbors",
+                "add-paths",
                 "route-refresh",
                 "ttl-security",
             ],


### PR DESCRIPTION
BGP Additional Paths / ADD-PATH (RFC 7911) for IPv4 and IPv6 unicast.

- Per-neighbor / peer-group ADD-PATH capability with `receive` / `send` modes, negotiated per (AFI, SAFI). The NLRI path-id codec is driven by the **per-direction negotiated** capability (via encode/decode contexts): decode reads a path-id only when receive is negotiated, encode writes one only when send is negotiated.
- RX: the Adj-RIB-In is keyed by `(neighbour, path-id)`, so multiple paths per prefix from one peer coexist; update/withdraw match a specific path-id.
- TX: advertises the additional paths (`send-all`) with stable path-ids.
- Fail-safe: a session that does not negotiate ADD-PATH is byte-for-byte unchanged (path-id 0, no path-id on the wire).

Tests: packet round-trip with path-ids, and path-ids-omitted-without-negotiation (the wire-format guard).

Scope: IPv4/IPv6 unicast. Deferred: VPN/EVPN/labeled AFs; `best-per-AS` TX mode; paths-limit (RFC 9184). Behavioral conformance tests for RX multi-path storage and TX all-paths advertisement are a recommended follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
