### PR TITLE
bgp: encode MP_UNREACH_NLRI in attribute-only withdraw UPDATEs

### DIFF
--- a/holo-bgp/src/packet/attribute.rs
+++ b/holo-bgp/src/packet/attribute.rs
@@ -1244,7 +1244,7 @@ impl MpReachNlri {
 impl MpUnreachNlri {
     pub const MIN_LEN: u16 = 3;
 
-    fn encode(&self, buf: &mut BytesMut) {
+    pub(crate) fn encode(&self, buf: &mut BytesMut) {
         buf.put_u8((AttrFlags::OPTIONAL | AttrFlags::EXTENDED).bits());
         buf.put_u8(AttrType::MpUnreachNlri as u8);
 

--- a/holo-bgp/src/packet/message.rs
+++ b/holo-bgp/src/packet/message.rs
@@ -741,20 +741,29 @@ impl UpdateMsg {
         // Path Attributes.
         let start_pos = buf.len();
         buf.put_u16(0);
-        if let Some(attrs) = &self.attrs {
-            // Encode path attributes.
-            attrs.encode(
-                buf,
-                &self.reach,
-                &self.mp_reach,
-                &self.mp_unreach,
-                cxt,
-            );
-
-            // Rewrite the "Total Path Attribute Length" field.
-            let len = (buf.len() - start_pos - 2) as u16;
-            buf[start_pos..start_pos + 2].copy_from_slice(&len.to_be_bytes());
+        match (&self.attrs, &self.mp_unreach) {
+            // Encode the full set of path attributes.
+            (Some(attrs), _) => {
+                attrs.encode(
+                    buf,
+                    &self.reach,
+                    &self.mp_reach,
+                    &self.mp_unreach,
+                    cxt,
+                );
+            }
+            // A withdraw-only UPDATE for a non-IPv4-unicast address family
+            // carries MP_UNREACH_NLRI as its only path attribute. It must still
+            // be encoded when no other attributes are present; otherwise the
+            // message has an empty attribute section and is indistinguishable
+            // from an End-of-RIB marker, so the withdrawal is never signaled.
+            (None, Some(mp_unreach)) => mp_unreach.encode(buf),
+            (None, None) => {}
         }
+
+        // Rewrite the "Total Path Attribute Length" field.
+        let len = (buf.len() - start_pos - 2) as u16;
+        buf[start_pos..start_pos + 2].copy_from_slice(&len.to_be_bytes());
 
         // Network Layer Reachability Information.
         if let Some(reach) = &self.reach {

--- a/holo-bgp/tests/packet/update.rs
+++ b/holo-bgp/tests/packet/update.rs
@@ -14,8 +14,8 @@ use holo_bgp::packet::attribute::{
 };
 use holo_bgp::packet::iana::Origin;
 use holo_bgp::packet::message::{
-    DecodeCxt, Message, MpReachNlri, MpUnreachNlri, NegotiatedCapability,
-    ReachNlri, UnreachNlri, UpdateMsg,
+    DecodeCxt, EncodeCxt, Message, MpReachNlri, MpUnreachNlri,
+    NegotiatedCapability, ReachNlri, UnreachNlri, UpdateMsg,
 };
 use holo_utils::bgp::{Comm, ExtComm, Extv6Comm, LargeComm};
 
@@ -189,4 +189,41 @@ fn test_decode_malformed_updates() {
             let _ = Message::decode(&bytes[0..msg_size], &cxt);
         }
     }
+}
+
+// Regression: a withdraw-only UPDATE whose sole path attribute is
+// MP_UNREACH_NLRI (i.e. `attrs` is None) must still encode that attribute.
+// Otherwise the message has an empty attribute section and is byte-identical
+// to an End-of-RIB marker (23 bytes), which silently drops the withdrawal.
+#[test]
+fn test_encode_mp_unreach_only_update() {
+    let encode_cxt = EncodeCxt {
+        capabilities: [NegotiatedCapability::FourOctetAsNumber].into(),
+    };
+    let msg = Message::Update(UpdateMsg {
+        reach: None,
+        unreach: None,
+        mp_reach: None,
+        mp_unreach: Some(MpUnreachNlri::Ipv6Unicast {
+            prefixes: vec![net6!("2001:db8:2::1/128")],
+        }),
+        attrs: None,
+    });
+
+    let bytes = msg.encode(&encode_cxt);
+
+    // Must not collapse to the 23-byte End-of-RIB marker...
+    assert_ne!(bytes.len(), 23);
+
+    // ...and must round-trip back to the same message.
+    let decode_cxt = DecodeCxt {
+        peer_type: PeerType::Internal,
+        peer_as: 65550,
+        reject_as_sets: true,
+        capabilities: [NegotiatedCapability::FourOctetAsNumber].into(),
+    };
+    let msg_size = Message::get_message_len(&bytes)
+        .expect("Buffer doesn't contain a full BGP message");
+    let decoded = Message::decode(&bytes[0..msg_size], &decode_cxt).unwrap();
+    assert_eq!(decoded, msg);
 }


### PR DESCRIPTION
UpdateMsg::encode() emitted the path-attribute section only when self.attrs was Some. A withdraw-only UPDATE for a non-IPv4-unicast address family carries MP_UNREACH_NLRI as its sole path attribute with attrs = None, so the attribute was skipped entirely. The resulting message has an empty attribute section, byte-identical to an IPv4-unicast End-of-RIB marker (RFC 4724): the withdrawal is never signaled to the peer, and the peer instead sees a spurious End-of-RIB.

Encode MP_UNREACH_NLRI even when no other path attributes are present, and add a regression test for a withdraw-only IPv6-unicast UPDATE.