### PR TITLE
vrrp: ignore advertisements received in the Initialize state

### DIFF
--- a/holo-vrrp/src/events.rs
+++ b/holo-vrrp/src/events.rs
@@ -95,9 +95,12 @@ pub(crate) fn process_vrrp_packet(
 
     // RFC 3768: Section 6.4.2 ("If an ADVERTISEMENT is received")
     match instance.state.state {
-        fsm::State::Initialize => {
-            unreachable!()
-        }
+        // An advertisement can still be delivered while the router is in the
+        // Initialize state: the receive task may have enqueued the packet just
+        // before the instance was shut down and transitioned back to
+        // Initialize. Ignore it rather than treating it as unreachable, which
+        // would panic the process.
+        fsm::State::Initialize => {}
         fsm::State::Backup => {
             if packet.priority == 0 {
                 let duration =


### PR DESCRIPTION
An advertisement can reach the event handler while the VRRP router is in the Initialize state: the receive task may enqueue a packet just before the instance is shut down and transitioned back to Initialize. The handler matched the Initialize state with unreachable!(), so this race panicked the process.

Handle the Initialize state by ignoring the advertisement.