### PR TITLE
bgp: only process UPDATE messages in the Established state

### DIFF
--- a/holo-bgp/src/events.rs
+++ b/holo-bgp/src/events.rs
@@ -121,7 +121,13 @@ pub(crate) fn process_nbr_msg(
                 }
                 Message::Update(msg) => {
                     nbr.fsm_event(instance, fsm::Event::RcvdUpdate);
-                    process_nbr_update(instance, nbr, msg)?;
+                    // An UPDATE message is only valid once the session reaches
+                    // the Established state (RFC 4271 Section 8.2.2). Processing
+                    // its NLRI beforehand has no negotiated capabilities and no
+                    // neighbor identifier to work with, which would panic.
+                    if nbr.state == fsm::State::Established {
+                        process_nbr_update(instance, nbr, msg)?;
+                    }
                 }
                 Message::Notification(msg) => {
                     nbr.fsm_event(instance, fsm::Event::RcvdNotif(msg.clone()));


### PR DESCRIPTION
process_nbr_msg() called process_nbr_update() for every UPDATE without checking the session state. A peer that sends an UPDATE carrying IPv4-unicast NLRI before the session reaches Established (for example in OpenSent, before its OPEN has been received) reaches the route-origin construction, which unwraps nbr.identifier -- still None until an OPEN is processed -- and panics the daemon. Routes could also be processed into the RIB after a session had already been torn down.

An UPDATE is only valid once the session is Established (RFC 4271 Section 8.2.2). Guard the route processing on that state.